### PR TITLE
Add optional SeedQR for camera signers

### DIFF
--- a/entropylab-0.1.3.html
+++ b/entropylab-0.1.3.html
@@ -211,7 +211,14 @@ td { border-top: 1px solid var(--border); padding: 8px; vertical-align: top; fon
 .qr svg { display: block; width: 140px; height: 140px; }
 .qr-descriptor { padding: 12px; }
 .qr-descriptor svg { width: 280px; height: 280px; }
+.qr-seed { padding: 12px; }
+.qr-seed svg { width: 200px; height: 200px; }
 .watch-only-qr { margin: 12px 0 16px; }
+.seed-qr-pair { display: grid; gap: 16px; }
+.seed-qr-pair .watch-only-qr { margin: 0; }
+@media (min-width: 720px) {
+  .seed-qr-pair { grid-template-columns: repeat(2, minmax(0, 1fr)); align-items: start; }
+}
 .err { margin: var(--space-control) 0 0; color: var(--danger); font-size: 14px; }
 .ok { color: var(--ok); }
 header { padding: 8px 0 16px; }
@@ -296,6 +303,7 @@ header { padding: 8px 0 16px; }
   .no-print { display: none !important; }
   html, body { background: white; color: #111; }
   .qr-descriptor svg { width: 52mm; height: 52mm; }
+  .qr-seed svg { width: 40mm; height: 40mm; }
 }
 
 .sr-only {
@@ -3387,7 +3395,7 @@ function hodlSingleWalletData(wallet){
 }
 function hodlHdWalletData(wallet){
   let privateFields=[];
-  if(wallet.mnemonic)privateFields.push(hodlSeedPhraseField(`Your seed phrase \u00b7 ${wallet.mnemonic.trim().split(/\s+/).length} words`,wallet.mnemonic));
+  if(wallet.mnemonic)privateFields.push(hodlSeedPhraseField(`Your seed phrase \u00b7 ${wallet.mnemonic.trim().split(/\s+/).length} words`,wallet.mnemonic),hodlSeedQrExport(wallet.mnemonic,{passphraseUsed:wallet.passphraseUsed,entropyHex:wallet.entropyHex}));
   if(wallet.entropyHex)privateFields.push(Ee("BIP39 entropy hex",wallet.entropyHex));
   if(wallet.seedHex)privateFields.push(Ee("Master seed hex",wallet.seedHex));
   if(wallet.rootXprv)privateFields.push(Ee(`Root ${wallet.rootPrivateLabel||cr[wallet.network].x.prvName}`,wallet.rootXprv));
@@ -3479,7 +3487,7 @@ Oo=function(wallet,revealPrivate){
   let hasPrivate=Boolean(wallet.mnemonic||wallet.entropyHex||wallet.seedHex||wallet.rootXprv||wallet.importedPrivateKey||wallet.accounts.some(hodlAccountHasPrivate));
   if(hasPrivate&&revealPrivate){
     lines.push("PRIVATE RECOVERY MATERIAL");
-    if(wallet.mnemonic)lines.push("","YOUR SEED PHRASE",wallet.mnemonic);
+    if(wallet.mnemonic){lines.push("","YOUR SEED PHRASE",wallet.mnemonic);let seedQrDigits=hodlSeedQrDigits(wallet.mnemonic);if(seedQrDigits)lines.push("","SEEDQR DIGITS",seedQrDigits)}
     if(wallet.entropyHex)lines.push("","BIP39 ENTROPY HEX",wallet.entropyHex);
     if(wallet.seedHex)lines.push("","MASTER SEED HEX (BIP39 PBKDF2, 512 bits)",wallet.seedHex);
     if(wallet.rootXprv)lines.push("",`BIP32 ROOT ${(wallet.rootPrivateLabel||cr[wallet.network].x.prvName).toUpperCase()}`,wallet.rootXprv);
@@ -3613,6 +3621,36 @@ function hodlSeedPhraseField(label,value){
   let text=String(value??"\u2014");
   if(Ge)return`<p class="private-field seed-phrase-field"><span class="muted">${$t(label)}</span><span class="secret private-field-value seed-phrase-value">${hodlSeedPhraseTokens(text)}</span></p>`;
   return`<p class="private-field seed-phrase-field"><span class="muted">${$t(label)}</span><span class="secret private-field-value secret-placeholder seed-phrase-value"><span class="secret-placeholder-mask" aria-hidden="true">${hodlSeedPhraseTokens(text,true)}</span><span class="secret-placeholder-message" aria-hidden="true">************</span><span class="secret-placeholder-label">Private value hidden</span></span></p>`
+}
+function hodlSeedQrDigits(mnemonic){
+  let words=String(mnemonic??"").trim().split(/\s+/).filter(Boolean);
+  if(words.length!==12&&words.length!==24)return"";
+  let digits="";
+  for(let word of words){
+    let index=Ae.indexOf(word);
+    if(index<0)return"";
+    digits+=String(index).padStart(4,"0");
+  }
+  return digits
+}
+function hodlCompactSeedQrBytes(entropyHex){
+  let hex=String(entropyHex??"").replace(/\s/g,"").toLowerCase();
+  if(hex.length!==32&&hex.length!==64)return null;
+  return Array.from(M.decode(hex))
+}
+function hodlSeedQrExport(mnemonic,options={}){
+  let words=String(mnemonic??"").trim().split(/\s+/).filter(Boolean);
+  if(!words.length||!Ge)return"";
+  if(words.length!==12&&words.length!==24)return`<details class="wallet-advanced"><summary>SeedQR</summary><p class="muted">SeedQR is defined for 12 and 24 word phrases. Type this ${words.length}-word seed on the signer.</p></details>`;
+  let digits=hodlSeedQrDigits(mnemonic);
+  if(!digits)return"";
+  let passNote=options.passphraseUsed?" This QR is the seed only. Enter the passphrase on the signer after scanning.":"";
+  let compact="";
+  try{
+    let bytes=hodlCompactSeedQrBytes(options.entropyHex);
+    if(bytes)compact=`<div class="watch-only-qr seed-qr"><div class="qr qr-seed" aria-label="CompactSeedQR">${Xs(bytes,{ecc:"L",border:4,pixelSize:4,blackColor:"#111111",whiteColor:"#ffffff"})}</div><p class="muted">CompactSeedQR. Same seed, smaller binary code.</p><p class="muted">Compatible with: SeedSigner, Krux, Jade, Passport.</p></div>`;
+  }catch{}
+  return`<details class="wallet-advanced"><summary>SeedQR</summary><p class="muted">Scan into a camera signer. This is the seed.${passNote}</p><div class="seed-qr-pair"><div class="watch-only-qr seed-qr"><div class="qr qr-seed" aria-label="SeedQR">${Xs(digits,{ecc:"L",border:4,pixelSize:4,blackColor:"#111111",whiteColor:"#ffffff"})}</div><p class="muted">SeedQR. Numeric.</p><p class="muted">Compatible with: SeedSigner, Krux, Jade, Passport, Coldcard Q.</p><p class="muted mono">${$t(digits)}</p></div>${compact}</div></details>`
 }
 
 var hodlSeedLengths=Object.freeze({

--- a/index.html
+++ b/index.html
@@ -211,7 +211,14 @@ td { border-top: 1px solid var(--border); padding: 8px; vertical-align: top; fon
 .qr svg { display: block; width: 140px; height: 140px; }
 .qr-descriptor { padding: 12px; }
 .qr-descriptor svg { width: 280px; height: 280px; }
+.qr-seed { padding: 12px; }
+.qr-seed svg { width: 200px; height: 200px; }
 .watch-only-qr { margin: 12px 0 16px; }
+.seed-qr-pair { display: grid; gap: 16px; }
+.seed-qr-pair .watch-only-qr { margin: 0; }
+@media (min-width: 720px) {
+  .seed-qr-pair { grid-template-columns: repeat(2, minmax(0, 1fr)); align-items: start; }
+}
 .err { margin: var(--space-control) 0 0; color: var(--danger); font-size: 14px; }
 .ok { color: var(--ok); }
 header { padding: 8px 0 16px; }
@@ -296,6 +303,7 @@ header { padding: 8px 0 16px; }
   .no-print { display: none !important; }
   html, body { background: white; color: #111; }
   .qr-descriptor svg { width: 52mm; height: 52mm; }
+  .qr-seed svg { width: 40mm; height: 40mm; }
 }
 
 .sr-only {
@@ -3387,7 +3395,7 @@ function hodlSingleWalletData(wallet){
 }
 function hodlHdWalletData(wallet){
   let privateFields=[];
-  if(wallet.mnemonic)privateFields.push(hodlSeedPhraseField(`Your seed phrase \u00b7 ${wallet.mnemonic.trim().split(/\s+/).length} words`,wallet.mnemonic));
+  if(wallet.mnemonic)privateFields.push(hodlSeedPhraseField(`Your seed phrase \u00b7 ${wallet.mnemonic.trim().split(/\s+/).length} words`,wallet.mnemonic),hodlSeedQrExport(wallet.mnemonic,{passphraseUsed:wallet.passphraseUsed,entropyHex:wallet.entropyHex}));
   if(wallet.entropyHex)privateFields.push(Ee("BIP39 entropy hex",wallet.entropyHex));
   if(wallet.seedHex)privateFields.push(Ee("Master seed hex",wallet.seedHex));
   if(wallet.rootXprv)privateFields.push(Ee(`Root ${wallet.rootPrivateLabel||cr[wallet.network].x.prvName}`,wallet.rootXprv));
@@ -3479,7 +3487,7 @@ Oo=function(wallet,revealPrivate){
   let hasPrivate=Boolean(wallet.mnemonic||wallet.entropyHex||wallet.seedHex||wallet.rootXprv||wallet.importedPrivateKey||wallet.accounts.some(hodlAccountHasPrivate));
   if(hasPrivate&&revealPrivate){
     lines.push("PRIVATE RECOVERY MATERIAL");
-    if(wallet.mnemonic)lines.push("","YOUR SEED PHRASE",wallet.mnemonic);
+    if(wallet.mnemonic){lines.push("","YOUR SEED PHRASE",wallet.mnemonic);let seedQrDigits=hodlSeedQrDigits(wallet.mnemonic);if(seedQrDigits)lines.push("","SEEDQR DIGITS",seedQrDigits)}
     if(wallet.entropyHex)lines.push("","BIP39 ENTROPY HEX",wallet.entropyHex);
     if(wallet.seedHex)lines.push("","MASTER SEED HEX (BIP39 PBKDF2, 512 bits)",wallet.seedHex);
     if(wallet.rootXprv)lines.push("",`BIP32 ROOT ${(wallet.rootPrivateLabel||cr[wallet.network].x.prvName).toUpperCase()}`,wallet.rootXprv);
@@ -3613,6 +3621,36 @@ function hodlSeedPhraseField(label,value){
   let text=String(value??"\u2014");
   if(Ge)return`<p class="private-field seed-phrase-field"><span class="muted">${$t(label)}</span><span class="secret private-field-value seed-phrase-value">${hodlSeedPhraseTokens(text)}</span></p>`;
   return`<p class="private-field seed-phrase-field"><span class="muted">${$t(label)}</span><span class="secret private-field-value secret-placeholder seed-phrase-value"><span class="secret-placeholder-mask" aria-hidden="true">${hodlSeedPhraseTokens(text,true)}</span><span class="secret-placeholder-message" aria-hidden="true">************</span><span class="secret-placeholder-label">Private value hidden</span></span></p>`
+}
+function hodlSeedQrDigits(mnemonic){
+  let words=String(mnemonic??"").trim().split(/\s+/).filter(Boolean);
+  if(words.length!==12&&words.length!==24)return"";
+  let digits="";
+  for(let word of words){
+    let index=Ae.indexOf(word);
+    if(index<0)return"";
+    digits+=String(index).padStart(4,"0");
+  }
+  return digits
+}
+function hodlCompactSeedQrBytes(entropyHex){
+  let hex=String(entropyHex??"").replace(/\s/g,"").toLowerCase();
+  if(hex.length!==32&&hex.length!==64)return null;
+  return Array.from(M.decode(hex))
+}
+function hodlSeedQrExport(mnemonic,options={}){
+  let words=String(mnemonic??"").trim().split(/\s+/).filter(Boolean);
+  if(!words.length||!Ge)return"";
+  if(words.length!==12&&words.length!==24)return`<details class="wallet-advanced"><summary>SeedQR</summary><p class="muted">SeedQR is defined for 12 and 24 word phrases. Type this ${words.length}-word seed on the signer.</p></details>`;
+  let digits=hodlSeedQrDigits(mnemonic);
+  if(!digits)return"";
+  let passNote=options.passphraseUsed?" This QR is the seed only. Enter the passphrase on the signer after scanning.":"";
+  let compact="";
+  try{
+    let bytes=hodlCompactSeedQrBytes(options.entropyHex);
+    if(bytes)compact=`<div class="watch-only-qr seed-qr"><div class="qr qr-seed" aria-label="CompactSeedQR">${Xs(bytes,{ecc:"L",border:4,pixelSize:4,blackColor:"#111111",whiteColor:"#ffffff"})}</div><p class="muted">CompactSeedQR. Same seed, smaller binary code.</p><p class="muted">Compatible with: SeedSigner, Krux, Jade, Passport.</p></div>`;
+  }catch{}
+  return`<details class="wallet-advanced"><summary>SeedQR</summary><p class="muted">Scan into a camera signer. This is the seed.${passNote}</p><div class="seed-qr-pair"><div class="watch-only-qr seed-qr"><div class="qr qr-seed" aria-label="SeedQR">${Xs(digits,{ecc:"L",border:4,pixelSize:4,blackColor:"#111111",whiteColor:"#ffffff"})}</div><p class="muted">SeedQR. Numeric.</p><p class="muted">Compatible with: SeedSigner, Krux, Jade, Passport, Coldcard Q.</p><p class="muted mono">${$t(digits)}</p></div>${compact}</div></details>`
 }
 
 var hodlSeedLengths=Object.freeze({

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "node scripts/build.mjs",
     "clean": "node scripts/build.mjs --clean",
     "test": "node --test test/*.test.mjs",
-    "test:ci": "node --test test/network-check.test.mjs test/ui-defaults.test.mjs test/validate.test.mjs",
+    "test:ci": "node --test test/network-check.test.mjs test/ui-defaults.test.mjs test/validate.test.mjs test/descriptor.test.mjs test/seedqr.test.mjs",
     "test:validate": "node --test test/validate.test.mjs",
     "test:browser": "node --test test/browser.test.mjs",
     "verify": "node scripts/verify-site.mjs",

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -209,7 +209,14 @@ td { border-top: 1px solid var(--border); padding: 8px; vertical-align: top; fon
 .qr svg { display: block; width: 140px; height: 140px; }
 .qr-descriptor { padding: 12px; }
 .qr-descriptor svg { width: 280px; height: 280px; }
+.qr-seed { padding: 12px; }
+.qr-seed svg { width: 200px; height: 200px; }
 .watch-only-qr { margin: 12px 0 16px; }
+.seed-qr-pair { display: grid; gap: 16px; }
+.seed-qr-pair .watch-only-qr { margin: 0; }
+@media (min-width: 720px) {
+  .seed-qr-pair { grid-template-columns: repeat(2, minmax(0, 1fr)); align-items: start; }
+}
 .err { margin: var(--space-control) 0 0; color: var(--danger); font-size: 14px; }
 .ok { color: var(--ok); }
 header { padding: 8px 0 16px; }
@@ -294,6 +301,7 @@ header { padding: 8px 0 16px; }
   .no-print { display: none !important; }
   html, body { background: white; color: #111; }
   .qr-descriptor svg { width: 52mm; height: 52mm; }
+  .qr-seed svg { width: 40mm; height: 40mm; }
 }
 
 .sr-only {

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -487,7 +487,7 @@ function hodlSingleWalletData(wallet){
 }
 function hodlHdWalletData(wallet){
   let privateFields=[];
-  if(wallet.mnemonic)privateFields.push(hodlSeedPhraseField(`Your seed phrase \u00b7 ${wallet.mnemonic.trim().split(/\s+/).length} words`,wallet.mnemonic));
+  if(wallet.mnemonic)privateFields.push(hodlSeedPhraseField(`Your seed phrase \u00b7 ${wallet.mnemonic.trim().split(/\s+/).length} words`,wallet.mnemonic),hodlSeedQrExport(wallet.mnemonic,{passphraseUsed:wallet.passphraseUsed,entropyHex:wallet.entropyHex}));
   if(wallet.entropyHex)privateFields.push(Ee("BIP39 entropy hex",wallet.entropyHex));
   if(wallet.seedHex)privateFields.push(Ee("Master seed hex",wallet.seedHex));
   if(wallet.rootXprv)privateFields.push(Ee(`Root ${wallet.rootPrivateLabel||cr[wallet.network].x.prvName}`,wallet.rootXprv));
@@ -579,7 +579,7 @@ Oo=function(wallet,revealPrivate){
   let hasPrivate=Boolean(wallet.mnemonic||wallet.entropyHex||wallet.seedHex||wallet.rootXprv||wallet.importedPrivateKey||wallet.accounts.some(hodlAccountHasPrivate));
   if(hasPrivate&&revealPrivate){
     lines.push("PRIVATE RECOVERY MATERIAL");
-    if(wallet.mnemonic)lines.push("","YOUR SEED PHRASE",wallet.mnemonic);
+    if(wallet.mnemonic){lines.push("","YOUR SEED PHRASE",wallet.mnemonic);let seedQrDigits=hodlSeedQrDigits(wallet.mnemonic);if(seedQrDigits)lines.push("","SEEDQR DIGITS",seedQrDigits)}
     if(wallet.entropyHex)lines.push("","BIP39 ENTROPY HEX",wallet.entropyHex);
     if(wallet.seedHex)lines.push("","MASTER SEED HEX (BIP39 PBKDF2, 512 bits)",wallet.seedHex);
     if(wallet.rootXprv)lines.push("",`BIP32 ROOT ${(wallet.rootPrivateLabel||cr[wallet.network].x.prvName).toUpperCase()}`,wallet.rootXprv);
@@ -713,6 +713,36 @@ function hodlSeedPhraseField(label,value){
   let text=String(value??"\u2014");
   if(Ge)return`<p class="private-field seed-phrase-field"><span class="muted">${$t(label)}</span><span class="secret private-field-value seed-phrase-value">${hodlSeedPhraseTokens(text)}</span></p>`;
   return`<p class="private-field seed-phrase-field"><span class="muted">${$t(label)}</span><span class="secret private-field-value secret-placeholder seed-phrase-value"><span class="secret-placeholder-mask" aria-hidden="true">${hodlSeedPhraseTokens(text,true)}</span><span class="secret-placeholder-message" aria-hidden="true">************</span><span class="secret-placeholder-label">Private value hidden</span></span></p>`
+}
+function hodlSeedQrDigits(mnemonic){
+  let words=String(mnemonic??"").trim().split(/\s+/).filter(Boolean);
+  if(words.length!==12&&words.length!==24)return"";
+  let digits="";
+  for(let word of words){
+    let index=Ae.indexOf(word);
+    if(index<0)return"";
+    digits+=String(index).padStart(4,"0");
+  }
+  return digits
+}
+function hodlCompactSeedQrBytes(entropyHex){
+  let hex=String(entropyHex??"").replace(/\s/g,"").toLowerCase();
+  if(hex.length!==32&&hex.length!==64)return null;
+  return Array.from(M.decode(hex))
+}
+function hodlSeedQrExport(mnemonic,options={}){
+  let words=String(mnemonic??"").trim().split(/\s+/).filter(Boolean);
+  if(!words.length||!Ge)return"";
+  if(words.length!==12&&words.length!==24)return`<details class="wallet-advanced"><summary>SeedQR</summary><p class="muted">SeedQR is defined for 12 and 24 word phrases. Type this ${words.length}-word seed on the signer.</p></details>`;
+  let digits=hodlSeedQrDigits(mnemonic);
+  if(!digits)return"";
+  let passNote=options.passphraseUsed?" This QR is the seed only. Enter the passphrase on the signer after scanning.":"";
+  let compact="";
+  try{
+    let bytes=hodlCompactSeedQrBytes(options.entropyHex);
+    if(bytes)compact=`<div class="watch-only-qr seed-qr"><div class="qr qr-seed" aria-label="CompactSeedQR">${Xs(bytes,{ecc:"L",border:4,pixelSize:4,blackColor:"#111111",whiteColor:"#ffffff"})}</div><p class="muted">CompactSeedQR. Same seed, smaller binary code.</p><p class="muted">Compatible with: SeedSigner, Krux, Jade, Passport.</p></div>`;
+  }catch{}
+  return`<details class="wallet-advanced"><summary>SeedQR</summary><p class="muted">Scan into a camera signer. This is the seed.${passNote}</p><div class="seed-qr-pair"><div class="watch-only-qr seed-qr"><div class="qr qr-seed" aria-label="SeedQR">${Xs(digits,{ecc:"L",border:4,pixelSize:4,blackColor:"#111111",whiteColor:"#ffffff"})}</div><p class="muted">SeedQR. Numeric.</p><p class="muted">Compatible with: SeedSigner, Krux, Jade, Passport, Coldcard Q.</p><p class="muted mono">${$t(digits)}</p></div>${compact}</div></details>`
 }
 
 var hodlSeedLengths=Object.freeze({

--- a/test/seedqr.test.mjs
+++ b/test/seedqr.test.mjs
@@ -1,0 +1,98 @@
+// SeedQR / CompactSeedQR payload encoding.
+// Run with: npm test
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = dirname(fileURLToPath(import.meta.url));
+const read = (path) => readFileSync(join(root, "..", path), "utf8");
+const vendor = read("src/js/vendor.js");
+const app = read("src/js/app.js");
+
+const WORDLIST_OPEN = "var Ae=Object.freeze(`";
+const wordlistStart = vendor.indexOf(WORDLIST_OPEN);
+assert.ok(wordlistStart >= 0);
+const wordlistBody = vendor.slice(wordlistStart + WORDLIST_OPEN.length);
+const wordlistEnd = wordlistBody.indexOf("`");
+assert.ok(wordlistEnd > 0);
+const Ae = wordlistBody.slice(0, wordlistEnd).split("\n");
+assert.equal(Ae.length, 2048);
+assert.equal(Ae[0], "abandon");
+assert.equal(Ae[2047], "zoo");
+
+function loadSlice(name) {
+  const start = app.indexOf(`function ${name}(`);
+  assert.ok(start >= 0, name);
+  let depth = 0;
+  let end = -1;
+  for (let i = app.indexOf("{", start); i < app.length; i++) {
+    if (app[i] === "{") depth++;
+    else if (app[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        end = i + 1;
+        break;
+      }
+    }
+  }
+  assert.ok(end > start, name);
+  return app.slice(start, end);
+}
+
+const hodlSeedQrDigits = new Function("Ae", `${loadSlice("hodlSeedQrDigits")}; return hodlSeedQrDigits;`)(Ae);
+
+function compactBytesFromMnemonic(mnemonic) {
+  const words = mnemonic.trim().split(/\s+/);
+  const bits = words.map((word) => Ae.indexOf(word).toString(2).padStart(11, "0")).join("");
+  const checksumBits = words.length === 12 ? 4 : 8;
+  const entropyBits = bits.slice(0, -checksumBits);
+  const bytes = [];
+  for (let i = 0; i < entropyBits.length; i += 8) bytes.push(Number.parseInt(entropyBits.slice(i, i + 8), 2));
+  return bytes;
+}
+
+const SPEC_12 = "vacuum bridge buddy supreme exclude milk consider tail expand wasp pattern nuclear";
+const SPEC_DIGITS = "192402220235174306311124037817700641198012901210";
+const ABANDON_12 = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+test("SeedQR digits match the SeedSigner 12-word vector", () => {
+  assert.equal(hodlSeedQrDigits(SPEC_12), SPEC_DIGITS);
+});
+
+test("SeedQR digits pad 12-word abandon to 48 numeric characters", () => {
+  const digits = hodlSeedQrDigits(ABANDON_12);
+  assert.equal(digits.length, 48);
+  assert.equal(digits, "000000000000000000000000000000000000000000000003");
+  assert.match(digits, /^\d+$/);
+});
+
+test("SeedQR digits omit 18-word phrases", () => {
+  const words = Array(17).fill("abandon").concat("agent").join(" ");
+  assert.equal(hodlSeedQrDigits(words), "");
+});
+
+test("CompactSeedQR bytes are BIP39 entropy without checksum", () => {
+  assert.deepEqual(compactBytesFromMnemonic(ABANDON_12), Array(16).fill(0));
+  const bytes = compactBytesFromMnemonic(SPEC_12);
+  assert.equal(bytes.length, 16);
+  const hex = bytes.map((byte) => byte.toString(16).padStart(2, "0")).join("");
+  const hodlCompactSeedQrBytes = new Function("M", `${loadSlice("hodlCompactSeedQrBytes")}; return hodlCompactSeedQrBytes;`)({
+    decode(value) {
+      const out = [];
+      for (let i = 0; i < value.length; i += 2) out.push(Number.parseInt(value.slice(i, i + 2), 16));
+      return out;
+    },
+  });
+  assert.deepEqual(hodlCompactSeedQrBytes(hex), bytes);
+  assert.equal(hodlCompactSeedQrBytes("00".repeat(24)), null);
+});
+
+test("SeedQR digits for 24 words are 96 numeric characters", () => {
+  const mnemonic = `${Array(23).fill("abandon").join(" ")} art`;
+  const digits = hodlSeedQrDigits(mnemonic);
+  assert.equal(digits.length, 96);
+  assert.match(digits, /^\d+$/);
+  assert.equal(digits.slice(0, 4), "0000");
+});


### PR DESCRIPTION
After you reveal private recovery material, SeedQR is a closed row under the seed phrase. Open it for both encodings:

- Numeric SeedQR (SeedSigner spec). Compatible with SeedSigner, Krux, Jade, Passport, and Coldcard Q.
- CompactSeedQR (BIP39 entropy bytes). Compatible with SeedSigner, Krux, Jade, and Passport. Coldcard Q does not scan this.

12 and 24 English words only. 18-word seeds get a type-it note. The QR is the seed; a BIP39 passphrase is entered on the signer after scanning.

Still offline: same inlined `uqr` helper as the descriptor QR. No SeedQR in the DOM until private material is shown. Editing the seed clears the result; Derive Wallet builds a new QR.

The private recovery sheet adds `SEEDQR DIGITS` when private is on.

`test/seedqr.test.mjs` checks the SeedSigner 12-word vector, 24-word length, 18-word omission, and Compact bytes = entropy. `test:ci` now also runs the descriptor and SeedQR payload tests.