### PR TITLE
Add traffic-free network adapter warning with CI tests

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           node-version: 22
 
+      - name: Run tests
+        run: npm test
+
       - name: Build static site
         run: npm run build
 

--- a/README.md
+++ b/README.md
@@ -74,14 +74,16 @@ directly):
 
 The version is declared once in `package.json` and substituted into the
 output at build time. After changing anything in `src/`, run `npm run build`
-and commit the regenerated files; CI verifies that the committed output is
-reproducible. To remove generated files, run `npm run clean`.
+and commit the regenerated files; CI runs the test suite (`npm test`) and
+verifies that the committed output is reproducible. To remove generated
+files, run `npm run clean`.
 
 ## Project structure
 
 ```
 ├── assets/                 Static assets (logo, favicon)
 ├── scripts/build.mjs       Zero-dependency build script
+├── test/network-check.test.mjs  Tests for the network-check module (npm test)
 ├── src/
 │   ├── index.html          HTML template (markup and document head)
 │   ├── css/styles.css      Application styles
@@ -89,6 +91,7 @@ reproducible. To remove generated files, run `npm run clean`.
 │       ├── vendor.js       Bundled third-party crypto (noble, scure, bip39)
 │       ├── app.js          Application logic
 │       ├── online.js       Hosted-site behavior and version picker
+│       ├── network-check.js Network adapter detection and warning
 │       ├── enhanced-inputs.js
 │       └── repeat-inputs.js
 ├── index.html              Compiled application (generated, committed)

--- a/entropylab-0.1.3.html
+++ b/entropylab-0.1.3.html
@@ -269,6 +269,11 @@ header { padding: 8px 0 16px; }
 }
 .online-warning strong { color: var(--ok); }
 .online-warning a { font-weight: 700; }
+.network-warning {
+  margin: 0 0 18px; padding: 14px 16px; border: 1px solid var(--ok); border-radius: 10px;
+  background: color-mix(in oklab, var(--ok) 12%, var(--surface)); color: var(--fg); line-height: 1.5;
+}
+.network-warning strong { color: var(--ok); }
 .beta-warning {
   margin: 0 0 12px; padding: 14px 16px; border: 1px solid var(--danger); border-radius: 10px;
   background: color-mix(in oklab, var(--danger) 14%, var(--surface)); color: var(--fg); line-height: 1.5;
@@ -635,6 +640,9 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
     </aside>
     <aside class="online-warning no-print" id="online-warning" role="alert" hidden>
       <strong>Online version:</strong> Do not enter seed phrases, private keys, or other wallet secrets on an internet-connected device. <a href="entropylab-0.1.3.html" download="entropylab-0.1.3.html">Download EntropyLab</a> and run the HTML file offline on a trusted, air-gapped computer.
+    </aside>
+    <aside class="network-warning no-print" id="network-warning" role="alert" hidden>
+      <strong>Network detected:</strong> This computer has an active network adapter — it is online and possibly connected to the internet. Do not enter wallet secrets here; disconnect from all networks (Wi-Fi and Ethernet) and use this file on an air-gapped computer.
     </aside>
     <header>
       <div>
@@ -4913,6 +4921,39 @@ function hodlFormatRecoverySheet(text) {
       .then((data) => render(Array.isArray(data.versions) ? data.versions : []))
       .catch(() => {});
   }
+})();
+</script>
+<script>
+// Network check: shows the green network warning when this computer has a
+// network adapter available, and removes the warning when it does not.
+// Detection relies on navigator.onLine plus the online/offline events
+// only — no network traffic of any kind is ever generated. When onLine is
+// false the OS reports no usable network adapter, so the machine is
+// offline. When true, an adapter is available with a link; that includes
+// a LAN without internet access, which still matters for an air-gap
+// warning. Browsers intentionally offer no finer-grained adapter
+// introspection, so a missing warning is not proof of an air gap.
+(() => {
+  const WARNING_ID = "network-warning";
+
+  const showWarning = () => {
+    document.getElementById(WARNING_ID)?.removeAttribute("hidden");
+  };
+
+  const removeWarning = () => {
+    document.getElementById(WARNING_ID)?.remove();
+  };
+
+  const checkNetwork = () => {
+    if (navigator.onLine === true) showWarning();
+    else removeWarning();
+  };
+
+  checkNetwork();
+  window.addEventListener("online", checkNetwork);
+  window.addEventListener("offline", checkNetwork);
+  // Chromium-only Network Information API: re-check on connection changes.
+  navigator.connection?.addEventListener("change", checkNetwork);
 })();
 </script>
 <script>

--- a/index.html
+++ b/index.html
@@ -269,6 +269,11 @@ header { padding: 8px 0 16px; }
 }
 .online-warning strong { color: var(--ok); }
 .online-warning a { font-weight: 700; }
+.network-warning {
+  margin: 0 0 18px; padding: 14px 16px; border: 1px solid var(--ok); border-radius: 10px;
+  background: color-mix(in oklab, var(--ok) 12%, var(--surface)); color: var(--fg); line-height: 1.5;
+}
+.network-warning strong { color: var(--ok); }
 .beta-warning {
   margin: 0 0 12px; padding: 14px 16px; border: 1px solid var(--danger); border-radius: 10px;
   background: color-mix(in oklab, var(--danger) 14%, var(--surface)); color: var(--fg); line-height: 1.5;
@@ -635,6 +640,9 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
     </aside>
     <aside class="online-warning no-print" id="online-warning" role="alert" hidden>
       <strong>Online version:</strong> Do not enter seed phrases, private keys, or other wallet secrets on an internet-connected device. <a href="entropylab-0.1.3.html" download="entropylab-0.1.3.html">Download EntropyLab</a> and run the HTML file offline on a trusted, air-gapped computer.
+    </aside>
+    <aside class="network-warning no-print" id="network-warning" role="alert" hidden>
+      <strong>Network detected:</strong> This computer has an active network adapter — it is online and possibly connected to the internet. Do not enter wallet secrets here; disconnect from all networks (Wi-Fi and Ethernet) and use this file on an air-gapped computer.
     </aside>
     <header>
       <div>
@@ -4913,6 +4921,39 @@ function hodlFormatRecoverySheet(text) {
       .then((data) => render(Array.isArray(data.versions) ? data.versions : []))
       .catch(() => {});
   }
+})();
+</script>
+<script>
+// Network check: shows the green network warning when this computer has a
+// network adapter available, and removes the warning when it does not.
+// Detection relies on navigator.onLine plus the online/offline events
+// only — no network traffic of any kind is ever generated. When onLine is
+// false the OS reports no usable network adapter, so the machine is
+// offline. When true, an adapter is available with a link; that includes
+// a LAN without internet access, which still matters for an air-gap
+// warning. Browsers intentionally offer no finer-grained adapter
+// introspection, so a missing warning is not proof of an air gap.
+(() => {
+  const WARNING_ID = "network-warning";
+
+  const showWarning = () => {
+    document.getElementById(WARNING_ID)?.removeAttribute("hidden");
+  };
+
+  const removeWarning = () => {
+    document.getElementById(WARNING_ID)?.remove();
+  };
+
+  const checkNetwork = () => {
+    if (navigator.onLine === true) showWarning();
+    else removeWarning();
+  };
+
+  checkNetwork();
+  window.addEventListener("online", checkNetwork);
+  window.addEventListener("offline", checkNetwork);
+  // Chromium-only Network Information API: re-check on connection changes.
+  navigator.connection?.addEventListener("change", checkNetwork);
 })();
 </script>
 <script>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "license": "MIT",
   "scripts": {
     "build": "node scripts/build.mjs",
-    "clean": "node scripts/build.mjs --clean"
+    "clean": "node scripts/build.mjs --clean",
+    "test": "node --test test/network-check.test.mjs"
   },
   "keywords": [
     "bitcoin",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -34,6 +34,7 @@ const template = read("index.html");
 const css = read("css/styles.css");
 const jsMain = read("js/vendor.js") + read("js/app.js");
 const jsOnline = read("js/online.js");
+const jsNetwork = read("js/network-check.js");
 const jsEnhanced = read("js/enhanced-inputs.js");
 const jsRepeat = read("js/repeat-inputs.js");
 
@@ -41,6 +42,7 @@ let html = template
   .replace("/*@@CSS@@*/", () => css)
   .replace("/*@@JS_MAIN@@*/", () => jsMain)
   .replace("/*@@JS_ONLINE@@*/", () => jsOnline)
+  .replace("/*@@JS_NETWORK@@*/", () => jsNetwork)
   .replace("/*@@JS_ENHANCED@@*/", () => jsEnhanced)
   .replace("/*@@JS_REPEAT@@*/", () => jsRepeat)
   .split("{{VERSION}}").join(version);

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -267,6 +267,11 @@ header { padding: 8px 0 16px; }
 }
 .online-warning strong { color: var(--ok); }
 .online-warning a { font-weight: 700; }
+.network-warning {
+  margin: 0 0 18px; padding: 14px 16px; border: 1px solid var(--ok); border-radius: 10px;
+  background: color-mix(in oklab, var(--ok) 12%, var(--surface)); color: var(--fg); line-height: 1.5;
+}
+.network-warning strong { color: var(--ok); }
 .beta-warning {
   margin: 0 0 12px; padding: 14px 16px; border: 1px solid var(--danger); border-radius: 10px;
   background: color-mix(in oklab, var(--danger) 14%, var(--surface)); color: var(--fg); line-height: 1.5;

--- a/src/index.html
+++ b/src/index.html
@@ -8,6 +8,9 @@
     <aside class="online-warning no-print" id="online-warning" role="alert" hidden>
       <strong>Online version:</strong> Do not enter seed phrases, private keys, or other wallet secrets on an internet-connected device. <a href="entropylab-{{VERSION}}.html" download="entropylab-{{VERSION}}.html">Download EntropyLab</a> and run the HTML file offline on a trusted, air-gapped computer.
     </aside>
+    <aside class="network-warning no-print" id="network-warning" role="alert" hidden>
+      <strong>Network detected:</strong> This computer has an active network adapter — it is online and possibly connected to the internet. Do not enter wallet secrets here; disconnect from all networks (Wi-Fi and Ethernet) and use this file on an air-gapped computer.
+    </aside>
     <header>
       <div>
         <div class="kicker">EntropyLab v{{VERSION}} · Offline · No entropy RNG · You provide the entropy</div>
@@ -211,5 +214,6 @@ needs the number of signatures you choose, on real signing devices.</p>
   </div>
 </div><!--/$--><script id="btc-calc-script">/*@@JS_MAIN@@*/</script>
 <script>/*@@JS_ONLINE@@*/</script>
+<script>/*@@JS_NETWORK@@*/</script>
 <script>/*@@JS_ENHANCED@@*/</script>
 <script>/*@@JS_REPEAT@@*/</script></body></html>

--- a/src/js/network-check.js
+++ b/src/js/network-check.js
@@ -1,0 +1,32 @@
+
+// Network check: shows the green network warning when this computer has a
+// network adapter available, and removes the warning when it does not.
+// Detection relies on navigator.onLine plus the online/offline events
+// only — no network traffic of any kind is ever generated. When onLine is
+// false the OS reports no usable network adapter, so the machine is
+// offline. When true, an adapter is available with a link; that includes
+// a LAN without internet access, which still matters for an air-gap
+// warning. Browsers intentionally offer no finer-grained adapter
+// introspection, so a missing warning is not proof of an air gap.
+(() => {
+  const WARNING_ID = "network-warning";
+
+  const showWarning = () => {
+    document.getElementById(WARNING_ID)?.removeAttribute("hidden");
+  };
+
+  const removeWarning = () => {
+    document.getElementById(WARNING_ID)?.remove();
+  };
+
+  const checkNetwork = () => {
+    if (navigator.onLine === true) showWarning();
+    else removeWarning();
+  };
+
+  checkNetwork();
+  window.addEventListener("online", checkNetwork);
+  window.addEventListener("offline", checkNetwork);
+  // Chromium-only Network Information API: re-check on connection changes.
+  navigator.connection?.addEventListener("change", checkNetwork);
+})();

--- a/test/network-check.test.mjs
+++ b/test/network-check.test.mjs
@@ -1,0 +1,109 @@
+// Tests for src/js/network-check.js using Node's built-in test runner.
+// The module is a browser IIFE, so each test executes it inside a sandbox
+// with stubbed document/navigator/window globals and asserts how it treats
+// the #network-warning element.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const read = (path) => readFileSync(join(root, path), "utf8");
+const src = read("src/js/network-check.js");
+
+const loadModule = ({ onLine, withConnectionApi = false, hasElement = true }) => {
+  const el = {
+    shown: false,
+    removed: false,
+    removeAttribute(name) {
+      if (name === "hidden") {
+        this.shown = true;
+        this.removed = false;
+      }
+    },
+    remove() {
+      this.removed = true;
+      this.shown = false;
+    },
+  };
+  const listeners = {};
+  const connectionListeners = {};
+  const nav = { onLine };
+  if (withConnectionApi) {
+    nav.connection = { addEventListener: (type, fn) => { connectionListeners[type] = fn; } };
+  }
+  const sandbox = {
+    document: { getElementById: (id) => (hasElement && id === "network-warning" ? el : null) },
+    navigator: nav,
+    window: { addEventListener: (type, fn) => { listeners[type] = fn; } },
+  };
+  new Function(...Object.keys(sandbox), src)(...Object.values(sandbox));
+  return { el, listeners, connectionListeners, nav };
+};
+
+test("never generates network traffic", () => {
+  assert.doesNotMatch(src, /\bfetch\b|XMLHttpRequest|WebSocket|RTCPeerConnection|sendBeacon|WebTransport/);
+});
+
+test("shows the warning when a network adapter is available", () => {
+  const { el } = loadModule({ onLine: true });
+  assert.equal(el.shown, true);
+  assert.equal(el.removed, false);
+});
+
+test("removes the warning when no network adapter is available", () => {
+  const { el } = loadModule({ onLine: false });
+  assert.equal(el.removed, true);
+  assert.equal(el.shown, false);
+});
+
+test("shows the warning when the online event fires", () => {
+  const { el, listeners, nav } = loadModule({ onLine: false });
+  assert.equal(el.removed, true);
+  nav.onLine = true;
+  listeners.online();
+  assert.equal(el.shown, true);
+  assert.equal(el.removed, false);
+});
+
+test("removes the warning when the offline event fires", () => {
+  const { el, listeners, nav } = loadModule({ onLine: true });
+  assert.equal(el.shown, true);
+  nav.onLine = false;
+  listeners.offline();
+  assert.equal(el.removed, true);
+  assert.equal(el.shown, false);
+});
+
+test("re-checks when the Network Information API reports a change", () => {
+  const { el, connectionListeners, nav } = loadModule({ onLine: true, withConnectionApi: true });
+  assert.equal(el.shown, true);
+  assert.equal(typeof connectionListeners.change, "function");
+  nav.onLine = false;
+  connectionListeners.change();
+  assert.equal(el.removed, true);
+});
+
+test("works without the Network Information API (Firefox/Safari)", () => {
+  const { el } = loadModule({ onLine: true, withConnectionApi: false });
+  assert.equal(el.shown, true);
+});
+
+test("does not throw when the warning element is missing", () => {
+  assert.doesNotThrow(() => loadModule({ onLine: true, hasElement: false }));
+  assert.doesNotThrow(() => loadModule({ onLine: false, hasElement: false }));
+});
+
+test("template ships the warning aside hidden and wired to the build", () => {
+  const template = read("src/index.html");
+  const build = read("scripts/build.mjs");
+  assert.match(template, /<aside[^>]*id="network-warning"[^>]*\shidden/);
+  assert.match(template, /\/\*@@JS_NETWORK@@\*\//);
+  assert.match(build, /network-check\.js/);
+});
+
+test("CSP keeps connect-src locked down to 'self'", () => {
+  const csp = read("src/index.html").match(/connect-src[^;"]*/)?.[0] ?? "";
+  assert.equal(csp.trim(), "connect-src 'self'");
+});


### PR DESCRIPTION
## Summary

- New `src/js/network-check.js` module: shows the green `#network-warning` aside when `navigator.onLine` reports an available network adapter — noting the computer is online and possibly connected to the internet — and removes the warning when no adapter is available.
- Detection is entirely traffic-free (no pings): it relies on `navigator.onLine` plus the `online`/`offline` window events, with Chromium's Network Information API `change` event as an extra trigger. The CSP is unchanged (`connect-src 'self'`).
- Wired into the zero-dependency build; regenerated `index.html` and `entropylab-0.1.3.html`.

## Tests

- Adds `npm test` using Node's built-in test runner (`node:test`, zero dependencies) with 10 tests: show/remove behavior, `online`/`offline`/`connection change` events, Firefox/Safari fallback (no Network Information API), missing-element safety, plus guards that the module never generates network traffic and that `connect-src` stays locked to `'self'`.
- The deploy workflow now runs the suite before building.

## Verification

- `npm test` — 10/10 pass locally (Node 22)
- `npm run build` — output is byte-for-byte reproducible, so the CI reproducibility gate stays green