### PR TITLE
Add Bryan bare HTML mode

### DIFF
--- a/entropylab-0.1.3.html
+++ b/entropylab-0.1.3.html
@@ -274,6 +274,12 @@ header { padding: 8px 0 16px; }
   background: color-mix(in oklab, var(--danger) 14%, var(--surface)); color: var(--fg); line-height: 1.5;
 }
 .beta-warning strong { color: var(--danger); }
+.bryan-mode-control {
+  display: flex; align-items: center; gap: 8px; width: fit-content; margin: 0 0 12px;
+  padding: 9px 12px; border: 1px solid var(--border); border-radius: 8px;
+  background: var(--surface-2); color: var(--fg); font-weight: 700; cursor: pointer;
+}
+.bryan-mode-control input { margin: 0; accent-color: var(--accent); }
 @media print {
   :root {
     color-scheme: light;
@@ -5154,6 +5160,72 @@ function hodlFormatRecoverySheet(text) {
   window.addEventListener("blur", () => stopRepeating());
   document.addEventListener("visibilitychange", () => {
     if (document.hidden) stopRepeating();
+  });
+})();
+</script>
+<script>(() => {
+  const wrap = document.querySelector("#btc-calc > .wrap");
+  if (!wrap) return;
+
+  const control = document.createElement("label");
+  control.className = "bryan-mode-control no-print";
+  const checkbox = document.createElement("input");
+  checkbox.type = "checkbox";
+  checkbox.id = "bryan-mode";
+  checkbox.setAttribute("aria-label", "Bryan mode: use bare HTML");
+  control.append(checkbox, document.createTextNode(" Bryan mode (bare HTML)"));
+  wrap.prepend(control);
+
+  const stylesheetStates = new Map();
+  const inlineStyleStates = new Map();
+  let inlineStyleObserver = null;
+
+  const removeInlineStyles = (root) => {
+    const elements = [];
+    if (root instanceof Element && root.hasAttribute("style")) elements.push(root);
+    root.querySelectorAll?.("[style]").forEach(element => elements.push(element));
+    elements.forEach(element => {
+      inlineStyleStates.set(element, element.getAttribute("style"));
+      element.removeAttribute("style");
+    });
+  };
+
+  const enableBryanMode = () => {
+    [...document.styleSheets].forEach(stylesheet => {
+      stylesheetStates.set(stylesheet, stylesheet.disabled);
+      stylesheet.disabled = true;
+    });
+    removeInlineStyles(document);
+    inlineStyleObserver = new MutationObserver(mutations => {
+      mutations.forEach(mutation => {
+        if (mutation.type === "attributes") removeInlineStyles(mutation.target);
+        mutation.addedNodes.forEach(node => removeInlineStyles(node));
+      });
+    });
+    inlineStyleObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["style"],
+      childList: true,
+      subtree: true
+    });
+  };
+
+  const disableBryanMode = () => {
+    inlineStyleObserver?.disconnect();
+    inlineStyleObserver = null;
+    stylesheetStates.forEach((disabled, stylesheet) => {
+      stylesheet.disabled = disabled;
+    });
+    stylesheetStates.clear();
+    inlineStyleStates.forEach((style, element) => {
+      if (element.isConnected && style !== null) element.setAttribute("style", style);
+    });
+    inlineStyleStates.clear();
+  };
+
+  checkbox.addEventListener("change", () => {
+    if (checkbox.checked) enableBryanMode();
+    else disableBryanMode();
   });
 })();
 </script></body></html>

--- a/index.html
+++ b/index.html
@@ -274,6 +274,12 @@ header { padding: 8px 0 16px; }
   background: color-mix(in oklab, var(--danger) 14%, var(--surface)); color: var(--fg); line-height: 1.5;
 }
 .beta-warning strong { color: var(--danger); }
