### PR TITLE
Add npm-based CI/CD pipeline with browser tests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,22 +1,23 @@
-name: Deploy EntropyLab to GitHub Pages
+name: EntropyLab CI/CD
 
 on:
+  pull_request:
   push:
     branches: [main]
   workflow_dispatch:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  build:
+  build-and-test:
+    name: Test and package
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -25,6 +26,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
+
+      - name: Install Firefox
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y firefox
+          firefox --version
 
       - name: Run tests
         run: npm test
@@ -41,6 +48,9 @@ jobs:
             exit 1
           fi
 
+      - name: Verify site artifact
+        run: npm run verify
+
       - name: Prepare static site
         run: |
           mkdir _site
@@ -48,21 +58,28 @@ jobs:
           cp -r assets _site/assets
           touch _site/.nojekyll
 
-      - name: Upload site artifact
+      - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: _site
+          retention-days: 7
 
   deploy:
-    needs: build
+    name: Deploy to GitHub Pages
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
     steps:
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5
 
-      - name: Deploy to GitHub Pages
+      - name: Deploy tested artifact
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+/_site/

--- a/README.md
+++ b/README.md
@@ -81,8 +81,16 @@ files, run `npm run clean`.
 
 ```
 ├── assets/                 Static assets (logo, favicon)
-├── scripts/build.mjs       Zero-dependency build script
-├── test/network-check.test.mjs  Tests for the network-check module (npm test)
+├── scripts/
+│   ├── build.mjs           Zero-dependency build script
+│   └── verify-site.mjs     Site artifact verification (npm run verify)
+├── test/
+│   ├── network-check.test.mjs   Tests for the network-check module
+│   ├── validate.test.mjs        Source and security invariants
+│   └── browser.test.mjs         Headless-Firefox integration harness
+├── tests/
+│   ├── browser-instrumentation.html  In-page test hooks
+│   └── browser-suite.html            In-page suite run by the browser harness
 ├── src/
 │   ├── index.html          HTML template (markup and document head)
 │   ├── css/styles.css      Application styles
@@ -98,6 +106,35 @@ files, run `npm run clean`.
 ├── versions.json           Version manifest for the hosted version picker
 └── versions/archived/      Historical releases excluded from the picker
 ```
+
+## Development and deployment
+
+The toolchain is npm and Node.js (>=18) with no third-party dependencies. Every
+local and CI operation is exposed as an npm script:
+
+```bash
+npm test                    # run all tests: network-check, source invariants, browser suite
+npm run test:validate       # validate source and security invariants
+npm run test:browser        # test crypto, sanitization, networking, exports in headless Firefox
+npm run build               # compile src/ into the committed root files
+npm run verify              # verify the site artifact (snapshot, manifest, assets)
+npm run ci                  # run test, build, and verify in order
+```
+
+GitHub Actions runs the same steps for pull requests and pushes to `main`,
+then stages the verified site (`index.html`, `entropylab-*.html`,
+`versions.json`, `assets/`) and deploys it to GitHub Pages. Local checks and
+CI/CD use the same commands; the workflow contains no separate build
+implementation.
+
+The browser tests run the assembled application in headless Firefox against a
+local Node.js HTTP server. They feed hostile markup and event-handler strings
+through user-facing fields and the version manifest, verify all observed
+application requests remain same-origin, exercise the hosted warning and
+assets, derive a known wallet through the UI, and inspect both watch-only and
+private recovery-sheet exports. They also run the BIP39 and BIP32 published
+vectors directly against the application code. Firefox is the only browser
+runtime used; the server, build, and test harness are dependency-free Node.js.
 
 ## Security notice
 

--- a/entropylab-0.1.3.html
+++ b/entropylab-0.1.3.html
@@ -88,7 +88,7 @@ textarea { display: block; min-height: 96px; letter-spacing: 0.08em; }
   white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word;
   color: var(--fg); font-family: var(--mono); font-size: 14px; line-height: 1.45; letter-spacing: 0.08em;
 }
-.dice-input-highlight[data-trailing-newline="true"]::after { content: "00b"; }
+.dice-input-highlight[data-trailing-newline="true"]::after { content: "\200b"; }
 .dice-roll-invalid {
   color: var(--danger);
 }

--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@ textarea { display: block; min-height: 96px; letter-spacing: 0.08em; }
   white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word;
   color: var(--fg); font-family: var(--mono); font-size: 14px; line-height: 1.45; letter-spacing: 0.08em;
 }
