### PR TITLE
Add noscript banner for browsers with JavaScript disabled

### DIFF
--- a/entropylab-0.1.3.html
+++ b/entropylab-0.1.3.html
@@ -635,6 +635,11 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 }
 </style></head><body><!--$--><div id="btc-calc" class="min-h-dvh bg-[#10110e]">
   <div class="wrap">
+    <noscript>
+      <aside class="beta-warning no-print" role="alert">
+        <strong>JavaScript is required:</strong> EntropyLab runs entirely inside your browser and never sends anything over the network. With JavaScript disabled the calculator cannot derive keys or addresses. Enable JavaScript, then run this file offline on an air-gapped computer.
+      </aside>
+    </noscript>
     <aside class="beta-warning no-print" role="alert">
       <strong>Beta software — not independently reviewed:</strong> EntropyLab is experimental and should be used only for testing. Do not rely on it to secure real bitcoin, and never test with funds you cannot afford to lose.
     </aside>

--- a/entropylab-0.1.3.html
+++ b/entropylab-0.1.3.html
@@ -637,7 +637,7 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
   <div class="wrap">
     <noscript>
       <aside class="beta-warning no-print" role="alert">
-        <strong>JavaScript is required:</strong> EntropyLab runs entirely inside your browser and never sends anything over the network. With JavaScript disabled the calculator cannot derive keys or addresses. Enable JavaScript, then run this file offline on an air-gapped computer.
+        <strong>JavaScript is required:</strong> EntropyLab performs wallet calculations locally inside your browser. With JavaScript disabled the calculator cannot derive keys or addresses. Enable JavaScript, then run this file offline on an air-gapped computer.
       </aside>
     </noscript>
     <aside class="beta-warning no-print" role="alert">

--- a/index.html
+++ b/index.html
@@ -635,6 +635,11 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 }
 </style></head><body><!--$--><div id="btc-calc" class="min-h-dvh bg-[#10110e]">
   <div class="wrap">
+    <noscript>
+      <aside class="beta-warning no-print" role="alert">
+        <strong>JavaScript is required:</strong> EntropyLab runs entirely inside your browser and never sends anything over the network. With JavaScript disabled the calculator cannot derive keys or addresses. Enable JavaScript, then run this file offline on an air-gapped computer.
+      </aside>
+    </noscript>
     <aside class="beta-warning no-print" role="alert">
       <strong>Beta software — not independently reviewed:</strong> EntropyLab is experimental and should be used only for testing. Do not rely on it to secure real bitcoin, and never test with funds you cannot afford to lose.
     </aside>

--- a/index.html
+++ b/index.html
@@ -637,7 +637,7 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
   <div class="wrap">
     <noscript>
       <aside class="beta-warning no-print" role="alert">
-        <strong>JavaScript is required:</strong> EntropyLab runs entirely inside your browser and never sends anything over the network. With JavaScript disabled the calculator cannot derive keys or addresses. Enable JavaScript, then run this file offline on an air-gapped computer.
+        <strong>JavaScript is required:</strong> EntropyLab performs wallet calculations locally inside your browser. With JavaScript disabled the calculator cannot derive keys or addresses. Enable JavaScript, then run this file offline on an air-gapped computer.
       </aside>
     </noscript>
     <aside class="beta-warning no-print" role="alert">

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
   <div class="wrap">
     <noscript>
       <aside class="beta-warning no-print" role="alert">
-        <strong>JavaScript is required:</strong> EntropyLab runs entirely inside your browser and never sends anything over the network. With JavaScript disabled the calculator cannot derive keys or addresses. Enable JavaScript, then run this file offline on an air-gapped computer.
+        <strong>JavaScript is required:</strong> EntropyLab performs wallet calculations locally inside your browser. With JavaScript disabled the calculator cannot derive keys or addresses. Enable JavaScript, then run this file offline on an air-gapped computer.
       </aside>
     </noscript>
     <aside class="beta-warning no-print" role="alert">

--- a/src/index.html
+++ b/src/index.html
@@ -2,6 +2,11 @@
 <html lang="en"><head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8"><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self'; object-src 'none'; base-uri 'none'; form-action 'none'"><meta name="referrer" content="no-referrer"><meta property="og:title" content="EntropyLab"><title>EntropyLab</title><meta name="application-name" content="EntropyLab"><meta name="application-version" content="v{{VERSION}}"><meta name="theme-color" content="#000000"><meta name="apple-mobile-web-app-title" content="EntropyLab"><meta name="apple-mobile-web-app-status-bar-style" content="black"><style>:is([id*='google_ads_iframe'],[id*='taboola-'],.taboolaHeight,.taboola-placeholder,#top-ad,#credential_picker_container,#credentials-picker-container,#credential_picker_iframe,#onetap_google_intermediate_iframe,[id*='google-one-tap-iframe'],#google-one-tap-popup-container,.google-one-tap__module,.google-one-tap-modal-div,.adthrive-auto-injected-player-container,.adthrive[id^="cls-video-container"]:has(.adthrive-auto-injected-player-container),#amp_floatingAdDiv,#ez-content-blocker-container) {display:none!important;min-height:0!important;height:0!important;}</style><style id="btc-calc-style">/*@@CSS@@*/</style></head><body><!--$--><div id="btc-calc" class="min-h-dvh bg-[#10110e]">
   <div class="wrap">
+    <noscript>
+      <aside class="beta-warning no-print" role="alert">
+        <strong>JavaScript is required:</strong> EntropyLab runs entirely inside your browser and never sends anything over the network. With JavaScript disabled the calculator cannot derive keys or addresses. Enable JavaScript, then run this file offline on an air-gapped computer.
+      </aside>
+    </noscript>
     <aside class="beta-warning no-print" role="alert">
       <strong>Beta software — not independently reviewed:</strong> EntropyLab is experimental and should be used only for testing. Do not rely on it to secure real bitcoin, and never test with funds you cannot afford to lose.
     </aside>


### PR DESCRIPTION
If you open the page with JavaScript turned off you just get the header, the warnings and the three tab buttons with no forms. The panels are hidden in the HTML and only shown by `app.js`, so with JS off there's nothing on the page telling you why it's empty.

This adds a `<noscript>` block above the beta warning in `src/index.html`.

Rebuilt `index.html` and `entropylab-0.1.3.html` with `npm run build`.

Open `index.html` with JS disabled and the banner shows at the top. With JS enabled, it doesn't appear.