+.bryan-mode-control {
+  display: flex; align-items: center; gap: 8px; width: fit-content; margin: 0 0 12px;
+  padding: 9px 12px; border: 1px solid var(--border); border-radius: 8px;
+  background: var(--surface-2); color: var(--fg); font-weight: 700; cursor: pointer;
+}
+.bryan-mode-control input { margin: 0; accent-color: var(--accent); }
 @media print {
   :root {
     color-scheme: light;
@@ -5154,6 +5160,72 @@ function hodlFormatRecoverySheet(text) {
   window.addEventListener("blur", () => stopRepeating());
   document.addEventListener("visibilitychange", () => {
     if (document.hidden) stopRepeating();
+  });
+})();
+</script>
+<script>(() => {
+  const wrap = document.querySelector("#btc-calc > .wrap");
+  if (!wrap) return;
+
+  const control = document.createElement("label");
+  control.className = "bryan-mode-control no-print";
+  const checkbox = document.createElement("input");
+  checkbox.type = "checkbox";
+  checkbox.id = "bryan-mode";
+  checkbox.setAttribute("aria-label", "Bryan mode: use bare HTML");
+  control.append(checkbox, document.createTextNode(" Bryan mode (bare HTML)"));
+  wrap.prepend(control);
+
+  const stylesheetStates = new Map();
+  const inlineStyleStates = new Map();
+  let inlineStyleObserver = null;
+
+  const removeInlineStyles = (root) => {
+    const elements = [];
+    if (root instanceof Element && root.hasAttribute("style")) elements.push(root);
+    root.querySelectorAll?.("[style]").forEach(element => elements.push(element));
+    elements.forEach(element => {
+      inlineStyleStates.set(element, element.getAttribute("style"));
+      element.removeAttribute("style");
+    });
+  };
+
+  const enableBryanMode = () => {
+    [...document.styleSheets].forEach(stylesheet => {
+      stylesheetStates.set(stylesheet, stylesheet.disabled);
+      stylesheet.disabled = true;
+    });
+    removeInlineStyles(document);
+    inlineStyleObserver = new MutationObserver(mutations => {
+      mutations.forEach(mutation => {
+        if (mutation.type === "attributes") removeInlineStyles(mutation.target);
+        mutation.addedNodes.forEach(node => removeInlineStyles(node));
+      });
+    });
+    inlineStyleObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["style"],
+      childList: true,
+      subtree: true
+    });
+  };
+
+  const disableBryanMode = () => {
+    inlineStyleObserver?.disconnect();
+    inlineStyleObserver = null;
+    stylesheetStates.forEach((disabled, stylesheet) => {
+      stylesheet.disabled = disabled;
+    });
+    stylesheetStates.clear();
+    inlineStyleStates.forEach((style, element) => {
+      if (element.isConnected && style !== null) element.setAttribute("style", style);
+    });
+    inlineStyleStates.clear();
+  };
+
+  checkbox.addEventListener("change", () => {
+    if (checkbox.checked) enableBryanMode();
+    else disableBryanMode();
   });
 })();
 </script></body></html>

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -36,6 +36,7 @@ const jsMain = read("js/vendor.js") + read("js/app.js");
 const jsOnline = read("js/online.js");
 const jsEnhanced = read("js/enhanced-inputs.js");
 const jsRepeat = read("js/repeat-inputs.js");
+const jsBryanMode = read("js/bryan-mode.js");
 
 let html = template
   .replace("/*@@CSS@@*/", () => css)
@@ -43,6 +44,7 @@ let html = template
   .replace("/*@@JS_ONLINE@@*/", () => jsOnline)
   .replace("/*@@JS_ENHANCED@@*/", () => jsEnhanced)
   .replace("/*@@JS_REPEAT@@*/", () => jsRepeat)