-.dice-input-highlight[data-trailing-newline="true"]::after { content: "00b"; }
+.dice-input-highlight[data-trailing-newline="true"]::after { content: "\200b"; }
 .dice-roll-invalid {
   color: var(--danger);
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,11 @@
   "scripts": {
     "build": "node scripts/build.mjs",
     "clean": "node scripts/build.mjs --clean",
-    "test": "node --test test/*.test.mjs"
+    "test": "node --test test/*.test.mjs",
+    "test:validate": "node --test test/validate.test.mjs",
+    "test:browser": "node --test test/browser.test.mjs",
+    "verify": "node scripts/verify-site.mjs",
+    "ci": "npm test && npm run build && npm run verify"
   },
   "keywords": [
     "bitcoin",

--- a/scripts/verify-site.mjs
+++ b/scripts/verify-site.mjs
@@ -1,0 +1,68 @@
+// Verifies the committed site artifact: the compiled index.html, the
+// versioned snapshot, the versions.json manifest, and the published assets.
+// Zero dependencies. Run with `npm run verify`.
+import {
+  existsSync,
+  lstatSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const fail = (message) => {
+  console.error(message);
+  process.exit(1);
+};
+
+const repoDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const pkg = JSON.parse(readFileSync(join(repoDir, "package.json"), "utf8"));
+const version = pkg.version;
+
+if (!/^\d+(?:\.\d+)*$/.test(version)) {
+  fail(`Invalid version in package.json: ${version}`);
+}
+const versionedFile = `entropylab-${version}.html`;
+
+for (const name of ["index.html", versionedFile, "versions.json", "assets/favicon.png", "assets/entropylab_dark.png"]) {
+  const path = join(repoDir, name);
+  if (!existsSync(path) || statSync(path).size === 0) {
+    fail(`Site artifact is missing or empty: ${name}`);
+  }
+}
+
+// The compiled application and its versioned snapshot must be identical.
+if (!readFileSync(join(repoDir, "index.html")).equals(readFileSync(join(repoDir, versionedFile)))) {
+  fail(`index.html does not match ${versionedFile}. Run 'npm run build' and commit the result.`);
+}
+
+// The manifest must be deterministic and complete for the current release.
+const expectedJson = `${JSON.stringify({ versions: [{ version: `v${version}`, file: versionedFile }] })}\n`;
+if (readFileSync(join(repoDir, "versions.json"), "utf8") !== expectedJson) {
+  fail(`versions.json does not match the current release.\nExpected: ${expectedJson}`);
+}
+
+// No stale generated snapshots at the repository root.
+const rootSnapshots = readdirSync(repoDir).filter((name) => /^entropylab-\d+(?:\.\d+)*\.html$/.test(name));
+if (JSON.stringify(rootSnapshots) !== JSON.stringify([versionedFile])) {
+  fail(`Unexpected versioned snapshots at the root: ${rootSnapshots.join(", ")}`);
+}
+
+// Published assets must be intact and free of symbolic links.
+const walk = (dir, prefix) => {
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name);
+    const label = join(prefix, name);
+    const stats = lstatSync(path);
+    if (stats.isSymbolicLink()) fail(`Symbolic link in published assets: ${label}`);
+    if (stats.isDirectory()) {
+      walk(path, label);
+    } else if (stats.size === 0) {
+      fail(`Empty published asset: ${label}`);
+    }
+  }
+};
+walk(join(repoDir, "assets"), "assets");
+
+console.log(`Verified site artifact for v${version} (index.html, ${versionedFile}, versions.json, assets/).`);

--- a/test/browser.test.mjs
+++ b/test/browser.test.mjs
@@ -1,0 +1,229 @@
+// Runs the assembled application in headless Firefox against a local Node.js
+// HTTP server and validates the BIP39/BIP32 vectors, input sanitization,
+// same-origin network behavior, hosted presentation, and recovery-sheet
+// exports. The in-page instrumentation and suite live in tests/.
+// Run with `npm run test:browser` or `npm test`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { createServer } from "node:http";
+import {
+  closeSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const read = (path) => readFileSync(join(root, path), "utf8");
+const firefoxBin = process.env.FIREFOX_BINARY ?? "firefox";
+
+const appVersion = JSON.parse(read("package.json")).version;
+const versionFile = `entropylab-${appVersion}.html`;
+const versionSource = join(root, versionFile);
+
+// Stage the site exactly the way scripts/build.mjs publishes it (the compiled
+// index.html plus its versioned snapshot), and add the instrumented test
+// document and the hostile version manifest.
+const stageSite = () => {
+  const workDir = mkdtempSync(join(tmpdir(), "entropylab-browser-"));
+  const siteDir = join(workDir, "site");
+  const downloadDir = join(workDir, "downloads");
+  const onlineProfile = join(workDir, "profile-online");
+  const offlineProfile = join(workDir, "profile-offline");
+  mkdirSync(join(siteDir, "assets"), { recursive: true });
+  mkdirSync(downloadDir, { recursive: true });
+  mkdirSync(onlineProfile, { recursive: true });
+  mkdirSync(offlineProfile, { recursive: true });
+  cpSync(versionSource, join(siteDir, versionFile));
+  cpSync(join(root, "assets"), join(siteDir, "assets"), { recursive: true });
+
+  const appHtml = read("index.html");
+  const instrumentation = read("tests/browser-instrumentation.html");
+  const suite = read("tests/browser-suite.html");
+
+  // Inject the test instrumentation before the application stylesheet.
+  const marker = '<style id="btc-calc-style">';
+  const markerIndex = appHtml.indexOf(marker);
+  if (markerIndex === -1) throw new Error("could not find the application stylesheet marker");
+  const stageOne = `${appHtml.slice(0, markerIndex)}${instrumentation}${appHtml.slice(markerIndex)}`;
+
+  // Expose the application crypto functions for the published vectors.
+  const bridge =
+    'globalThis.__entropyLabCrypto={entropyToMnemonic:(hex)=>_n(M.decode(hex)),mnemonicToEntropy:(mnemonic)=>M.encode(Er(mnemonic,Ae)),mnemonicToSeed:(mnemonic,passphrase)=>M.encode(wi(mnemonic,passphrase)),validateMnemonic:(mnemonic)=>Mt(mnemonic).ok,masterXprv:(mnemonic,passphrase)=>Gt.fromMasterSeed(wi(mnemonic,passphrase)).privateExtendedKey};';
+  const anchor = 'var ec=document.getElementById("btc-calc")';
+  const stageTwo = stageOne.replace(anchor, `${bridge}${anchor}`);
+  if (stageTwo === stageOne) throw new Error("could not find the crypto bridge anchor");
+
+  // Append the browser suite before the document end.
+  const testHtml = `${stageTwo.replace(/<\/body>\s*<\/html>\s*$/, "")}${suite}</body></html>\n`;
+  const testHtmlPath = join(siteDir, "browser-tests.html");
+  writeFileSync(testHtmlPath, testHtml, "utf8");
+
+  writeFileSync(
+    join(siteDir, "versions.json"),
+    `${JSON.stringify({
+      versions: [
+        { version: `v${appVersion}`, file: versionFile },
+        { version: "<img src=x onerror=window.__browserTestInjected=true>", file: "javascript:window.__browserTestInjected=true" },
+        { version: "v9.9.9", file: "../../outside.html" },
+      ],
+    })}\n`,
+    "utf8",
+  );
+
+  writeFileSync(join(workDir, "not-found.txt"), "Not found\n", "utf8");
+
+  const userJs = [
+    'user_pref("browser.download.folderList", 2);',
+    `user_pref("browser.download.dir", "${downloadDir}");`,
+    'user_pref("browser.download.useDownloadDir", true);',
+    'user_pref("browser.download.alwaysOpenPanel", false);',
+    'user_pref("browser.helperApps.neverAsk.saveToDisk", "text/plain,application/octet-stream");',
+    'user_pref("browser.shell.checkDefaultBrowser", false);',
+    'user_pref("browser.startup.homepage_override.mstone", "ignore");',
+    'user_pref("datareporting.policy.dataSubmissionEnabled", false);',
+    'user_pref("toolkit.telemetry.enabled", false);',
+    "",
+  ].join("\n");
+  writeFileSync(join(onlineProfile, "user.js"), userJs, "utf8");
+  writeFileSync(join(offlineProfile, "user.js"), userJs, "utf8");
+
+  return { workDir, siteDir, downloadDir, onlineProfile, offlineProfile, testHtmlPath };
+};
+
+// A real HTTP server: concurrent connections, correct framing, 404s.
+const createTestServer = ({ siteDir, testHtmlPath }) => {
+  const notFound = { file: join(dirname(testHtmlPath), "..", "not-found.txt"), type: "text/plain; charset=utf-8" };
+  const routes = {
+    "/": { file: testHtmlPath, type: "text/html; charset=utf-8" },
+    "/browser-tests.html": { file: testHtmlPath, type: "text/html; charset=utf-8" },
+    "/versions.json": { file: join(siteDir, "versions.json"), type: "application/json" },
+    [`/${versionFile}`]: { file: join(siteDir, versionFile), type: "text/html; charset=utf-8" },
+    "/assets/favicon.png": { file: join(siteDir, "assets/favicon.png"), type: "image/png" },
+    "/assets/entropylab_dark.png": { file: join(siteDir, "assets/entropylab_dark.png"), type: "image/png" },
+  };
+  const server = createServer((request, response) => {
+    const path = new URL(request.url, "http://localhost").pathname;
+    const route = routes[path] ?? { ...notFound, status: 404, reason: "Not Found" };
+    response.writeHead(route.status ?? 200, {
+      "Content-Type": route.type,
+      "Content-Length": statSync(route.file).size,
+      "Cache-Control": "no-store",
+    });
+    response.end(readFileSync(route.file));
+  });
+  const listen = () => new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve(server.address().port));
+  });
+  return { server, listen };
+};
+
+const spawnFirefox = (profile, url, logPath) => {
+  const logFd = openSync(logPath, "w");
+  const process = spawn(firefoxBin, ["--headless", "--new-instance", "--profile", profile, url], {
+    stdio: ["ignore", logFd, logFd],
+  });
+  closeSync(logFd);
+  process.on("error", () => {});
+  return process;
+};
+
+const waitForFile = async (file, timeoutMs) => {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(file) && statSync(file).size > 0) return true;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return false;
+};
+
+const parseReport = (file) => {
+  const lines = readFileSync(file, "utf8").trim().split("\n");
+  const results = lines.map((line) => {
+    const [status, name, error] = line.split("\t");
+    return { ok: status === "ok", name: name ?? "", error: error ?? "" };
+  });
+  return {
+    checks: results.length,
+    results,
+    failures: results.filter((result) => !result.ok),
+  };
+};
+
+const tail = (file, maxLines = 120) => {
+  if (!existsSync(file)) return "";
+  return readFileSync(file, "utf8").split("\n").slice(-maxLines).join("\n");
+};
+
+test("headless Firefox runs the hosted and offline suites", async () => {
+  const versionCheck = spawnSync(firefoxBin, ["--version"], { stdio: "pipe" });
+  assert.equal(versionCheck.status, 0, `Firefox is required for the browser tests (tried "${firefoxBin}").`);
+  assert.match(appVersion, /^\d+(\.\d+)*$/, `invalid application version in package.json: ${appVersion}`);
+  assert.ok(existsSync(join(root, "index.html")), "compiled index.html is missing (run 'npm run build')");
+  assert.ok(existsSync(versionSource), `current release snapshot is missing: ${versionFile}`);
+
+  const { workDir, siteDir, downloadDir, onlineProfile, offlineProfile, testHtmlPath } = stageSite();
+  const { server, listen } = createTestServer({ siteDir, testHtmlPath });
+  const browsers = [];
+  let port = 0;
+  try {
+    port = await listen();
+    const onlineUrl = `http://127.0.0.1:${port}/browser-tests.html?online-preview=1`;
+    const offlineUrl = `file://${testHtmlPath}?offline-test=1`;
+    const onlineLog = join(workDir, "firefox-online.log");
+    const offlineLog = join(workDir, "firefox-offline.log");
+    browsers.push(spawnFirefox(onlineProfile, onlineUrl, onlineLog));
+    browsers.push(spawnFirefox(offlineProfile, offlineUrl, offlineLog));
+
+    const onlineReport = join(downloadDir, "online-results.txt");
+    const offlineReport = join(downloadDir, "offline-results.txt");
+    const [onlineDone, offlineDone] = await Promise.all([
+      waitForFile(onlineReport, 60000),
+      waitForFile(offlineReport, 60000),
+    ]);
+    assert.ok(
+      onlineDone && offlineDone,
+      `Timed out waiting for Firefox test reports.\n--- firefox-online.log ---\n${tail(onlineLog)}\n--- firefox-offline.log ---\n${tail(offlineLog)}`,
+    );
+
+    const online = parseReport(onlineReport);
+    const offline = parseReport(offlineReport);
+    // Guard against a report that exists because the suite bailed out early:
+    // the hosted suite must genuinely run its full battery of checks.
+    assert.ok(online.checks >= 20, `online suite report is incomplete: only ${online.checks} checks`);
+    assert.ok(offline.checks >= 2, `offline suite report is incomplete: only ${offline.checks} checks`);
+
+    const all = [...offline.results, ...online.results];
+    let counter = 0;
+    for (const result of all) {
+      counter += 1;
+      if (result.ok) {
+        console.log(`ok ${counter} - ${result.name}`);
+      } else {
+        console.error(`not ok ${counter} - ${result.name}`);
+        console.error(`  ${result.error}`);
+      }
+    }
+    console.log(`1..${counter}`);
+    const failures = [...offline.failures, ...online.failures];
+    assert.equal(failures.length, 0, `${failures.length} Firefox integration test(s) failed: ${failures.map((f) => `${f.name}: ${f.error}`).join("; ")}`);
+    console.log(`All ${counter} cryptographic and browser integration tests passed.`);
+  } finally {
+    for (const browser of browsers) {
+      browser.kill("SIGKILL");
+    }
+    await new Promise((resolve) => server.close(resolve));
+    rmSync(workDir, { recursive: true, force: true });
+  }
+});