+  .replace("/*@@JS_BRYAN_MODE@@*/", () => jsBryanMode)
   .split("{{VERSION}}").join(version);
 
 for (const leftover of html.match(/\/\*@@|{{VERSION}}/g) || []) {

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -272,6 +272,12 @@ header { padding: 8px 0 16px; }
   background: color-mix(in oklab, var(--danger) 14%, var(--surface)); color: var(--fg); line-height: 1.5;
 }
 .beta-warning strong { color: var(--danger); }
+.bryan-mode-control {
+  display: flex; align-items: center; gap: 8px; width: fit-content; margin: 0 0 12px;
+  padding: 9px 12px; border: 1px solid var(--border); border-radius: 8px;
+  background: var(--surface-2); color: var(--fg); font-weight: 700; cursor: pointer;
+}
+.bryan-mode-control input { margin: 0; accent-color: var(--accent); }
 @media print {
   :root {
     color-scheme: light;

--- a/src/index.html
+++ b/src/index.html
@@ -212,4 +212,5 @@ needs the number of signatures you choose, on real signing devices.</p>
 </div><!--/$--><script id="btc-calc-script">/*@@JS_MAIN@@*/</script>
 <script>/*@@JS_ONLINE@@*/</script>
 <script>/*@@JS_ENHANCED@@*/</script>
-<script>/*@@JS_REPEAT@@*/</script></body></html>
+<script>/*@@JS_REPEAT@@*/</script>
+<script>/*@@JS_BRYAN_MODE@@*/</script></body></html>

--- a/src/js/bryan-mode.js
+++ b/src/js/bryan-mode.js
@@ -1,0 +1,65 @@
+(() => {
+  const wrap = document.querySelector("#btc-calc > .wrap");
+  if (!wrap) return;
+
+  const control = document.createElement("label");
+  control.className = "bryan-mode-control no-print";
+  const checkbox = document.createElement("input");
+  checkbox.type = "checkbox";
+  checkbox.id = "bryan-mode";
+  checkbox.setAttribute("aria-label", "Bryan mode: use bare HTML");
+  control.append(checkbox, document.createTextNode(" Bryan mode (bare HTML)"));
+  wrap.prepend(control);
+
+  const stylesheetStates = new Map();
+  const inlineStyleStates = new Map();
+  let inlineStyleObserver = null;
+
+  const removeInlineStyles = (root) => {
+    const elements = [];
+    if (root instanceof Element && root.hasAttribute("style")) elements.push(root);
+    root.querySelectorAll?.("[style]").forEach(element => elements.push(element));
+    elements.forEach(element => {
+      inlineStyleStates.set(element, element.getAttribute("style"));
+      element.removeAttribute("style");
+    });
+  };
+
+  const enableBryanMode = () => {
+    [...document.styleSheets].forEach(stylesheet => {
+      stylesheetStates.set(stylesheet, stylesheet.disabled);
+      stylesheet.disabled = true;
+    });
+    removeInlineStyles(document);
+    inlineStyleObserver = new MutationObserver(mutations => {
+      mutations.forEach(mutation => {
+        if (mutation.type === "attributes") removeInlineStyles(mutation.target);
+        mutation.addedNodes.forEach(node => removeInlineStyles(node));
+      });
+    });
+    inlineStyleObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["style"],
+      childList: true,
+      subtree: true
+    });
+  };
+
+  const disableBryanMode = () => {
+    inlineStyleObserver?.disconnect();
+    inlineStyleObserver = null;
+    stylesheetStates.forEach((disabled, stylesheet) => {
+      stylesheet.disabled = disabled;
+    });
+    stylesheetStates.clear();
+    inlineStyleStates.forEach((style, element) => {
+      if (element.isConnected && style !== null) element.setAttribute("style", style);
+    });
+    inlineStyleStates.clear();
+  };
+
+  checkbox.addEventListener("change", () => {
+    if (checkbox.checked) enableBryanMode();
+    else disableBryanMode();
+  });
+})();


### PR DESCRIPTION
Adds a Bryan mode checkbox that removes page styling and restores it when unchecked.

Test: `npm run build`