--- a/test/validate.test.mjs
+++ b/test/validate.test.mjs
@@ -1,0 +1,134 @@
+// Source validation and security invariants for the EntropyLab repository.
+// Run with `npm run test:validate` or `npm test`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const read = (path) => readFileSync(join(root, path), "utf8");
+
+const pkg = JSON.parse(read("package.json"));
+const appVersion = pkg.version;
+const versionedFile = `entropylab-${appVersion}.html`;
+
+const requiredFiles = [
+  "README.md",
+  "LICENSE",
+  "package.json",
+  "index.html",
+  versionedFile,
+  "versions.json",
+  "assets/favicon.png",
+  "assets/entropylab_dark.png",
+  "assets/entropylab_light.png",
+  "assets/entropylab_banner.png",
+  "scripts/build.mjs",
+  "scripts/verify-site.mjs",
+  "test/validate.test.mjs",
+  "test/browser.test.mjs",
+  "tests/browser-instrumentation.html",
+  "tests/browser-suite.html",
+  "src/index.html",
+  "src/css/styles.css",
+  "src/js/vendor.js",
+  "src/js/app.js",
+  "src/js/online.js",
+  "src/js/network-check.js",
+  "src/js/enhanced-inputs.js",
+  "src/js/repeat-inputs.js",
+  ".github/workflows/ci-cd.yml",
+];
+
+for (const file of requiredFiles) {
+  test(`${file} exists`, () => {
+    const path = join(root, file);
+    assert.ok(existsSync(path) && statSync(path).isFile(), `${file} is missing or not a file`);
+  });
+}
+
+test("package.json declares a valid version and the expected scripts", () => {
+  assert.match(appVersion, /^\d+(\.\d+)*$/, `invalid version: ${appVersion}`);
+  for (const script of ["build", "clean", "test", "verify", "ci"]) {
+    assert.equal(typeof pkg.scripts?.[script], "string", `package.json is missing the "${script}" script`);
+  }
+});
+
+test("Node scripts and test files parse", () => {
+  const nodeFiles = [
+    "scripts/build.mjs",
+    "scripts/verify-site.mjs",
+    ...readdirSync(join(root, "test")).filter((name) => name.endsWith(".mjs")).map((name) => `test/${name}`),
+  ];
+  for (const file of nodeFiles) {
+    execFileSync(process.execPath, ["--check", join(root, file)], { stdio: "pipe" });
+  }
+});
+
+const readmeVersion = read("README.md").match(/^Current version: \*\*v([^*]*)\*\*$/m)?.[1] ?? "";
+
+test("README version agrees with package.json", () => {
+  assert.equal(readmeVersion, appVersion, `package.json: ${appVersion}; README: ${readmeVersion}`);
+});
+
+test("the current release snapshot exists and matches the compiled app", () => {
+  const snapshot = join(root, versionedFile);
+  assert.ok(existsSync(snapshot), `${versionedFile} is missing`);
+  assert.ok(
+    readFileSync(join(root, "index.html")).equals(readFileSync(snapshot)),
+    `index.html does not match ${versionedFile}`,
+  );
+});
+
+test("versions.json lists the current snapshot", () => {
+  assert.deepEqual(
+    JSON.parse(read("versions.json")),
+    { versions: [{ version: `v${appVersion}`, file: versionedFile }] },
+  );
+});
+
+const htmlFiles = ["index.html", versionedFile];
+
+for (const file of htmlFiles) {
+  test(`${file} declares HTML5`, () => {
+    assert.match(read(file), /^<!DOCTYPE html>/);
+  });
+  test(`${file} has a closing html element`, () => {
+    assert.match(read(file), /<\/html>\s*$/);
+  });
+  test(`${file} includes the offline content security policy`, () => {
+    assert.ok(read(file).includes("default-src 'none'"), `${file} is missing the offline CSP`);
+  });
+  test(`${file} contains application JavaScript`, () => {
+    assert.ok(read(file).includes("<script>"), `${file} has no inline script`);
+  });
+  test(`${file} has no remote executable subresources`, () => {
+    const html = read(file);
+    assert.doesNotMatch(html, /<(script|iframe)[^>]+src=["' ]*https?:\/\//i);
+    assert.doesNotMatch(html, /<link[^>]+href=["' ]*https?:\/\//i);
+  });
+}
+
+test("repository source has no unresolved merge markers", () => {
+  const offenders = [];
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const name = entry.name;
+      const path = join(dir, name);
+      if (name === ".git" || name.endsWith(".png")) continue;
+      if (entry.isSymbolicLink()) continue;
+      if (entry.isDirectory()) {
+        walk(path);
+      } else {
+        const lines = readFileSync(path, "utf8").split("\n");
+        if (lines.some((line) => /^(<<<<<<<|=======|>>>>>>>)/.test(line))) {
+          offenders.push(relative(root, path));
+        }
+      }
+    }
+  };
+  walk(root);
+  assert.deepEqual(offenders, [], `unresolved merge markers in: ${offenders.join(", ")}`);
+});

--- a/tests/browser-instrumentation.html
+++ b/tests/browser-instrumentation.html
@@ -1,0 +1,69 @@
+<script>
+window.__entropyLabTest = { network: [], downloadName: "", lastBlob: null };
+(() => {
+  const state = window.__entropyLabTest;
+  const absolute = (value) => {
+    try { return new URL(value instanceof Request ? value.url : String(value), location.href).href; }
+    catch { return String(value); }
+  };
+  const originalFetch = window.fetch.bind(window);
+  window.fetch = (input, init) => {
+    const entry = { type: "fetch", url: absolute(input), completed: false };
+    state.network.push(entry);
+    const request = originalFetch(input, init);
+    request.then(
+      (response) => { entry.completed = true; entry.status = response.status; },
+      () => { entry.completed = true; entry.status = 0; },
+    );
+    return request;
+  };
+  const originalOpen = XMLHttpRequest.prototype.open;
+  XMLHttpRequest.prototype.open = function(method, url, ...rest) {
+    state.network.push({ type: "xhr", url: absolute(url) });
+    return originalOpen.call(this, method, url, ...rest);
+  };
+  const OriginalWebSocket = window.WebSocket;
+  window.WebSocket = class extends OriginalWebSocket {
+    constructor(url, protocols) {
+      state.network.push({ type: "websocket", url: absolute(url) });
+      super(url, protocols);
+    }
+  };
+  const OriginalEventSource = window.EventSource;
+  window.EventSource = class extends OriginalEventSource {
+    constructor(url, options) {
+      state.network.push({ type: "eventsource", url: absolute(url) });
+      super(url, options);
+    }
+  };
+  const originalSendBeacon = navigator.sendBeacon?.bind(navigator);
+  if (originalSendBeacon) {
+    navigator.sendBeacon = (url, data) => {
+      state.network.push({ type: "beacon", url: absolute(url) });
+      return originalSendBeacon(url, data);
+    };
+  }
+  const originalCreateObjectURL = URL.createObjectURL.bind(URL);
+  const originalAnchorClick = HTMLAnchorElement.prototype.click;
+  URL.createObjectURL = (blob) => {
+    state.lastBlob = blob;
+    return originalCreateObjectURL(blob);
+  };
+  HTMLAnchorElement.prototype.click = function() {
+    if (this.dataset.testReport === "true") return originalAnchorClick.call(this);
+    if (this.download) {
+      state.downloadName = this.download;
+      return;
+    }
+    return originalAnchorClick.call(this);
+  };
+  window.__downloadTestReport = (filename, text) => {
+    const link = document.createElement("a");
+    link.dataset.testReport = "true";
+    link.download = filename;
+    link.href = originalCreateObjectURL(new Blob([text], { type: "text/plain" }));
+    document.body.appendChild(link);
+    link.click();
+  };
+})();
+</script>

--- a/tests/browser-suite.html
+++ b/tests/browser-suite.html
@@ -1,0 +1,255 @@
+<script>
+(async () => {
+  const results = [];
+  const state = window.__entropyLabTest;
+  const crypto = window.__entropyLabCrypto;
+  const wait = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+  const until = async (predicate, description, timeout = 15000) => {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+      const value = predicate();
+      if (value) return value;
+      await wait(50);
+    }
+    throw new Error("Timed out waiting for " + description);
+  };
+  const test = async (name, body) => {
+    try {
+      await body();
+      results.push({ name, ok: true });
+    } catch (error) {
+      results.push({
+        name,
+        ok: false,
+        error: (error instanceof Error ? error.message : String(error)).replace(/[\t\r\n]+/g, " "),
+      });
+    }
+  };
+  const assert = (condition, message) => { if (!condition) throw new Error(message); };
+  const equal = (actual, expected) => {
+    if (actual !== expected) throw new Error(`expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  };
+  const report = (filename) => {
+    const text = results.map((result) =>
+      [result.ok ? "ok" : "not ok", result.name, result.error || ""].join("\t")
+    ).join("\n") + "\n";
+    window.__downloadTestReport(filename, text);
+  };
+  const currentVersion = document.querySelector('meta[name="application-version"]')?.content;
+  const currentNumber = currentVersion?.replace(/^v/, "");
+  const currentFile = `entropylab-${currentNumber}.html`;
+  const versionHeader = `ENTROPYLAB ${currentVersion?.toUpperCase()}`;
+
+  await wait(500);
+
+  if (new URLSearchParams(location.search).get("offline-test") === "1") {
+    await test("offline mode keeps online-only presentation disabled", () => {
+      const warning = document.getElementById("online-warning");
+      const brand = document.getElementById("online-brand-mark");
+      assert(warning && warning.hidden, "Offline mode displayed the online warning");
+      assert(brand && brand.hidden && !brand.getAttribute("src"), "Offline mode loaded online branding");
+    });
+    await test("offline mode performs no HTTP, WebSocket, or XHR connections", () => {
+      assert(state.network.length === 0, "Offline code attempted a connection");
+      const external = performance.getEntriesByType("resource")
+        .map((entry) => entry.name)
+        .filter((url) => /^(https?|wss?):/i.test(url));
+      assert(external.length === 0, "Offline mode loaded a network resource: " + external.join(", "));
+      const options = [...document.querySelectorAll(".version-select option")];
+      assert(options.length === 1 && options[0].value === currentFile, "Local version fallback is missing");
+    });
+    report("offline-results.txt");
+    return;
+  }
+
+  const vectors = [
+    {
+      entropy: "00000000000000000000000000000000",
+      mnemonic: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+      seed: "c55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e53495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c81b2f001698e7463b04",
+      xprv: "xprv9s21ZrQH143K3h3fDYiay8mocZ3afhfULfb5GX8kCBdno77K4HiA15Tg23wpbeF1pLfs1c5SPmYHrEpTuuRhxMwvKDwqdKiGJS9XFKzUsAF",
+    },
+    {
+      entropy: "000000000000000000000000000000000000000000000000",
+      mnemonic: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon agent",
+      seed: "035895f2f481b1b0f01fcf8c289c794660b289981a78f8106447707fdd9666ca06da5a9a565181599b79f53b844d8a71dd9f439c52a3d7b3e8a79c906ac845fa",
+      xprv: "xprv9s21ZrQH143K3mEDrypcZ2usWqFgzKB6jBBx9B6GfC7fu26X6hPRzVjzkqkPvDqp6g5eypdk6cyhGnBngbjeHTe4LsuLG1cCmKJka5SMkmU",
+    },
+    {
+      entropy: "0000000000000000000000000000000000000000000000000000000000000000",
+      mnemonic: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
+      seed: "bda85446c68413707090a52022edd26a1c9462295029f2e60cd7c4f2bbd3097170af7a4d73245cafa9c3cca8d561a7c3de6f5d4a10be8ed2a5e608d68f92fcc8",
+      xprv: "xprv9s21ZrQH143K32qBagUJAMU2LsHg3ka7jqMcV98Y7gVeVyNStwYS3U7yVVoDZ4btbRNf4h6ibWpY22iRmXq35qgLs79f312g2kj5539ebPM",
+    },
+  ];
+
+  for (const [index, vector] of vectors.entries()) {
+    const bits = vector.entropy.length * 4;
+    await test(`BIP39 vector ${index + 1}: ${bits}-bit entropy produces the expected mnemonic`, () => {
+      equal(crypto.entropyToMnemonic(vector.entropy), vector.mnemonic);
+    });
+    await test(`BIP39 vector ${index + 1}: mnemonic recovers the original entropy`, () => {
+      equal(crypto.mnemonicToEntropy(vector.mnemonic), vector.entropy);
+    });
+    await test(`BIP39 vector ${index + 1}: mnemonic and passphrase produce the expected seed`, () => {
+      equal(crypto.mnemonicToSeed(vector.mnemonic, "TREZOR"), vector.seed);
+    });
+    await test(`BIP32 vector ${index + 1}: seed produces the expected master xprv`, () => {
+      equal(crypto.masterXprv(vector.mnemonic, "TREZOR"), vector.xprv);
+    });
+  }
+
+  await test("BIP39 accepts a checksum-valid mnemonic", () => equal(crypto.validateMnemonic(vectors[0].mnemonic), true));
+  await test("BIP39 rejects a mnemonic with an invalid checksum", () => equal(crypto.validateMnemonic("abandon ".repeat(11) + "abandon"), false));
+  await test("BIP39 rejects a word outside the English list", () => equal(crypto.validateMnemonic("abandon ".repeat(11) + "entropy-lab"), false));
+  await test("BIP39 applies NFKD normalization to passphrases", () => {
+    equal(crypto.mnemonicToSeed(vectors[0].mnemonic, "caf\u00e9"), crypto.mnemonicToSeed(vectors[0].mnemonic, "cafe\u0301"));
+  });
+
+  const chooseMode = async (label) => {
+    const button = [...document.querySelectorAll("#modes button")].find((item) => item.textContent.includes(label));
+    assert(button, "Missing mode button: " + label);
+    button.click();
+    await wait(0);
+  };
+  const input = (element, value) => {
+    element.value = value;
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+  };
+
+  await test("hosted preview enables its warning and same-origin branding", () => {
+    const warning = document.getElementById("online-warning");
+    const brand = document.getElementById("online-brand-mark");
+    const favicon = document.getElementById("online-favicon");
+    assert(warning && !warning.hidden, "Online warning was not displayed");
+    assert(brand && !brand.hidden && new URL(brand.src).origin === location.origin, "Brand asset is not same-origin");
+    assert(favicon && new URL(favicon.href).origin === location.origin, "Favicon is not same-origin");
+  });
+
+  await test("hosted version manifest is fetched and allowlisted before entering the DOM", async () => {
+    const manifest = await until(
+      () => state.network.find((entry) => new URL(entry.url).pathname === "/versions.json" && entry.completed),
+      "completed version-manifest request",
+    );
+    assert(manifest.status === 200, `Version manifest returned HTTP ${manifest.status}`);
+    await wait(0);
+    const options = [...document.querySelectorAll(".version-select option")];
+    assert(options.length === 1 && options[0].value === currentFile, "Unsafe manifest entry was accepted");
+    assert(window.__browserTestInjected !== true, "Manifest executed script");
+  });
+
+  await test("hex, seed, and private-key inputs cannot inject markup", async () => {
+    const payload = '<img src=x onerror="window.__browserTestInjected=true">';
+    await chooseMode("Hex");
+    const hex = await until(() => document.getElementById("hex"), "hex input");
+    input(hex, payload + "0000");
+    assert(!/[<>="']/.test(hex.value), "Dangerous characters remained in hex input");
+    await chooseMode("Seed phrase");
+    const seed = await until(() => document.getElementById("seed"), "seed input");
+    input(seed, payload + "abandon");
+    assert(!/[<>="']/.test(seed.value), "Dangerous characters remained in seed input");
+    await chooseMode("Private key");
+    const key = await until(() => document.getElementById("key"), "private-key input");
+    input(key, payload);
+    assert(!/[<>="']/.test(key.value), "Dangerous characters remained in private-key input");
+    assert(!document.querySelector('img[src="x"]') && window.__browserTestInjected !== true, "Input executed markup");
+  });
+
+  await test("dice, binary, passphrase, multisig, and PSBT inputs cannot inject markup", async () => {
+    const payload = '<img src=x onerror="window.__browserTestInjected=true">';
+    await chooseMode("Dice rolls");
+    const dice = await until(() => document.getElementById("dice"), "dice input");
+    input(dice, payload + "123456");
+    assert(!/[<>="']/.test(dice.value), "Dangerous characters remained in dice input");
+    await chooseMode("Hex");
+    document.querySelector('input[name="entropy-format"][value="bin"]').click();
+    const binary = await until(() => document.getElementById("bin"), "binary input");
+    input(binary, payload + "010101");
+    assert(!/[<>="']/.test(binary.value), "Dangerous characters remained in binary input");
+    const passphrase = document.getElementById("pass");
+    input(passphrase, payload);
+    assert(!document.querySelector('img[src="x"]'), "Passphrase created markup");
+    input(passphrase, "");
+    document.querySelector('#workspace [data-workspace="msig"]').click();
+    const xpub = await until(() => document.querySelector("#msig-keys textarea"), "multisig input");
+    input(xpub, payload + "tpub123");
+    assert(!/[<>="']/.test(xpub.value), "Dangerous characters remained in multisig input");
+    document.querySelector('#workspace [data-workspace="psbt"]').click();
+    const psbt = await until(() => document.getElementById("psbt-text"), "PSBT input");
+    input(psbt, payload);
+    document.getElementById("psbt-go").click();
+    await until(() => document.getElementById("psbt-error").textContent, "PSBT rejection");
+    assert(!document.querySelector("#psbt-card img") && window.__browserTestInjected !== true, "Input executed markup");
+    document.querySelector('#workspace [data-workspace="calc"]').click();
+    await until(() => !document.getElementById("calc-card").hidden, "key workspace");
+  });
+
+  await test("a known BIP39 wallet can be derived through the UI", async () => {
+    document.querySelector('[data-seed-words="12"]').click();
+    await chooseMode("Hex");
+    document.querySelector('input[name="entropy-format"][value="hex"]').click();
+    const hex = await until(() => document.getElementById("hex"), "hex input");
+    input(hex, vectors[0].entropy);
+    const network = document.getElementById("network");
+    assert(network && [...network.options].some((option) => option.value === "testnet"), "Network selector is missing or has no testnet option");
+    network.value = "testnet";
+    network.dispatchEvent(new Event("change", { bubbles: true }));
+    const derive = await until(() => !document.getElementById("go").disabled && document.getElementById("go"), "derive button");
+    derive.click();
+    await until(() => document.getElementById("save") || document.getElementById("error").textContent, "wallet result");
+    assert(!document.getElementById("error").textContent, "Wallet derivation failed");
+  });
+
+  await test("watch-only export omits private recovery material", async () => {
+    state.lastBlob = null;
+    state.downloadName = "";
+    document.getElementById("save").click();
+    const blob = await until(() => state.lastBlob, "watch-only export");
+    const text = await blob.text();
+    assert(state.downloadName === "bitcoin-recovery-sheet.txt", "Unexpected filename");
+    assert(text.includes(versionHeader) && text.includes("Network: testnet"), "Export headers are missing");
+    assert(text.includes("PRIVATE RECOVERY MATERIAL OMITTED"), "Omission notice is missing");
+    assert(!text.includes("YOUR SEED PHRASE") && !text.includes("MASTER SEED HEX") && !text.includes("BIP32 ROOT TPRV"), "Watch-only export leaked private data");
+  });
+
+  await test("private export contains complete recovery material", async () => {
+    const reveal = document.getElementById("reveal");
+    reveal.checked = true;
+    reveal.dispatchEvent(new Event("change", { bubbles: true }));
+    await until(() => document.getElementById("save"), "private export control");
+    state.lastBlob = null;
+    document.getElementById("save").click();
+    const text = await (await until(() => state.lastBlob, "private export")).text();
+    assert(text.includes("YOUR SEED PHRASE") && text.includes(vectors[0].mnemonic), "Mnemonic is missing");
+    assert(text.includes("BIP39 ENTROPY HEX\n" + vectors[0].entropy), "Entropy is missing");
+    assert(text.includes("MASTER SEED HEX") && text.includes("BIP32 ROOT TPRV"), "Private derivation data is missing");
+  });
+
+  await test("versioned HTML export downloads the current self-contained release", async () => {
+    const link = document.querySelector(".download-html");
+    assert(link && link.download === currentFile, "HTML export filename is wrong");
+    const target = new URL(link.href);
+    assert(target.origin === location.origin && target.pathname.endsWith("/" + currentFile), "HTML export target is wrong");
+    const response = await fetch(target);
+    const html = await response.text();
+    assert(response.ok, `HTML export returned HTTP ${response.status}`);
+    assert(html.startsWith("<!DOCTYPE html>"), "HTML export is not a complete document");
+    assert(html.includes(`name="application-version" content="${currentVersion}"`), "HTML export version is wrong");
+  });
+
+  await test("hosted application makes only expected same-origin connections", () => {
+    const resources = performance.getEntriesByType("resource").map((entry) => entry.name);
+    const observed = [...state.network.map((entry) => entry.url), ...resources];
+    const external = observed.filter((url) => {
+      try { return new URL(url, location.href).origin !== location.origin; }
+      catch { return true; }
+    });
+    assert(external.length === 0, "External network activity: " + external.join(", "));
+    for (const expectedPath of ["/versions.json", "/assets/entropylab_dark.png", "/assets/favicon.png", "/" + currentFile]) {
+      assert(observed.some((url) => new URL(url, location.href).pathname === expectedPath), `Expected request is missing: ${expectedPath}`);
+    }
+  });
+
+  report("online-results.txt");
+})();
+</script>


### PR DESCRIPTION
Adds a full CI/CD pipeline: test, build, verify, then deploy to GitHub Pages.

- `package.json` with `test` / `build` / `verify` / `ci` scripts
- `scripts/build.mjs` + `scripts/verify-site.mjs`: deterministic site artifact
- `test/validate.test.mjs`: source and security invariants
- `test/browser.test.mjs`: runs the app in headless Firefox against Node's built-in http server (vectors, input sanitization, same-origin behavior, recovery-sheet exports)
- Replaces the deploy-only workflow: CI runs `npm run ci`