### PR TITLE
Add Taproot BIP86 multisig wallets

### DIFF
--- a/entropylab-0.1.3.html
+++ b/entropylab-0.1.3.html
@@ -816,8 +816,33 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
   transform: translateX(-50%); background: var(--border);
 }
 .msig-threshold-help { margin: 12px 0 0; text-align: center; }
-.msig-keys { display: grid; gap: var(--space-component); margin-top: var(--space-section); }
-.msig-keys .field { margin-top: 0; }
+ .msig-keys { display: grid; gap: var(--space-component); margin-top: var(--space-section); }
+ .msig-keys .field { margin-top: 0; }
+ .msig-key-order-status[hidden] { display: none; }
+ .msig-advanced { margin: 0; }
+ .msig-advanced summary {
+   width: fit-content; color: var(--muted); font-weight: 700; cursor: pointer;
+ }
+ .msig-advanced summary:hover { color: var(--fg); }
+ .msig-advanced summary:focus-visible { outline: 2px solid var(--accent); outline-offset: 4px; border-radius: 3px; }
+ .msig-advanced[open] summary { margin-bottom: 12px; color: var(--fg); }
+.msig-key-row { display: grid; gap: 8px; }
+.msig-key-row-head {
+  display: flex; align-items: center; justify-content: space-between; gap: 10px; flex-wrap: wrap;
+}
+.msig-key-position { color: var(--muted); font-size: 12px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; }
+.msig-keys-listed .msig-key-position { color: var(--fg); }
+.msig-key-move { display: flex; gap: 8px; }
+.msig-key-move-btn { min-height: 36px; padding: 0 12px; }
+.msig-key-move-btn:disabled { opacity: 0.42; cursor: not-allowed; }
+.msig-script-order {
+  margin: 0; padding-left: 1.25em; display: grid; gap: 8px;
+}
+.msig-script-order li { padding-left: 4px; }
+.msig-script-order-position {
+  display: block; color: var(--muted); font-size: 12px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase;
+}
+.msig-script-order code { font-size: 13px; overflow-wrap: anywhere; }
 @media (max-width: 520px) {
   .msig-threshold-control { --msig-slider-inset: 12px; padding: 14px 10px 12px; }
   .msig-threshold-labels { gap: 8px; margin-inline: 10px; }
@@ -1180,6 +1205,7 @@ the first five dice of a word are skipped (reroll). After 23 words, pick
         <p class="field-note msig-threshold-help" id="msig-threshold-help">Enter values, drag either handle, or use the arrow keys. Editing one value past the other moves both.</p>
       </fieldset>
       <div id="msig-keys" class="msig-keys"><label class="field">Co-signer 1 multisig extended public key<textarea id="msig-x-0" placeholder="[fingerprint/48h/0h/0h/2h]Zpub…" autocomplete="off" spellcheck="false"></textarea></label><label class="field">Co-signer 2 multisig extended public key<textarea id="msig-x-1" placeholder="[fingerprint/48h/0h/0h/2h]Zpub…" autocomplete="off" spellcheck="false"></textarea></label><label class="field">Co-signer 3 multisig extended public key<textarea id="msig-x-2" placeholder="[fingerprint/48h/0h/0h/2h]Zpub…" autocomplete="off" spellcheck="false"></textarea></label></div>
+      <p class="hint" id="msig-key-order-status" hidden></p>
       <p class="hint ok" id="msig-hint">Spending will need 2 of these 3 keys. Receiving needs none of the private keys.</p>
       <div class="key-settings msig-output-settings">
         <label class="choice msig-legacy-account-toggle" id="msig-legacy-account-toggle" hidden>
@@ -1188,7 +1214,7 @@ the first five dice of a word are skipped (reroll). After 23 words, pick
         </label>
         <div class="key-settings-row">
           <label class="field">Script type
-            <select id="msig-script-type" aria-describedby="msig-script-warning"><option value="p2sh">Legacy · BIP45</option><option value="p2sh-p2wsh">Nested SegWit · BIP48</option><option value="p2wsh" selected="selected">Native SegWit · BIP48</option><option value="mixed" disabled data-custom-select-placeholder="true">Mixed · incompatible keys</option></select>
+            <select id="msig-script-type" aria-describedby="msig-script-warning"><option value="p2sh">Legacy · BIP45</option><option value="p2sh-p2wsh">Nested SegWit · BIP48</option><option value="p2wsh" selected="selected">Native SegWit · BIP48</option><option value="p2tr">Taproot · BIP86</option><option value="mixed" disabled data-custom-select-placeholder="true">Mixed · incompatible keys</option></select>
             <span class="field-note msig-script-warning" id="msig-script-warning" role="status" hidden></span>
           </label>
           <label class="field">Network
@@ -1205,6 +1231,16 @@ the first five dice of a word are skipped (reroll). After 23 words, pick
             <select id="msig-count"><option value="5" selected="selected">5 + 5</option><option value="10">10 + 10</option><option value="20">20 + 20</option></select>
           </label>
         </div>
+        <details class="msig-advanced" id="msig-advanced">
+          <summary>Advanced</summary>
+          <label class="field">Key order
+            <select id="msig-key-order">
+              <option value="sorted" selected="selected">Sorted · sortedmulti</option>
+              <option value="listed">As listed · multi</option>
+            </select>
+            <span class="field-note" id="msig-key-order-help">Sorted is the default. Addresses stay the same no matter which co-signer you paste first. As listed uses multi: the order of the fields is part of the wallet. Taproot uses sortedmulti_a or multi_a.</span>
+          </label>
+        </details>
       </div>
       <div class="row current-item-actions">
         <button class="btn primary" id="msig-go" type="button" aria-describedby="msig-script-warning" disabled aria-disabled="true">Derive Multisig</button>
@@ -3549,6 +3585,7 @@ zoo`.split(`
         <p class="field-note msig-threshold-help" id="msig-threshold-help">Enter values, drag either handle, or use the arrow keys. Editing one value past the other moves both.</p>
       </fieldset>
       <div id="msig-keys" class="msig-keys"></div>
+      <p class="hint" id="msig-key-order-status" hidden></p>
       <p class="hint" id="msig-hint"></p>
       <div class="key-settings msig-output-settings">
         <label class="choice msig-legacy-account-toggle" id="msig-legacy-account-toggle" hidden>
@@ -3557,7 +3594,7 @@ zoo`.split(`
         </label>
         <div class="key-settings-row">
           <label class="field">Script type
-            <select id="msig-script-type" aria-describedby="msig-script-warning"><option value="p2sh">Legacy · BIP45</option><option value="p2sh-p2wsh">Nested SegWit · BIP48</option><option value="p2wsh" selected>Native SegWit · BIP48</option><option value="mixed" disabled data-custom-select-placeholder="true">Mixed · incompatible keys</option></select>
+            <select id="msig-script-type" aria-describedby="msig-script-warning"><option value="p2sh">Legacy · BIP45</option><option value="p2sh-p2wsh">Nested SegWit · BIP48</option><option value="p2wsh" selected>Native SegWit · BIP48</option><option value="p2tr">Taproot · BIP86</option><option value="mixed" disabled data-custom-select-placeholder="true">Mixed · incompatible keys</option></select>
             <span class="field-note msig-script-warning" id="msig-script-warning" role="status" hidden></span>
           </label>
           <label class="field">Network
@@ -3574,6 +3611,16 @@ zoo`.split(`
             <select id="msig-count"><option value="5">5 + 5</option><option value="10">10 + 10</option><option value="20">20 + 20</option></select>
           </label>
         </div>
+        <details class="msig-advanced" id="msig-advanced">
+          <summary>Advanced</summary>
+          <label class="field">Key order
+            <select id="msig-key-order">
+              <option value="sorted" selected>Sorted · sortedmulti</option>
+              <option value="listed">As listed · multi</option>
+            </select>
+            <span class="field-note" id="msig-key-order-help">Sorted is the default. Addresses stay the same no matter which co-signer you paste first. As listed uses multi: the order of the fields is part of the wallet. Taproot uses sortedmulti_a or multi_a.</span>
+          </label>
+        </details>
       </div>
       <div class="row current-item-actions">
         <button class="btn primary" id="msig-go" type="button" aria-describedby="msig-script-warning" disabled aria-disabled="true">Derive Multisig</button>
@@ -3731,7 +3778,8 @@ function hodlBuildMultisigCosignerExports(root,network,accountIndex,masterFinger
     {accountId:"bip44",kind:"p2sh",standard:"bip45",label:"Legacy · BIP45 · No account",family:"x",accountPath:"m/45'",originPath:"45h"},
     {accountId:"bip44",kind:"p2sh",standard:"bip87",label:`Legacy · BIP87 · Account ${accountIndex}`,family:"x",accountPath:`m/87'/${coinType}'/${accountIndex}'`,originPath:`87h/${coinType}h/${accountIndex}h`},
     {accountId:"bip49",kind:"p2sh-p2wsh",label:"Nested SegWit · BIP48",family:"y",scriptIndex:1},
-    {accountId:"bip84",kind:"p2wsh",label:"Native SegWit · BIP48",family:"z",scriptIndex:2}
+    {accountId:"bip84",kind:"p2wsh",label:"Native SegWit · BIP48",family:"z",scriptIndex:2},
+    {accountId:"bip86",kind:"p2tr",label:"Taproot · BIP86",family:"x",accountPath:`m/86'/${coinType}'/${accountIndex}'`,originPath:`86h/${coinType}h/${accountIndex}h`}
   ].map(definition=>{
     let accountPath=definition.accountPath||`m/48'/${coinType}'/${accountIndex}'/${definition.scriptIndex}'`,originPath=definition.originPath||`48h/${coinType}h/${accountIndex}h/${definition.scriptIndex}h`;
     let node=root.derive(accountPath),publicKey=definition.family==="x"?hodlSerializeExtendedKey(node.publicExtendedKey,network,"x",!1):hodlSerializeMultisigExtendedKey(node.publicExtendedKey,network,definition.family);
@@ -3878,9 +3926,9 @@ function hodlMatchMsigAddressBeyond(address,start){
   let bip45=re.script==="p2sh"&&re.scriptStandard==="bip45",receivePath=bip45?"m/0/0/":"m/0/",changePath=bip45?"m/0/1/":"m/1/";
   for(let index=start;index<hodlAddressSearchLimit;index++){
     let receiveKeys=nodes.map(node=>{let key=node.derive(receivePath+index).publicKey;if(!key)throw new Error("Could not derive a public key");return key});
-    if(hodlAddressesEqual(address,hodlMsigAddr(receiveKeys,re.m,re.network,re.script).address))return{state:"match",chain:"receive",index,path:receivePath.slice(1)+index,beyond:!0};
+    if(hodlAddressesEqual(address,hodlMsigAddr(receiveKeys,re.m,re.network,re.script,re.sorted!==!1).address))return{state:"match",chain:"receive",index,path:receivePath.slice(1)+index,beyond:!0};
     let changeKeys=nodes.map(node=>{let key=node.derive(changePath+index).publicKey;if(!key)throw new Error("Could not derive a public key");return key});
-    if(hodlAddressesEqual(address,hodlMsigAddr(changeKeys,re.m,re.network,re.script).address))return{state:"match",chain:"change",index,path:changePath.slice(1)+index,beyond:!0}
+    if(hodlAddressesEqual(address,hodlMsigAddr(changeKeys,re.m,re.network,re.script,re.sorted!==!1).address))return{state:"match",chain:"change",index,path:changePath.slice(1)+index,beyond:!0}
   }
   return{state:"miss",searchedTo:hodlAddressSearchLimit-1}
 }
@@ -5519,12 +5567,21 @@ function hodlOriginMatchesParsedKey(origin,parsed){
 function hodlMultisigDerivationStandard(origin){
   let steps=hodlNormalizeOriginPath(origin?.path).split("/").filter(Boolean);
   if(steps[0]==="45h")return"bip45";
+  if(steps[0]==="86h")return"bip86";
   if(steps[0]==="87h")return"bip87";
   if(steps[0]==="48h")return"bip48";
   return null
 }
 function hodlOriginScriptError(origin,kind,network,legacyStandard="bip45"){
   let steps=hodlNormalizeOriginPath(origin.path).split("/");
+  if(kind==="p2tr"){
+    if(steps[0]!=="86h")return"BIP86 origin must start at 86h.";
+    let coin=network==="testnet"?"1h":"0h";
+    if(steps[1]!==coin)return`This ${network} BIP86 origin should use ${coin} as the coin type.`;
+    if(steps.length!==3)return"BIP86 origin must be 86h/coin/account.";
+    if(!/^\d+h$/.test(steps[2]))return"BIP86 account index must be hardened.";
+    return""
+  }
   if(kind==="p2wsh"||kind==="p2sh-p2wsh"){
     if(steps[0]!=="48h")return"This script type's origin must start at 48h.";
     let coin=network==="testnet"?"1h":"0h";
@@ -5549,7 +5606,7 @@ function hodlOriginScriptError(origin,kind,network,legacyStandard="bip45"){
 function hodlMultisigAccountNumber(origin,kind){
   let steps=hodlNormalizeOriginPath(origin?.path).split("/");
   if(kind==="p2sh"&&steps[0]==="45h")return null;
-  let standard=kind==="p2sh"?"BIP87":"BIP48",match=steps[2]?.match(/^(\d+)h$/);
+  let standard=kind==="p2tr"?"BIP86":kind==="p2sh"?"BIP87":"BIP48",match=steps[2]?.match(/^(\d+)h$/);
   if(!match)throw new Error(`${standard} account index must be hardened.`);
   let account=Number(match[1]);
   if(!Number.isSafeInteger(account)||account<0||account>0x7fffffff)throw new Error(`${standard} account index is out of range.`);
@@ -5565,6 +5622,7 @@ function hodlMultisigAccountWarning(summary){
 function hodlMultisigOriginScriptKind(origin){
   let steps=hodlNormalizeOriginPath(origin?.path).split("/").filter(Boolean);
   if(steps.length===1&&steps[0]==="45h")return"p2sh";
+  if(steps[0]==="86h"&&steps.length===3)return"p2tr";
   if(steps[0]!=="48h"||steps.length!==4)return null;
   if(steps[3]==="1h")return"p2sh-p2wsh";
   if(steps[3]==="2h")return"p2wsh";
@@ -5575,7 +5633,7 @@ function hodlMultisigScriptEvidence(parsed){
   return{prefixKind,originKind:hodlMultisigOriginScriptKind(parsed?.origin),standard:hodlMultisigDerivationStandard(parsed?.origin)}
 }
 function hodlSummarizeMultisigScriptKinds(kinds){
-  let supported=["p2sh","p2sh-p2wsh","p2wsh"],unique=[...new Set((kinds||[]).filter(kind=>supported.includes(kind)))];
+  let supported=["p2sh","p2sh-p2wsh","p2wsh","p2tr"],unique=[...new Set((kinds||[]).filter(kind=>supported.includes(kind)))];
   return{kind:unique.length>1?"mixed":unique[0]||null,kinds:unique,mixed:unique.length>1}
 }
 function hodlParseMultisigCosigner(raw){
@@ -5592,7 +5650,7 @@ function hodlDetectMsigScriptSummary(values=hodlReadMsigXpubs()){
   let summary=hodlSummarizeMultisigScriptKinds(kinds),standards=[...new Set(legacyStandards)],legacyScriptConflict=standards.includes("bip87")&&summary.kinds.some(kind=>kind!=="p2sh");
   return{...summary,legacyStandard:standards.length===1?standards[0]:null,legacyStandards:standards,legacyMixed:standards.length>1,legacyScriptConflict}
 }
-function hodlMultisigScriptLabel(kind){return kind==="p2sh"?"Legacy":kind==="p2sh-p2wsh"?"Nested SegWit":kind==="p2wsh"?"Native SegWit":"Unknown"}
+function hodlMultisigScriptLabel(kind){return kind==="p2sh"?"Legacy":kind==="p2sh-p2wsh"?"Nested SegWit":kind==="p2wsh"?"Native SegWit":kind==="p2tr"?"Taproot":"Unknown"}
 function hodlSelectedLegacyMultisigStandard(){return document.getElementById("msig-legacy-bip87")?.checked?"bip87":"bip45"}
 function hodlUpdateMsigLegacyControls(){
   let checkbox=document.getElementById("msig-legacy-bip87"),toggle=document.getElementById("msig-legacy-account-toggle"),option=document.querySelector('#msig-script-type option[value="p2sh"]'),legacy=hodlScriptKind()==="p2sh";
@@ -5605,6 +5663,7 @@ function hodlMultisigKeyPlaceholder(kind,network,legacyStandard="bip45"){
   if(kind==="p2sh")return`[fingerprint/45h]${testnet?"tpub":"xpub"}…`;
   if(kind==="p2sh-p2wsh")return`[fingerprint/48h/${coin}/0h/1h]${testnet?"Upub":"Ypub"}…`;
   if(kind==="p2wsh")return`[fingerprint/48h/${coin}/0h/2h]${testnet?"Vpub":"Zpub"}…`;
+  if(kind==="p2tr")return`[fingerprint/86h/${coin}/0h]${testnet?"tpub":"xpub"}…`;
   return"Use matching multisig extended public keys"
 }
 function hodlUpdateMsigKeyPlaceholders(){
@@ -5715,22 +5774,97 @@ function hodlBindMsigThresholdSlider(){
   let finish=event=>{if(!drag||event.pointerId!==drag.pointerId)return;if(!drag.handle){slider.dataset.activeHandle="n";nInput.focus({preventScroll:!0})}drag=null};
   slider.addEventListener("pointerup",finish);slider.addEventListener("pointercancel",finish);slider.addEventListener("lostpointercapture",()=>{drag=null})
 }
+function hodlMsigKeysSorted(){return document.getElementById("msig-key-order")?.value!=="listed"}
+function hodlMsigPolicyOp(kind,sorted){return kind==="p2tr"?sorted?"sortedmulti_a":"multi_a":sorted?"sortedmulti":"multi"}
+function hodlMsigInnerDescriptor(kind,m,inner,sorted){
+  let core=`${hodlMsigPolicyOp(kind,sorted)}(${m},${inner})`;
+  if(kind==="p2tr")return `tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,${core})`;
+  if(kind==="p2wsh")return `wsh(${core})`;
+  if(kind==="p2sh-p2wsh")return `sh(wsh(${core}))`;
+  return `sh(${core})`
+}
+function hodlUpdateMsigKeyOrderStatus(){
+  let status=document.getElementById("msig-key-order-status");if(!status)return;
+  let sorted=hodlMsigKeysSorted();status.hidden=sorted;if(sorted){status.textContent="";status.className="hint";return}
+  let op=hodlMsigPolicyOp(hodlScriptKind(),!1);
+  let parts=[...document.querySelectorAll("#msig-keys textarea")].map((ta,index)=>{
+    let raw=ta.value.trim();
+    if(!raw)return "position "+(index+1);
+    try{let parsed=hodlParseMultisigCosigner(raw);if(parsed.origin?.fingerprint)return "position "+(index+1)+" "+parsed.origin.fingerprint}catch{}
+    return "position "+(index+1)
+  });
+  status.textContent=op+" uses this order: "+parts.join(", ")+". Use Move up or Move down to change a position.";
+  status.className="hint ok"
+}
+function hodlSyncMsigKeyMoveButtons(){
+  let rows=[...document.querySelectorAll("#msig-keys .msig-key-row")];
+  rows.forEach((row,index)=>{
+    let up=row.querySelector('[data-msig-move="-1"]'),down=row.querySelector('[data-msig-move="1"]');
+    if(up){up.disabled=index===0;up.setAttribute("aria-label","Move co-signer "+(index+1)+" up to position "+index)}
+    if(down){down.disabled=index===rows.length-1;down.setAttribute("aria-label","Move co-signer "+(index+1)+" down to position "+(index+2))}
+  })
+}
+function hodlReindexMsigKeys(){
+  [...document.querySelectorAll("#msig-keys .msig-key-row")].forEach((row,index)=>{
+    let ta=row.querySelector("textarea"),pos=row.querySelector(".msig-key-position"),lab=row.querySelector("label.field");
+    if(ta)ta.id="msig-x-"+index;
+    if(pos)pos.textContent="Position "+(index+1);
+    if(lab){let title=lab.childNodes[0];if(title&&title.nodeType===3)title.textContent="Co-signer "+(index+1)+" multisig extended public key"}
+  });
+  hodlSyncMsigKeyMoveButtons();hodlUpdateMsigKeyPlaceholders();hodlUpdateMsigKeyOrderStatus()
+}
+function hodlMoveMsigKeyRow(row,offset){
+  let box=document.getElementById("msig-keys"),rows=[...box.querySelectorAll(".msig-key-row")],index=rows.indexOf(row),next=index+offset;
+  if(index<0||next<0||next>=rows.length)return;
+  if(offset<0)box.insertBefore(row,rows[next]);else box.insertBefore(row,rows[next].nextSibling);
+  hodlReindexMsigKeys();hodlInvalidateMsig();hodlSyncMsigClearButton(!0)
+}
+function hodlBindMsigKeyReorder(box){
+  if(box.dataset.reorderBound)return;box.dataset.reorderBound="1";
+  box.addEventListener("click",event=>{
+    if(hodlMsigKeysSorted())return;
+    let button=event.target.closest("[data-msig-move]");if(!button||button.disabled)return;
+    hodlMoveMsigKeyRow(button.closest(".msig-key-row"),Number(button.dataset.msigMove))
+  })
+}
+function hodlMsigScriptOrder(keyTokens){
+  return keyTokens.map((token,index)=>{
+    let match=String(token).match(/^\[([0-9a-f]{8})\/([^\]]+)\]/i);
+    return{position:index+1,fingerprint:match?match[1]:"",path:match?match[2]:""}
+  })
+}
 function hodlFillKeys(values){
-  let n=Number(document.getElementById("msig-n").value||3),saved=Array.isArray(values)?values:hodlReadMsigXpubs(),box=document.getElementById("msig-keys");box.innerHTML="";
+  let n=Number(document.getElementById("msig-n").value||3),saved=Array.isArray(values)?values:hodlReadMsigXpubs(),box=document.getElementById("msig-keys"),listed=!hodlMsigKeysSorted();
+  box.classList.toggle("msig-keys-listed",listed);box.innerHTML="";
   for(let i=0;i<n;i++){
+    let row=document.createElement("div");row.className="msig-key-row";
+    if(listed){
+      let head=document.createElement("div");head.className="msig-key-row-head";
+      let pos=document.createElement("span");pos.className="msig-key-position";pos.textContent="Position "+(i+1);
+      let moves=document.createElement("div");moves.className="msig-key-move";
+      let up=document.createElement("button");up.type="button";up.className="btn secondary msig-key-move-btn";up.dataset.msigMove="-1";up.textContent="Move up";
+      let down=document.createElement("button");down.type="button";down.className="btn secondary msig-key-move-btn";down.dataset.msigMove="1";down.textContent="Move down";
+      moves.append(up,down);head.append(pos,moves);row.appendChild(head)
+    }
     let lab=document.createElement("label");lab.className="field";lab.textContent="Co-signer "+(i+1)+" multisig extended public key";
-    let ta=document.createElement("textarea");ta.id="msig-x-"+i;ta.autocomplete="off";ta.spellcheck=false;ta.value=saved[i]||"";lab.appendChild(ta);box.appendChild(lab);
-    ta.oninput=()=>{ta.value=hodlFilterXpub(ta.value);hodlUpdateMsigScriptDetection();document.querySelectorAll("#msig-keys textarea").forEach(hodlCheckXpub);hodlInvalidateMsig()}
+    let ta=document.createElement("textarea");ta.id="msig-x-"+i;ta.autocomplete="off";ta.spellcheck=false;ta.value=saved[i]||"";lab.appendChild(ta);row.appendChild(lab);box.appendChild(row);
+    ta.oninput=()=>{ta.value=hodlFilterXpub(ta.value);hodlUpdateMsigScriptDetection();document.querySelectorAll("#msig-keys textarea").forEach(hodlCheckXpub);hodlUpdateMsigKeyOrderStatus();hodlInvalidateMsig()}
   }
-  hodlUpdateMsigScriptDetection();box.querySelectorAll("textarea").forEach(ta=>{if(ta.value)hodlCheckXpub(ta)});hodlUpdateMsigHint();hodlUpdateMsigAccount()
+  hodlBindMsigKeyReorder(box);hodlSyncMsigKeyMoveButtons();hodlUpdateMsigScriptDetection();box.querySelectorAll("textarea").forEach(ta=>{if(ta.value)hodlCheckXpub(ta)});hodlUpdateMsigHint();hodlUpdateMsigAccount();hodlUpdateMsigKeyOrderStatus()
 }
 function hodlMultisigPrefixCompatible(parsed,kind){
+  if(kind==="p2tr")return parsed.family==="x";
   if(parsed.scope==="singlesig")return parsed.family==="x";
   if(kind==="p2sh-p2wsh")return parsed.family==="y";
   if(kind==="p2wsh")return parsed.family==="z";
   return!1
 }
 function hodlMultisigAccountKeyError(parsed,kind,legacyStandard="bip45"){
+  if(kind==="p2tr"){
+    if(parsed.depth!==3)return`Taproot BIP86 requires a depth-3 account key at m/86h/coinh/accounth; this key is depth ${parsed.depth}.`;
+    if(parsed.childNumber<0x80000000)return"A BIP86 account index must be hardened.";
+    return""
+  }
   if(kind==="p2wsh"||kind==="p2sh-p2wsh"){
     let scriptIndex=kind==="p2wsh"?2:1,label=kind==="p2wsh"?"Native SegWit":"Nested SegWit",expected=0x80000000+scriptIndex;
     if(parsed.depth!==4)return`${label} requires a depth-4 BIP48 script-account key ending in /${scriptIndex}h; this key is depth ${parsed.depth}.`;
@@ -5756,11 +5890,25 @@ function hodlDuplicateMultisigKey(ta,parsed){
   return!1
 }
 function hodlCheckXpub(ta){let value=ta.value.trim();if(!value){hodlHint(ta,!0,"");return}try{let parsed=hodlParseMultisigCosigner(value),network=hodlSelectedNetwork(document.getElementById("msig-network")),kind=hodlScriptKind(),legacyStandard=hodlSelectedLegacyMultisigStandard();if(kind==="mixed")throw new Error("These keys do not define one compatible multisig policy. Use one script type and one Legacy derivation standard.");if(parsed.isPrivate)throw new Error("Paste an extended public key, never an extended private key.");if(parsed.network!==network)throw new Error(`${parsed.prefix} is for ${parsed.network}; the multisig is set to ${network}.`);if(!hodlMultisigPrefixCompatible(parsed,kind))throw new Error(parsed.scope==="singlesig"?"Use a generic xpub/tpub here, or a proper uppercase multisig SLIP-132 export.":`${parsed.prefix} does not match the selected multisig script type.`);let accountError=hodlMultisigAccountKeyError(parsed,kind,legacyStandard);if(accountError)throw new Error(accountError);if(!parsed.origin)throw new Error(`Paste ${hodlMultisigKeyPlaceholder(kind,network,legacyStandard)} so a signer can recognize this key.`);let originError=hodlOriginMatchesParsedKey(parsed.origin,parsed);if(originError)throw new Error(originError);let scriptOriginError=hodlOriginScriptError(parsed.origin,kind,network,legacyStandard);if(scriptOriginError)throw new Error(scriptOriginError);if(hodlDuplicateMultisigKey(ta,parsed))throw new Error("This duplicates another co-signer. Every co-signer must use a distinct extended public key.");hodlHint(ta,!0,`${parsed.prefix} origin, checksum, and derivation path look valid`)}catch(error){hodlHint(ta,!1,error.message||"Not a valid multisig extended public key")}}
-function hodlResetMsigForm(){hodlSetMsigThresholds(2,3);hodlSyncSelect(document.getElementById("msig-script-type"),"p2wsh");let legacy=document.getElementById("msig-legacy-bip87");if(legacy)legacy.checked=!1;hodlUpdateMsigLegacyControls();hodlSyncSelect(document.getElementById("msig-network"),"mainnet");hodlSyncSelect(document.getElementById("msig-count"),"5");hodlFillKeys([]);document.getElementById("msig-error").textContent=""}
-function hodlInitMsig(){hodlBindMsigThresholdSlider();let recheck=()=>{hodlUpdateMsigScriptDetection();hodlInvalidateMsig();document.querySelectorAll("#msig-keys textarea").forEach(hodlCheckXpub)},script=document.getElementById("msig-script-type"),legacy=document.getElementById("msig-legacy-bip87");script.addEventListener("change",()=>{if(script.value!=="mixed")script.dataset.lastConcrete=script.value;recheck()});if(legacy)legacy.addEventListener("change",()=>{hodlUpdateMsigLegacyControls();hodlUpdateMsigKeyPlaceholders();hodlInvalidateMsig();document.querySelectorAll("#msig-keys textarea").forEach(hodlCheckXpub);hodlSyncMsigClearButton(!0)});document.getElementById("msig-network").addEventListener("change",recheck);document.getElementById("msig-count").addEventListener("change",hodlInvalidateMsig);hodlResetMsigForm();W("#msig-go").onclick=hodlBuildMsig;W("#msig-wipe").onclick=hodlWipeActiveMsig}
+function hodlResetMsigForm(){hodlSetMsigThresholds(2,3);hodlSyncSelect(document.getElementById("msig-script-type"),"p2wsh");let legacy=document.getElementById("msig-legacy-bip87");if(legacy)legacy.checked=!1;hodlUpdateMsigLegacyControls();hodlSyncSelect(document.getElementById("msig-key-order"),"sorted");let advanced=document.getElementById("msig-advanced");if(advanced)advanced.open=!1;hodlSyncSelect(document.getElementById("msig-network"),"mainnet");hodlSyncSelect(document.getElementById("msig-count"),"5");hodlFillKeys([]);document.getElementById("msig-error").textContent=""}
+function hodlInitMsig(){hodlBindMsigThresholdSlider();let recheck=()=>{hodlUpdateMsigScriptDetection();hodlInvalidateMsig();document.querySelectorAll("#msig-keys textarea").forEach(hodlCheckXpub);hodlUpdateMsigKeyOrderStatus()},script=document.getElementById("msig-script-type"),legacy=document.getElementById("msig-legacy-bip87"),keyOrder=document.getElementById("msig-key-order");script.addEventListener("change",()=>{if(script.value!=="mixed")script.dataset.lastConcrete=script.value;recheck()});if(legacy)legacy.addEventListener("change",()=>{hodlUpdateMsigLegacyControls();hodlUpdateMsigKeyPlaceholders();hodlInvalidateMsig();document.querySelectorAll("#msig-keys textarea").forEach(hodlCheckXpub);hodlSyncMsigClearButton(!0)});if(keyOrder)keyOrder.addEventListener("change",()=>{let advanced=document.getElementById("msig-advanced");if(keyOrder.value==="listed"&&advanced)advanced.open=!0;hodlFillKeys();hodlInvalidateMsig();hodlSyncMsigClearButton(!0)});document.getElementById("msig-network").addEventListener("change",recheck);document.getElementById("msig-count").addEventListener("change",hodlInvalidateMsig);hodlResetMsigForm();W("#msig-go").onclick=hodlBuildMsig;W("#msig-wipe").onclick=hodlWipeActiveMsig}
 function hodlCmpBytes(a,b){let n=Math.min(a.length,b.length);for(let i=0;i<n;i++)if(a[i]!==b[i])return a[i]-b[i];return a.length-b.length}
 function hodlScriptKind(){return document.getElementById("msig-script-type")?.value||"p2wsh"}
-function hodlMsigAddr(pubkeys,m,network,kind){let sorted=[...pubkeys].sort(hodlCmpBytes);let ms=Oe.encode({type:"ms",m,pubkeys:sorted});let net=_s(network);if(kind==="p2wsh"){let hash=tr(ms);return{address:or(net).encode({type:"wsh",hash}),scriptHex:M.encode(ms),kind}}if(kind==="p2sh-p2wsh"){let hash=tr(ms);let wshScript=Oe.encode({type:"wsh",hash});let wrapped=Jr({script:wshScript,witnessScript:ms},net);return{address:wrapped.address,scriptHex:M.encode(ms),kind}}let wrapped=Jr({script:ms},net);return{address:wrapped.address,scriptHex:M.encode(ms),kind}}
+function hodlTaprootNumsKey(){return M.decode("50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0")}
+function hodlXOnlyPubkey(pubkey){if(!pubkey||pubkey.length<32)throw new Error("Could not derive a public key");return pubkey.length===33?pubkey.slice(1):pubkey.slice(0,32)}
+function hodlMsigAddr(pubkeys,m,network,kind,sorted=!0){
+  let net=_s(network);
+  if(kind==="p2tr"){
+    let xonly=[...pubkeys].map(hodlXOnlyPubkey);if(sorted)xonly.sort(hodlCmpBytes);
+    let script=Oe.encode({type:"tr_ms",m,pubkeys:xonly}),out=en(hodlTaprootNumsKey(),{script},net);
+    if(!out?.address)throw new Error("Failed to build Taproot multisig address");
+    return{address:out.address,scriptHex:M.encode(script),kind}
+  }
+  let keys=[...pubkeys];if(sorted)keys.sort(hodlCmpBytes);let ms=Oe.encode({type:"ms",m,pubkeys:keys});
+  if(kind==="p2wsh"){let hash=tr(ms);return{address:or(net).encode({type:"wsh",hash}),scriptHex:M.encode(ms),kind}}
+  if(kind==="p2sh-p2wsh"){let hash=tr(ms);let wshScript=Oe.encode({type:"wsh",hash});let wrapped=Jr({script:wshScript,witnessScript:ms},net);return{address:wrapped.address,scriptHex:M.encode(ms),kind}}
+  let wrapped=Jr({script:ms},net);return{address:wrapped.address,scriptHex:M.encode(ms),kind}
+}
 function hodlValidatedMsigInputs(){
   let network=hodlSelectedNetwork(document.getElementById("msig-network")),count=Number(document.getElementById("msig-count")?.value),n=Number(document.getElementById("msig-n")?.value),m=Number(document.getElementById("msig-m")?.value);
   if(!(m>=1&&n>=1&&m<=n&&n<=15))throw new Error("Pick how many signatures out of how many keys.");
@@ -5788,28 +5936,30 @@ function hodlBuildMsig(){
   try{
     let{network,count,n,m,kind,legacyStandard,nodes,xpubs,keyTokens,accountSummary,accountWarning}=hodlValidatedMsigInputs(),bip45=kind==="p2sh"&&legacyStandard==="bip45";
     let receiveSuffix=bip45?"/0/0/*":"/0/*",changeSuffix=bip45?"/0/1/*":"/1/*";
-    let inner=keyTokens.map(key=>key+receiveSuffix).join(","),innerChange=keyTokens.map(key=>key+changeSuffix).join(",");
-    let descriptor=kind==="p2wsh"?`wsh(sortedmulti(${m},${inner}))`:kind==="p2sh-p2wsh"?`sh(wsh(sortedmulti(${m},${inner})))`:`sh(sortedmulti(${m},${inner}))`;
-    let changeDescriptor=kind==="p2wsh"?`wsh(sortedmulti(${m},${innerChange}))`:kind==="p2sh-p2wsh"?`sh(wsh(sortedmulti(${m},${innerChange})))`:`sh(sortedmulti(${m},${innerChange}))`;
+    let sorted=hodlMsigKeysSorted(),inner=keyTokens.map(key=>key+receiveSuffix).join(","),innerChange=keyTokens.map(key=>key+changeSuffix).join(",");
+    let descriptor=hodlMsigInnerDescriptor(kind,m,inner,sorted),changeDescriptor=hodlMsigInnerDescriptor(kind,m,innerChange,sorted);
     let receive=[],change=[],receivePath=bip45?"m/0/0/":"m/0/",changePath=bip45?"m/0/1/":"m/1/";for(let index=0;index<count;index++){
       let receivePublicKeys=nodes.map(node=>{let key=node.derive(receivePath+index).publicKey;if(!key)throw new Error("Could not derive a public key");return key});
       let changePublicKeys=nodes.map(node=>{let key=node.derive(changePath+index).publicKey;if(!key)throw new Error("Could not derive a public key");return key});
-      receive.push(Object.assign({index,path:receivePath.slice(1)+index},hodlMsigAddr(receivePublicKeys,m,network,kind)));
-      change.push(Object.assign({index,path:changePath.slice(1)+index},hodlMsigAddr(changePublicKeys,m,network,kind)))
+      receive.push(Object.assign({index,path:receivePath.slice(1)+index},hodlMsigAddr(receivePublicKeys,m,network,kind,sorted)));
+      change.push(Object.assign({index,path:changePath.slice(1)+index},hodlMsigAddr(changePublicKeys,m,network,kind,sorted)))
     }
     let notes=["This is watch-only. Private keys never entered this calculator.","Each key origin lets a signer match its seed to one co-signer.","A signer is only needed when you spend."];
     if(bip45)notes.push("Legacy BIP45 addresses use co-signer branch 0 for this receive and change set.");
     if(kind==="p2sh"&&legacyStandard==="bip87")notes.push("Legacy P2SH uses the selected BIP87 account paths. Keep the descriptor with every seed backup.");
-    re={kind:"msig",network,m,n,script:kind,scriptStandard:kind==="p2sh"?legacyStandard:"bip48",account:accountSummary.account,accountMixed:accountSummary.mixed,nodes,xpubs,receiveDescriptor:Le(descriptor),changeDescriptor:Le(changeDescriptor),walletDescriptor:hodlWatchOnlyMultipathDescriptor(Le(descriptor)),receive,change,notes,warnings:accountWarning?[accountWarning]:[]};
+    if(kind==="p2tr")notes.push("Taproot script-path multisig. The internal key is the BIP341 NUMS point, so spending is only possible through the "+(sorted?"sortedmulti_a":"multi_a")+" script path.");
+    if(!sorted)notes.push("This wallet uses "+hodlMsigPolicyOp(kind,!1)+", so the listed co-signer order is part of the script. Reordering keys changes addresses.");
+    re={kind:"msig",network,m,n,script:kind,sorted,scriptOrder:hodlMsigScriptOrder(keyTokens),scriptStandard:kind==="p2tr"?"bip86":kind==="p2sh"?legacyStandard:"bip48",account:accountSummary.account,accountMixed:accountSummary.mixed,nodes,xpubs,receiveDescriptor:Le(descriptor),changeDescriptor:Le(changeDescriptor),walletDescriptor:hodlWatchOnlyMultipathDescriptor(Le(descriptor)),receive,change,notes,warnings:accountWarning?[accountWarning]:[]};
     hodlCaptureMsig();hodlShowMsig();hodlFocusWalletResult()
   }catch(exception){re=null;dr.innerHTML="";error.textContent=exception.message||String(exception);hodlCaptureMsig()}
 }
 function hodlShowMsig(){if(!re||re.kind!=="msig")return;Ge=!1;let accountLabel=re.accountMixed?" · Account Mixed":re.account==null?"":` · Account ${re.account}`,standardLabel=re.scriptStandard?` · ${re.scriptStandard.toUpperCase()}`:"";dr.innerHTML=`
     <section class="card account-result-card">
-      <div class="kicker">${re.m}-of-${re.n} multisig${standardLabel} · ${re.network}${accountLabel}</div>
+      <div class="kicker">${re.m}-of-${re.n} multisig${standardLabel}${re.sorted===!1?" · listed order":""} · ${re.network}${accountLabel}</div>
       <h2 tabindex="-1">Your multisig receive wallet</h2>
       <p class="muted">Anyone can pay these addresses. Spending later needs ${re.m} signature${re.m===1?"":"s"} from the configured ${re.n} signing key${re.n===1?"":"s"}. This screen has no private keys.</p>
       ${hodlWalletMessages(re,"multisig")}
+      ${re.sorted===!1&&re.scriptOrder?.length?`<section class="account-result-section" aria-labelledby="multisig-order-heading"><div class="wallet-data-section-head"><h3 id="multisig-order-heading">Script key order</h3><p class="muted">${hodlMsigPolicyOp(re.script,!1)} uses the co-signers in this order. Changing the order creates a different wallet.</p></div><ol class="msig-script-order">${re.scriptOrder.map(item=>`<li><span class="msig-script-order-position">Position ${item.position}</span><code>${$t(item.fingerprint?item.fingerprint+"/"+item.path:item.fingerprint||"")}</code></li>`).join("")}</ol></section>`:""}
       <section class="account-result-section account-watch-section" aria-labelledby="multisig-watch-heading">
         <div class="wallet-data-section-head">
           <h3 id="multisig-watch-heading">Watch-only wallet data</h3>
@@ -6157,11 +6307,11 @@ function hodlDeleteActiveKey(){
   (hodlActiveKey>=0?W("#key-tabs").children[hodlActiveKey]:W("#add-key"))?.focus();
 }
 var hodlNextMsigId=1,hodlNextMsigNumber=1,hodlMsigs=[],hodlActiveMsig=-1;
-function hodlNewMsigState(name,msigId,msigNumber){let id=msigId??hodlNextMsigId++,number=msigNumber??hodlNextMsigNumber++;return{id,number,name:name||hodlDefaultMsigName(number),result:null,error:"",fields:{m:"2",n:"3",script:"p2wsh",legacyBip87:!1,xpubs:["","",""],network:"mainnet",count:"5"}}}
+function hodlNewMsigState(name,msigId,msigNumber){let id=msigId??hodlNextMsigId++,number=msigNumber??hodlNextMsigNumber++;return{id,number,name:name||hodlDefaultMsigName(number),result:null,error:"",fields:{m:"2",n:"3",script:"p2wsh",legacyBip87:!1,keyOrder:"sorted",xpubs:["","",""],network:"mainnet",count:"5"}}}
 function hodlMsigStateNeedsClear(state){
   if(!state)return!1;let fields=state.fields||{},xpubs=Array.isArray(fields.xpubs)?fields.xpubs:[];
   return Boolean(state.result)||String(state.error??"").length>0||xpubs.some(value=>String(value??"").length>0)||
-    String(fields.m??"2")!=="2"||String(fields.n??"3")!=="3"||String(fields.script??"p2wsh")!=="p2wsh"||Boolean(fields.legacyBip87)||String(fields.network??"mainnet")!=="mainnet"||String(fields.count??"5")!=="5"
+    String(fields.m??"2")!=="2"||String(fields.n??"3")!=="3"||String(fields.script??"p2wsh")!=="p2wsh"||Boolean(fields.legacyBip87)||String(fields.keyOrder??"sorted")!=="sorted"||String(fields.network??"mainnet")!=="mainnet"||String(fields.count??"5")!=="5"
 }
 function hodlSyncMsigClearButton(capture=!1){
   if(capture)hodlCaptureMsig();let button=document.getElementById("msig-wipe");if(!button)return;
@@ -6170,14 +6320,14 @@ function hodlSyncMsigClearButton(capture=!1){
 function hodlCaptureMsig(){
   if(hodlActiveMsig<0||!hodlMsigs[hodlActiveMsig])return;
   let state=hodlMsigs[hodlActiveMsig];
-  state.fields.n=document.getElementById("msig-n").value||"3";state.fields.m=document.getElementById("msig-m").value||"2";state.fields.script=hodlScriptKind();state.fields.legacyBip87=hodlSelectedLegacyMultisigStandard()==="bip87";hodlMergeMsigXpubs(state);state.fields.network=hodlSelectedNetwork(document.getElementById("msig-network"));state.fields.count=document.getElementById("msig-count").value||"5";
+  state.fields.n=document.getElementById("msig-n").value||"3";state.fields.m=document.getElementById("msig-m").value||"2";state.fields.script=hodlScriptKind();state.fields.legacyBip87=hodlSelectedLegacyMultisigStandard()==="bip87";state.fields.keyOrder=hodlMsigKeysSorted()?"sorted":"listed";hodlMergeMsigXpubs(state);state.fields.network=hodlSelectedNetwork(document.getElementById("msig-network"));state.fields.count=document.getElementById("msig-count").value||"5";
   state.result=re&&re.kind==="msig"?re:null;state.error=document.getElementById("msig-error").textContent||"";
 }
 function hodlRestoreMsig(){
   let state=hodlMsigs[hodlActiveMsig],panel=document.getElementById("msig-card");
   if(!state){re=null;Ge=!1;hodlResetMsigForm();dr.innerHTML="";panel.hidden=!0;hodlSyncMsigClearButton();return}
   hodlSetMsigThresholds(state.fields.m||"2",state.fields.n||"3");
-  let legacy=document.getElementById("msig-legacy-bip87");if(legacy)legacy.checked=Boolean(state.fields.legacyBip87);hodlSyncSelect(document.getElementById("msig-script-type"),state.fields.script||"p2wsh");hodlUpdateMsigLegacyControls();state.fields.network=state.fields.network==="testnet"?"testnet":"mainnet";hodlSyncSelect(document.getElementById("msig-network"),state.fields.network);hodlSyncSelect(document.getElementById("msig-count"),state.fields.count||"5");hodlFillKeys(state.fields.xpubs||[]);
+  let legacy=document.getElementById("msig-legacy-bip87");if(legacy)legacy.checked=Boolean(state.fields.legacyBip87);hodlSyncSelect(document.getElementById("msig-script-type"),state.fields.script||"p2wsh");hodlUpdateMsigLegacyControls();state.fields.keyOrder=state.fields.keyOrder==="listed"?"listed":"sorted";hodlSyncSelect(document.getElementById("msig-key-order"),state.fields.keyOrder);let advanced=document.getElementById("msig-advanced");if(advanced)advanced.open=state.fields.keyOrder==="listed";state.fields.network=state.fields.network==="testnet"?"testnet":"mainnet";hodlSyncSelect(document.getElementById("msig-network"),state.fields.network);hodlSyncSelect(document.getElementById("msig-count"),state.fields.count||"5");hodlFillKeys(state.fields.xpubs||[]);
   document.getElementById("msig-error").textContent=state.error||"";re=state.result;Ge=!1;panel.hidden=!1;
   if(re&&re.kind==="msig")hodlShowMsig();else dr.innerHTML="";hodlSyncMsigClearButton();
 }

--- a/index.html
+++ b/index.html
@@ -816,8 +816,33 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
   transform: translateX(-50%); background: var(--border);
 }
 .msig-threshold-help { margin: 12px 0 0; text-align: center; }
-.msig-keys { display: grid; gap: var(--space-component); margin-top: var(--space-section); }
-.msig-keys .field { margin-top: 0; }
+ .msig-keys { display: grid; gap: var(--space-component); margin-top: var(--space-section); }
+ .msig-keys .field { margin-top: 0; }
+ .msig-key-order-status[hidden] { display: none; }
+ .msig-advanced { margin: 0; }
+ .msig-advanced summary {
+   width: fit-content; color: var(--muted); font-weight: 700; cursor: pointer;
+ }
+ .msig-advanced summary:hover { color: var(--fg); }
+ .msig-advanced summary:focus-visible { outline: 2px solid var(--accent); outline-offset: 4px; border-radius: 3px; }
+ .msig-advanced[open] summary { margin-bottom: 12px; color: var(--fg); }
+.msig-key-row { display: grid; gap: 8px; }
+.msig-key-row-head {
+  display: flex; align-items: center; justify-content: space-between; gap: 10px; flex-wrap: wrap;
+}
+.msig-key-position { color: var(--muted); font-size: 12px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; }
+.msig-keys-listed .msig-key-position { color: var(--fg); }
+.msig-key-move { display: flex; gap: 8px; }
+.msig-key-move-btn { min-height: 36px; padding: 0 12px; }
+.msig-key-move-btn:disabled { opacity: 0.42; cursor: not-allowed; }
+.msig-script-order {
+  margin: 0; padding-left: 1.25em; display: grid; gap: 8px;
+}
+.msig-script-order li { padding-left: 4px; }
+.msig-script-order-position {
+  display: block; color: var(--muted); font-size: 12px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase;
+}
+.msig-script-order code { font-size: 13px; overflow-wrap: anywhere; }
 @media (max-width: 520px) {
   .msig-threshold-control { --msig-slider-inset: 12px; padding: 14px 10px 12px; }
   .msig-threshold-labels { gap: 8px; margin-inline: 10px; }
@@ -1180,6 +1205,7 @@ the first five dice of a word are skipped (reroll). After 23 words, pick
         <p class="field-note msig-threshold-help" id="msig-threshold-help">Enter values, drag either handle, or use the arrow keys. Editing one value past the other moves both.</p>
       </fieldset>
       <div id="msig-keys" class="msig-keys"><label class="field">Co-signer 1 multisig extended public key<textarea id="msig-x-0" placeholder="[fingerprint/48h/0h/0h/2h]Zpub…" autocomplete="off" spellcheck="false"></textarea></label><label class="field">Co-signer 2 multisig extended public key<textarea id="msig-x-1" placeholder="[fingerprint/48h/0h/0h/2h]Zpub…" autocomplete="off" spellcheck="false"></textarea></label><label class="field">Co-signer 3 multisig extended public key<textarea id="msig-x-2" placeholder="[fingerprint/48h/0h/0h/2h]Zpub…" autocomplete="off" spellcheck="false"></textarea></label></div>
+      <p class="hint" id="msig-key-order-status" hidden></p>
       <p class="hint ok" id="msig-hint">Spending will need 2 of these 3 keys. Receiving needs none of the private keys.</p>
       <div class="key-settings msig-output-settings">
         <label class="choice msig-legacy-account-toggle" id="msig-legacy-account-toggle" hidden>
@@ -1188,7 +1214,7 @@ the first five dice of a word are skipped (reroll). After 23 words, pick
         </label>
         <div class="key-settings-row">
           <label class="field">Script type
-            <select id="msig-script-type" aria-describedby="msig-script-warning"><option value="p2sh">Legacy · BIP45</option><option value="p2sh-p2wsh">Nested SegWit · BIP48</option><option value="p2wsh" selected="selected">Native SegWit · BIP48</option><option value="mixed" disabled data-custom-select-placeholder="true">Mixed · incompatible keys</option></select>
+            <select id="msig-script-type" aria-describedby="msig-script-warning"><option value="p2sh">Legacy · BIP45</option><option value="p2sh-p2wsh">Nested SegWit · BIP48</option><option value="p2wsh" selected="selected">Native SegWit · BIP48</option><option value="p2tr">Taproot · BIP86</option><option value="mixed" disabled data-custom-select-placeholder="true">Mixed · incompatible keys</option></select>
             <span class="field-note msig-script-warning" id="msig-script-warning" role="status" hidden></span>
           </label>
           <label class="field">Network
@@ -1205,6 +1231,16 @@ the first five dice of a word are skipped (reroll). After 23 words, pick
             <select id="msig-count"><option value="5" selected="selected">5 + 5</option><option value="10">10 + 10</option><option value="20">20 + 20</option></select>
           </label>
         </div>
+        <details class="msig-advanced" id="msig-advanced">
+          <summary>Advanced</summary>
+          <label class="field">Key order
+            <select id="msig-key-order">
+              <option value="sorted" selected="selected">Sorted · sortedmulti</option>
+              <option value="listed">As listed · multi</option>
+            </select>
+            <span class="field-note" id="msig-key-order-help">Sorted is the default. Addresses stay the same no matter which co-signer you paste first. As listed uses multi: the order of the fields is part of the wallet. Taproot uses sortedmulti_a or multi_a.</span>
+          </label>
+        </details>
       </div>
       <div class="row current-item-actions">
         <button class="btn primary" id="msig-go" type="button" aria-describedby="msig-script-warning" disabled aria-disabled="true">Derive Multisig</button>
@@ -3549,6 +3585,7 @@ zoo`.split(`
         <p class="field-note msig-threshold-help" id="msig-threshold-help">Enter values, drag either handle, or use the arrow keys. Editing one value past the other moves both.</p>
       </fieldset>
       <div id="msig-keys" class="msig-keys"></div>
+      <p class="hint" id="msig-key-order-status" hidden></p>
       <p class="hint" id="msig-hint"></p>
       <div class="key-settings msig-output-settings">
         <label class="choice msig-legacy-account-toggle" id="msig-legacy-account-toggle" hidden>
@@ -3557,7 +3594,7 @@ zoo`.split(`
         </label>
         <div class="key-settings-row">
           <label class="field">Script type
-            <select id="msig-script-type" aria-describedby="msig-script-warning"><option value="p2sh">Legacy · BIP45</option><option value="p2sh-p2wsh">Nested SegWit · BIP48</option><option value="p2wsh" selected>Native SegWit · BIP48</option><option value="mixed" disabled data-custom-select-placeholder="true">Mixed · incompatible keys</option></select>
+            <select id="msig-script-type" aria-describedby="msig-script-warning"><option value="p2sh">Legacy · BIP45</option><option value="p2sh-p2wsh">Nested SegWit · BIP48</option><option value="p2wsh" selected>Native SegWit · BIP48</option><option value="p2tr">Taproot · BIP86</option><option value="mixed" disabled data-custom-select-placeholder="true">Mixed · incompatible keys</option></select>
             <span class="field-note msig-script-warning" id="msig-script-warning" role="status" hidden></span>
           </label>
           <label class="field">Network
@@ -3574,6 +3611,16 @@ zoo`.split(`
             <select id="msig-count"><option value="5">5 + 5</option><option value="10">10 + 10</option><option value="20">20 + 20</option></select>
           </label>
         </div>
+        <details class="msig-advanced" id="msig-advanced">
+          <summary>Advanced</summary>
+          <label class="field">Key order
+            <select id="msig-key-order">
+              <option value="sorted" selected>Sorted · sortedmulti</option>
+              <option value="listed">As listed · multi</option>
+            </select>
+            <span class="field-note" id="msig-key-order-help">Sorted is the default. Addresses stay the same no matter which co-signer you paste first. As listed uses multi: the order of the fields is part of the wallet. Taproot uses sortedmulti_a or multi_a.</span>
+          </label>
+        </details>
       </div>
       <div class="row current-item-actions">
         <button class="btn primary" id="msig-go" type="button" aria-describedby="msig-script-warning" disabled aria-disabled="true">Derive Multisig</button>
@@ -3731,7 +3778,8 @@ function hodlBuildMultisigCosignerExports(root,network,accountIndex,masterFinger
     {accountId:"bip44",kind:"p2sh",standard:"bip45",label:"Legacy · BIP45 · No account",family:"x",accountPath:"m/45'",originPath:"45h"},
     {accountId:"bip44",kind:"p2sh",standard:"bip87",label:`Legacy · BIP87 · Account ${accountIndex}`,family:"x",accountPath:`m/87'/${coinType}'/${accountIndex}'`,originPath:`87h/${coinType}h/${accountIndex}h`},
     {accountId:"bip49",kind:"p2sh-p2wsh",label:"Nested SegWit · BIP48",family:"y",scriptIndex:1},
-    {accountId:"bip84",kind:"p2wsh",label:"Native SegWit · BIP48",family:"z",scriptIndex:2}
+    {accountId:"bip84",kind:"p2wsh",label:"Native SegWit · BIP48",family:"z",scriptIndex:2},
+    {accountId:"bip86",kind:"p2tr",label:"Taproot · BIP86",family:"x",accountPath:`m/86'/${coinType}'/${accountIndex}'`,originPath:`86h/${coinType}h/${accountIndex}h`}
   ].map(definition=>{
     let accountPath=definition.accountPath||`m/48'/${coinType}'/${accountIndex}'/${definition.scriptIndex}'`,originPath=definition.originPath||`48h/${coinType}h/${accountIndex}h/${definition.scriptIndex}h`;
     let node=root.derive(accountPath),publicKey=definition.family==="x"?hodlSerializeExtendedKey(node.publicExtendedKey,network,"x",!1):hodlSerializeMultisigExtendedKey(node.publicExtendedKey,network,definition.family);
@@ -3878,9 +3926,9 @@ function hodlMatchMsigAddressBeyond(address,start){
   let bip45=re.script==="p2sh"&&re.scriptStandard==="bip45",receivePath=bip45?"m/0/0/":"m/0/",changePath=bip45?"m/0/1/":"m/1/";
   for(let index=start;index<hodlAddressSearchLimit;index++){
     let receiveKeys=nodes.map(node=>{let key=node.derive(receivePath+index).publicKey;if(!key)throw new Error("Could not derive a public key");return key});
-    if(hodlAddressesEqual(address,hodlMsigAddr(receiveKeys,re.m,re.network,re.script).address))return{state:"match",chain:"receive",index,path:receivePath.slice(1)+index,beyond:!0};
+    if(hodlAddressesEqual(address,hodlMsigAddr(receiveKeys,re.m,re.network,re.script,re.sorted!==!1).address))return{state:"match",chain:"receive",index,path:receivePath.slice(1)+index,beyond:!0};
     let changeKeys=nodes.map(node=>{let key=node.derive(changePath+index).publicKey;if(!key)throw new Error("Could not derive a public key");return key});
-    if(hodlAddressesEqual(address,hodlMsigAddr(changeKeys,re.m,re.network,re.script).address))return{state:"match",chain:"change",index,path:changePath.slice(1)+index,beyond:!0}
+    if(hodlAddressesEqual(address,hodlMsigAddr(changeKeys,re.m,re.network,re.script,re.sorted!==!1).address))return{state:"match",chain:"change",index,path:changePath.slice(1)+index,beyond:!0}
   }
   return{state:"miss",searchedTo:hodlAddressSearchLimit-1}
 }
@@ -5519,12 +5567,21 @@ function hodlOriginMatchesParsedKey(origin,parsed){
 function hodlMultisigDerivationStandard(origin){
   let steps=hodlNormalizeOriginPath(origin?.path).split("/").filter(Boolean);
   if(steps[0]==="45h")return"bip45";
+  if(steps[0]==="86h")return"bip86";
   if(steps[0]==="87h")return"bip87";
   if(steps[0]==="48h")return"bip48";
   return null
 }
 function hodlOriginScriptError(origin,kind,network,legacyStandard="bip45"){
   let steps=hodlNormalizeOriginPath(origin.path).split("/");
+  if(kind==="p2tr"){
+    if(steps[0]!=="86h")return"BIP86 origin must start at 86h.";
+    let coin=network==="testnet"?"1h":"0h";
+    if(steps[1]!==coin)return`This ${network} BIP86 origin should use ${coin} as the coin type.`;
+    if(steps.length!==3)return"BIP86 origin must be 86h/coin/account.";
+    if(!/^\d+h$/.test(steps[2]))return"BIP86 account index must be hardened.";
+    return""
+  }
   if(kind==="p2wsh"||kind==="p2sh-p2wsh"){
     if(steps[0]!=="48h")return"This script type's origin must start at 48h.";
     let coin=network==="testnet"?"1h":"0h";
@@ -5549,7 +5606,7 @@ function hodlOriginScriptError(origin,kind,network,legacyStandard="bip45"){
 function hodlMultisigAccountNumber(origin,kind){
   let steps=hodlNormalizeOriginPath(origin?.path).split("/");
   if(kind==="p2sh"&&steps[0]==="45h")return null;
-  let standard=kind==="p2sh"?"BIP87":"BIP48",match=steps[2]?.match(/^(\d+)h$/);
+  let standard=kind==="p2tr"?"BIP86":kind==="p2sh"?"BIP87":"BIP48",match=steps[2]?.match(/^(\d+)h$/);
   if(!match)throw new Error(`${standard} account index must be hardened.`);
   let account=Number(match[1]);
   if(!Number.isSafeInteger(account)||account<0||account>0x7fffffff)throw new Error(`${standard} account index is out of range.`);
@@ -5565,6 +5622,7 @@ function hodlMultisigAccountWarning(summary){
 function hodlMultisigOriginScriptKind(origin){
   let steps=hodlNormalizeOriginPath(origin?.path).split("/").filter(Boolean);
   if(steps.length===1&&steps[0]==="45h")return"p2sh";
+  if(steps[0]==="86h"&&steps.length===3)return"p2tr";
   if(steps[0]!=="48h"||steps.length!==4)return null;
   if(steps[3]==="1h")return"p2sh-p2wsh";
   if(steps[3]==="2h")return"p2wsh";
@@ -5575,7 +5633,7 @@ function hodlMultisigScriptEvidence(parsed){
   return{prefixKind,originKind:hodlMultisigOriginScriptKind(parsed?.origin),standard:hodlMultisigDerivationStandard(parsed?.origin)}
 }
 function hodlSummarizeMultisigScriptKinds(kinds){
-  let supported=["p2sh","p2sh-p2wsh","p2wsh"],unique=[...new Set((kinds||[]).filter(kind=>supported.includes(kind)))];
+  let supported=["p2sh","p2sh-p2wsh","p2wsh","p2tr"],unique=[...new Set((kinds||[]).filter(kind=>supported.includes(kind)))];
   return{kind:unique.length>1?"mixed":unique[0]||null,kinds:unique,mixed:unique.length>1}
 }
 function hodlParseMultisigCosigner(raw){
@@ -5592,7 +5650,7 @@ function hodlDetectMsigScriptSummary(values=hodlReadMsigXpubs()){
   let summary=hodlSummarizeMultisigScriptKinds(kinds),standards=[...new Set(legacyStandards)],legacyScriptConflict=standards.includes("bip87")&&summary.kinds.some(kind=>kind!=="p2sh");
   return{...summary,legacyStandard:standards.length===1?standards[0]:null,legacyStandards:standards,legacyMixed:standards.length>1,legacyScriptConflict}
 }
-function hodlMultisigScriptLabel(kind){return kind==="p2sh"?"Legacy":kind==="p2sh-p2wsh"?"Nested SegWit":kind==="p2wsh"?"Native SegWit":"Unknown"}
+function hodlMultisigScriptLabel(kind){return kind==="p2sh"?"Legacy":kind==="p2sh-p2wsh"?"Nested SegWit":kind==="p2wsh"?"Native SegWit":kind==="p2tr"?"Taproot":"Unknown"}
 function hodlSelectedLegacyMultisigStandard(){return document.getElementById("msig-legacy-bip87")?.checked?"bip87":"bip45"}
 function hodlUpdateMsigLegacyControls(){
   let checkbox=document.getElementById("msig-legacy-bip87"),toggle=document.getElementById("msig-legacy-account-toggle"),option=document.querySelector('#msig-script-type option[value="p2sh"]'),legacy=hodlScriptKind()==="p2sh";
@@ -5605,6 +5663,7 @@ function hodlMultisigKeyPlaceholder(kind,network,legacyStandard="bip45"){
   if(kind==="p2sh")return`[fingerprint/45h]${testnet?"tpub":"xpub"}…`;
   if(kind==="p2sh-p2wsh")return`[fingerprint/48h/${coin}/0h/1h]${testnet?"Upub":"Ypub"}…`;
   if(kind==="p2wsh")return`[fingerprint/48h/${coin}/0h/2h]${testnet?"Vpub":"Zpub"}…`;
+  if(kind==="p2tr")return`[fingerprint/86h/${coin}/0h]${testnet?"tpub":"xpub"}…`;
   return"Use matching multisig extended public keys"
 }
 function hodlUpdateMsigKeyPlaceholders(){
@@ -5715,22 +5774,97 @@ function hodlBindMsigThresholdSlider(){
   let finish=event=>{if(!drag||event.pointerId!==drag.pointerId)return;if(!drag.handle){slider.dataset.activeHandle="n";nInput.focus({preventScroll:!0})}drag=null};
   slider.addEventListener("pointerup",finish);slider.addEventListener("pointercancel",finish);slider.addEventListener("lostpointercapture",()=>{drag=null})
 }
+function hodlMsigKeysSorted(){return document.getElementById("msig-key-order")?.value!=="listed"}
+function hodlMsigPolicyOp(kind,sorted){return kind==="p2tr"?sorted?"sortedmulti_a":"multi_a":sorted?"sortedmulti":"multi"}
+function hodlMsigInnerDescriptor(kind,m,inner,sorted){
+  let core=`${hodlMsigPolicyOp(kind,sorted)}(${m},${inner})`;
+  if(kind==="p2tr")return `tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,${core})`;
+  if(kind==="p2wsh")return `wsh(${core})`;
+  if(kind==="p2sh-p2wsh")return `sh(wsh(${core}))`;
+  return `sh(${core})`
+}
+function hodlUpdateMsigKeyOrderStatus(){
+  let status=document.getElementById("msig-key-order-status");if(!status)return;
+  let sorted=hodlMsigKeysSorted();status.hidden=sorted;if(sorted){status.textContent="";status.className="hint";return}
+  let op=hodlMsigPolicyOp(hodlScriptKind(),!1);
+  let parts=[...document.querySelectorAll("#msig-keys textarea")].map((ta,index)=>{
+    let raw=ta.value.trim();
+    if(!raw)return "position "+(index+1);
+    try{let parsed=hodlParseMultisigCosigner(raw);if(parsed.origin?.fingerprint)return "position "+(index+1)+" "+parsed.origin.fingerprint}catch{}
+    return "position "+(index+1)
+  });
+  status.textContent=op+" uses this order: "+parts.join(", ")+". Use Move up or Move down to change a position.";
+  status.className="hint ok"
+}
+function hodlSyncMsigKeyMoveButtons(){
+  let rows=[...document.querySelectorAll("#msig-keys .msig-key-row")];
+  rows.forEach((row,index)=>{
+    let up=row.querySelector('[data-msig-move="-1"]'),down=row.querySelector('[data-msig-move="1"]');
+    if(up){up.disabled=index===0;up.setAttribute("aria-label","Move co-signer "+(index+1)+" up to position "+index)}
+    if(down){down.disabled=index===rows.length-1;down.setAttribute("aria-label","Move co-signer "+(index+1)+" down to position "+(index+2))}
+  })
+}
+function hodlReindexMsigKeys(){
+  [...document.querySelectorAll("#msig-keys .msig-key-row")].forEach((row,index)=>{
+    let ta=row.querySelector("textarea"),pos=row.querySelector(".msig-key-position"),lab=row.querySelector("label.field");
+    if(ta)ta.id="msig-x-"+index;
+    if(pos)pos.textContent="Position "+(index+1);
+    if(lab){let title=lab.childNodes[0];if(title&&title.nodeType===3)title.textContent="Co-signer "+(index+1)+" multisig extended public key"}
+  });
+  hodlSyncMsigKeyMoveButtons();hodlUpdateMsigKeyPlaceholders();hodlUpdateMsigKeyOrderStatus()
+}
+function hodlMoveMsigKeyRow(row,offset){
+  let box=document.getElementById("msig-keys"),rows=[...box.querySelectorAll(".msig-key-row")],index=rows.indexOf(row),next=index+offset;
+  if(index<0||next<0||next>=rows.length)return;
+  if(offset<0)box.insertBefore(row,rows[next]);else box.insertBefore(row,rows[next].nextSibling);
+  hodlReindexMsigKeys();hodlInvalidateMsig();hodlSyncMsigClearButton(!0)
+}
+function hodlBindMsigKeyReorder(box){
+  if(box.dataset.reorderBound)return;box.dataset.reorderBound="1";
+  box.addEventListener("click",event=>{
+    if(hodlMsigKeysSorted())return;
+    let button=event.target.closest("[data-msig-move]");if(!button||button.disabled)return;
+    hodlMoveMsigKeyRow(button.closest(".msig-key-row"),Number(button.dataset.msigMove))
+  })
+}
+function hodlMsigScriptOrder(keyTokens){
+  return keyTokens.map((token,index)=>{
+    let match=String(token).match(/^\[([0-9a-f]{8})\/([^\]]+)\]/i);
+    return{position:index+1,fingerprint:match?match[1]:"",path:match?match[2]:""}
+  })
+}
 function hodlFillKeys(values){
-  let n=Number(document.getElementById("msig-n").value||3),saved=Array.isArray(values)?values:hodlReadMsigXpubs(),box=document.getElementById("msig-keys");box.innerHTML="";
+  let n=Number(document.getElementById("msig-n").value||3),saved=Array.isArray(values)?values:hodlReadMsigXpubs(),box=document.getElementById("msig-keys"),listed=!hodlMsigKeysSorted();
+  box.classList.toggle("msig-keys-listed",listed);box.innerHTML="";
   for(let i=0;i<n;i++){
+    let row=document.createElement("div");row.className="msig-key-row";
+    if(listed){
+      let head=document.createElement("div");head.className="msig-key-row-head";
+      let pos=document.createElement("span");pos.className="msig-key-position";pos.textContent="Position "+(i+1);
+      let moves=document.createElement("div");moves.className="msig-key-move";
+      let up=document.createElement("button");up.type="button";up.className="btn secondary msig-key-move-btn";up.dataset.msigMove="-1";up.textContent="Move up";
+      let down=document.createElement("button");down.type="button";down.className="btn secondary msig-key-move-btn";down.dataset.msigMove="1";down.textContent="Move down";
+      moves.append(up,down);head.append(pos,moves);row.appendChild(head)
+    }
     let lab=document.createElement("label");lab.className="field";lab.textContent="Co-signer "+(i+1)+" multisig extended public key";
-    let ta=document.createElement("textarea");ta.id="msig-x-"+i;ta.autocomplete="off";ta.spellcheck=false;ta.value=saved[i]||"";lab.appendChild(ta);box.appendChild(lab);
-    ta.oninput=()=>{ta.value=hodlFilterXpub(ta.value);hodlUpdateMsigScriptDetection();document.querySelectorAll("#msig-keys textarea").forEach(hodlCheckXpub);hodlInvalidateMsig()}
+    let ta=document.createElement("textarea");ta.id="msig-x-"+i;ta.autocomplete="off";ta.spellcheck=false;ta.value=saved[i]||"";lab.appendChild(ta);row.appendChild(lab);box.appendChild(row);
+    ta.oninput=()=>{ta.value=hodlFilterXpub(ta.value);hodlUpdateMsigScriptDetection();document.querySelectorAll("#msig-keys textarea").forEach(hodlCheckXpub);hodlUpdateMsigKeyOrderStatus();hodlInvalidateMsig()}
   }
-  hodlUpdateMsigScriptDetection();box.querySelectorAll("textarea").forEach(ta=>{if(ta.value)hodlCheckXpub(ta)});hodlUpdateMsigHint();hodlUpdateMsigAccount()
+  hodlBindMsigKeyReorder(box);hodlSyncMsigKeyMoveButtons();hodlUpdateMsigScriptDetection();box.querySelectorAll("textarea").forEach(ta=>{if(ta.value)hodlCheckXpub(ta)});hodlUpdateMsigHint();hodlUpdateMsigAccount();hodlUpdateMsigKeyOrderStatus()
 }
 function hodlMultisigPrefixCompatible(parsed,kind){
+  if(kind==="p2tr")return parsed.family==="x";
   if(parsed.scope==="singlesig")return parsed.family==="x";
   if(kind==="p2sh-p2wsh")return parsed.family==="y";
   if(kind==="p2wsh")return parsed.family==="z";
   return!1
 }
 function hodlMultisigAccountKeyError(parsed,kind,legacyStandard="bip45"){
+  if(kind==="p2tr"){
+    if(parsed.depth!==3)return`Taproot BIP86 requires a depth-3 account key at m/86h/coinh/accounth; this key is depth ${parsed.depth}.`;
+    if(parsed.childNumber<0x80000000)return"A BIP86 account index must be hardened.";
+    return""
+  }
   if(kind==="p2wsh"||kind==="p2sh-p2wsh"){
     let scriptIndex=kind==="p2wsh"?2:1,label=kind==="p2wsh"?"Native SegWit":"Nested SegWit",expected=0x80000000+scriptIndex;
     if(parsed.depth!==4)return`${label} requires a depth-4 BIP48 script-account key ending in /${scriptIndex}h; this key is depth ${parsed.depth}.`;
@@ -5756,11 +5890,25 @@ function hodlDuplicateMultisigKey(ta,parsed){
   return!1
 }
 function hodlCheckXpub(ta){let value=ta.value.trim();if(!value){hodlHint(ta,!0,"");return}try{let parsed=hodlParseMultisigCosigner(value),network=hodlSelectedNetwork(document.getElementById("msig-network")),kind=hodlScriptKind(),legacyStandard=hodlSelectedLegacyMultisigStandard();if(kind==="mixed")throw new Error("These keys do not define one compatible multisig policy. Use one script type and one Legacy derivation standard.");if(parsed.isPrivate)throw new Error("Paste an extended public key, never an extended private key.");if(parsed.network!==network)throw new Error(`${parsed.prefix} is for ${parsed.network}; the multisig is set to ${network}.`);if(!hodlMultisigPrefixCompatible(parsed,kind))throw new Error(parsed.scope==="singlesig"?"Use a generic xpub/tpub here, or a proper uppercase multisig SLIP-132 export.":`${parsed.prefix} does not match the selected multisig script type.`);let accountError=hodlMultisigAccountKeyError(parsed,kind,legacyStandard);if(accountError)throw new Error(accountError);if(!parsed.origin)throw new Error(`Paste ${hodlMultisigKeyPlaceholder(kind,network,legacyStandard)} so a signer can recognize this key.`);let originError=hodlOriginMatchesParsedKey(parsed.origin,parsed);if(originError)throw new Error(originError);let scriptOriginError=hodlOriginScriptError(parsed.origin,kind,network,legacyStandard);if(scriptOriginError)throw new Error(scriptOriginError);if(hodlDuplicateMultisigKey(ta,parsed))throw new Error("This duplicates another co-signer. Every co-signer must use a distinct extended public key.");hodlHint(ta,!0,`${parsed.prefix} origin, checksum, and derivation path look valid`)}catch(error){hodlHint(ta,!1,error.message||"Not a valid multisig extended public key")}}
-function hodlResetMsigForm(){hodlSetMsigThresholds(2,3);hodlSyncSelect(document.getElementById("msig-script-type"),"p2wsh");let legacy=document.getElementById("msig-legacy-bip87");if(legacy)legacy.checked=!1;hodlUpdateMsigLegacyControls();hodlSyncSelect(document.getElementById("msig-network"),"mainnet");hodlSyncSelect(document.getElementById("msig-count"),"5");hodlFillKeys([]);document.getElementById("msig-error").textContent=""}
-function hodlInitMsig(){hodlBindMsigThresholdSlider();let recheck=()=>{hodlUpdateMsigScriptDetection();hodlInvalidateMsig();document.querySelectorAll("#msig-keys textarea").forEach(hodlCheckXpub)},script=document.getElementById("msig-script-type"),legacy=document.getElementById("msig-legacy-bip87");script.addEventListener("change",()=>{if(script.value!=="mixed")script.dataset.lastConcrete=script.value;recheck()});if(legacy)legacy.addEventListener("change",()=>{hodlUpdateMsigLegacyControls();hodlUpdateMsigKeyPlaceholders();hodlInvalidateMsig();document.querySelectorAll("#msig-keys textarea").forEach(hodlCheckXpub);hodlSyncMsigClearButton(!0)});document.getElementById("msig-network").addEventListener("change",recheck);document.getElementById("msig-count").addEventListener("change",hodlInvalidateMsig);hodlResetMsigForm();W("#msig-go").onclick=hodlBuildMsig;W("#msig-wipe").onclick=hodlWipeActiveMsig}
+function hodlResetMsigForm(){hodlSetMsigThresholds(2,3);hodlSyncSelect(document.getElementById("msig-script-type"),"p2wsh");let legacy=document.getElementById("msig-legacy-bip87");if(legacy)legacy.checked=!1;hodlUpdateMsigLegacyControls();hodlSyncSelect(document.getElementById("msig-key-order"),"sorted");let advanced=document.getElementById("msig-advanced");if(advanced)advanced.open=!1;hodlSyncSelect(document.getElementById("msig-network"),"mainnet");hodlSyncSelect(document.getElementById("msig-count"),"5");hodlFillKeys([]);document.getElementById("msig-error").textContent=""}
+function hodlInitMsig(){hodlBindMsigThresholdSlider();let recheck=()=>{hodlUpdateMsigScriptDetection();hodlInvalidateMsig();document.querySelectorAll("#msig-keys textarea").forEach(hodlCheckXpub);hodlUpdateMsigKeyOrderStatus()},script=document.getElementById("msig-script-type"),legacy=document.getElementById("msig-legacy-bip87"),keyOrder=document.getElementById("msig-key-order");script.addEventListener("change",()=>{if(script.value!=="mixed")script.dataset.lastConcrete=script.value;recheck()});if(legacy)legacy.addEventListener("change",()=>{hodlUpdateMsigLegacyControls();hodlUpdateMsigKeyPlaceholders();hodlInvalidateMsig();document.querySelectorAll("#msig-keys textarea").forEach(hodlCheckXpub);hodlSyncMsigClearButton(!0)});if(keyOrder)keyOrder.addEventListener("change",()=>{let advanced=document.getElementById("msig-advanced");if(keyOrder.value==="listed"&&advanced)advanced.open=!0;hodlFillKeys();hodlInvalidateMsig();hodlSyncMsigClearButton(!0)});document.getElementById("msig-network").addEventListener("change",recheck);document.getElementById("msig-count").addEventListener("change",hodlInvalidateMsig);hodlResetMsigForm();W("#msig-go").onclick=hodlBuildMsig;W("#msig-wipe").onclick=hodlWipeActiveMsig}
 function hodlCmpBytes(a,b){let n=Math.min(a.length,b.length);for(let i=0;i<n;i++)if(a[i]!==b[i])return a[i]-b[i];return a.length-b.length}
 function hodlScriptKind(){return document.getElementById("msig-script-type")?.value||"p2wsh"}
-function hodlMsigAddr(pubkeys,m,network,kind){let sorted=[...pubkeys].sort(hodlCmpBytes);let ms=Oe.encode({type:"ms",m,pubkeys:sorted});let net=_s(network);if(kind==="p2wsh"){let hash=tr(ms);return{address:or(net).encode({type:"wsh",hash}),scriptHex:M.encode(ms),kind}}if(kind==="p2sh-p2wsh"){let hash=tr(ms);let wshScript=Oe.encode({type:"wsh",hash});let wrapped=Jr({script:wshScript,witnessScript:ms},net);return{address:wrapped.address,scriptHex:M.encode(ms),kind}}let wrapped=Jr({script:ms},net);return{address:wrapped.address,scriptHex:M.encode(ms),kind}}
+function hodlTaprootNumsKey(){return M.decode("50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0")}
+function hodlXOnlyPubkey(pubkey){if(!pubkey||pubkey.length<32)throw new Error("Could not derive a public key");return pubkey.length===33?pubkey.slice(1):pubkey.slice(0,32)}
+function hodlMsigAddr(pubkeys,m,network,kind,sorted=!0){
+  let net=_s(network);
+  if(kind==="p2tr"){
+    let xonly=[...pubkeys].map(hodlXOnlyPubkey);if(sorted)xonly.sort(hodlCmpBytes);
+    let script=Oe.encode({type:"tr_ms",m,pubkeys:xonly}),out=en(hodlTaprootNumsKey(),{script},net);
+    if(!out?.address)throw new Error("Failed to build Taproot multisig address");
+    return{address:out.address,scriptHex:M.encode(script),kind}
+  }
+  let keys=[...pubkeys];if(sorted)keys.sort(hodlCmpBytes);let ms=Oe.encode({type:"ms",m,pubkeys:keys});
+  if(kind==="p2wsh"){let hash=tr(ms);return{address:or(net).encode({type:"wsh",hash}),scriptHex:M.encode(ms),kind}}
+  if(kind==="p2sh-p2wsh"){let hash=tr(ms);let wshScript=Oe.encode({type:"wsh",hash});let wrapped=Jr({script:wshScript,witnessScript:ms},net);return{address:wrapped.address,scriptHex:M.encode(ms),kind}}
+  let wrapped=Jr({script:ms},net);return{address:wrapped.address,scriptHex:M.encode(ms),kind}
+}
 function hodlValidatedMsigInputs(){
   let network=hodlSelectedNetwork(document.getElementById("msig-network")),count=Number(document.getElementById("msig-count")?.value),n=Number(document.getElementById("msig-n")?.value),m=Number(document.getElementById("msig-m")?.value);
   if(!(m>=1&&n>=1&&m<=n&&n<=15))throw new Error("Pick how many signatures out of how many keys.");
@@ -5788,28 +5936,30 @@ function hodlBuildMsig(){
   try{
     let{network,count,n,m,kind,legacyStandard,nodes,xpubs,keyTokens,accountSummary,accountWarning}=hodlValidatedMsigInputs(),bip45=kind==="p2sh"&&legacyStandard==="bip45";
     let receiveSuffix=bip45?"/0/0/*":"/0/*",changeSuffix=bip45?"/0/1/*":"/1/*";
-    let inner=keyTokens.map(key=>key+receiveSuffix).join(","),innerChange=keyTokens.map(key=>key+changeSuffix).join(",");
-    let descriptor=kind==="p2wsh"?`wsh(sortedmulti(${m},${inner}))`:kind==="p2sh-p2wsh"?`sh(wsh(sortedmulti(${m},${inner})))`:`sh(sortedmulti(${m},${inner}))`;
-    let changeDescriptor=kind==="p2wsh"?`wsh(sortedmulti(${m},${innerChange}))`:kind==="p2sh-p2wsh"?`sh(wsh(sortedmulti(${m},${innerChange})))`:`sh(sortedmulti(${m},${innerChange}))`;
+    let sorted=hodlMsigKeysSorted(),inner=keyTokens.map(key=>key+receiveSuffix).join(","),innerChange=keyTokens.map(key=>key+changeSuffix).join(",");
+    let descriptor=hodlMsigInnerDescriptor(kind,m,inner,sorted),changeDescriptor=hodlMsigInnerDescriptor(kind,m,innerChange,sorted);
     let receive=[],change=[],receivePath=bip45?"m/0/0/":"m/0/",changePath=bip45?"m/0/1/":"m/1/";for(let index=0;index<count;index++){
       let receivePublicKeys=nodes.map(node=>{let key=node.derive(receivePath+index).publicKey;if(!key)throw new Error("Could not derive a public key");return key});
       let changePublicKeys=nodes.map(node=>{let key=node.derive(changePath+index).publicKey;if(!key)throw new Error("Could not derive a public key");return key});
-      receive.push(Object.assign({index,path:receivePath.slice(1)+index},hodlMsigAddr(receivePublicKeys,m,network,kind)));
-      change.push(Object.assign({index,path:changePath.slice(1)+index},hodlMsigAddr(changePublicKeys,m,network,kind)))
+      receive.push(Object.assign({index,path:receivePath.slice(1)+index},hodlMsigAddr(receivePublicKeys,m,network,kind,sorted)));
+      change.push(Object.assign({index,path:changePath.slice(1)+index},hodlMsigAddr(changePublicKeys,m,network,kind,sorted)))
     }
     let notes=["This is watch-only. Private keys never entered this calculator.","Each key origin lets a signer match its seed to one co-signer.","A signer is only needed when you spend."];
     if(bip45)notes.push("Legacy BIP45 addresses use co-signer branch 0 for this receive and change set.");
     if(kind==="p2sh"&&legacyStandard==="bip87")notes.push("Legacy P2SH uses the selected BIP87 account paths. Keep the descriptor with every seed backup.");
-    re={kind:"msig",network,m,n,script:kind,scriptStandard:kind==="p2sh"?legacyStandard:"bip48",account:accountSummary.account,accountMixed:accountSummary.mixed,nodes,xpubs,receiveDescriptor:Le(descriptor),changeDescriptor:Le(changeDescriptor),walletDescriptor:hodlWatchOnlyMultipathDescriptor(Le(descriptor)),receive,change,notes,warnings:accountWarning?[accountWarning]:[]};
+    if(kind==="p2tr")notes.push("Taproot script-path multisig. The internal key is the BIP341 NUMS point, so spending is only possible through the "+(sorted?"sortedmulti_a":"multi_a")+" script path.");
+    if(!sorted)notes.push("This wallet uses "+hodlMsigPolicyOp(kind,!1)+", so the listed co-signer order is part of the script. Reordering keys changes addresses.");
+    re={kind:"msig",network,m,n,script:kind,sorted,scriptOrder:hodlMsigScriptOrder(keyTokens),scriptStandard:kind==="p2tr"?"bip86":kind==="p2sh"?legacyStandard:"bip48",account:accountSummary.account,accountMixed:accountSummary.mixed,nodes,xpubs,receiveDescriptor:Le(descriptor),changeDescriptor:Le(changeDescriptor),walletDescriptor:hodlWatchOnlyMultipathDescriptor(Le(descriptor)),receive,change,notes,warnings:accountWarning?[accountWarning]:[]};
     hodlCaptureMsig();hodlShowMsig();hodlFocusWalletResult()
   }catch(exception){re=null;dr.innerHTML="";error.textContent=exception.message||String(exception);hodlCaptureMsig()}
 }
 function hodlShowMsig(){if(!re||re.kind!=="msig")return;Ge=!1;let accountLabel=re.accountMixed?" · Account Mixed":re.account==null?"":` · Account ${re.account}`,standardLabel=re.scriptStandard?` · ${re.scriptStandard.toUpperCase()}`:"";dr.innerHTML=`
     <section class="card account-result-card">
-      <div class="kicker">${re.m}-of-${re.n} multisig${standardLabel} · ${re.network}${accountLabel}</div>
+      <div class="kicker">${re.m}-of-${re.n} multisig${standardLabel}${re.sorted===!1?" · listed order":""} · ${re.network}${accountLabel}</div>
       <h2 tabindex="-1">Your multisig receive wallet</h2>
       <p class="muted">Anyone can pay these addresses. Spending later needs ${re.m} signature${re.m===1?"":"s"} from the configured ${re.n} signing key${re.n===1?"":"s"}. This screen has no private keys.</p>
       ${hodlWalletMessages(re,"multisig")}
+      ${re.sorted===!1&&re.scriptOrder?.length?`<section class="account-result-section" aria-labelledby="multisig-order-heading"><div class="wallet-data-section-head"><h3 id="multisig-order-heading">Script key order</h3><p class="muted">${hodlMsigPolicyOp(re.script,!1)} uses the co-signers in this order. Changing the order creates a different wallet.</p></div><ol class="msig-script-order">${re.scriptOrder.map(item=>`<li><span class="msig-script-order-position">Position ${item.position}</span><code>${$t(item.fingerprint?item.fingerprint+"/"+item.path:item.fingerprint||"")}</code></li>`).join("")}</ol></section>`:""}
       <section class="account-result-section account-watch-section" aria-labelledby="multisig-watch-heading">
         <div class="wallet-data-section-head">
           <h3 id="multisig-watch-heading">Watch-only wallet data</h3>
@@ -6157,11 +6307,11 @@ function hodlDeleteActiveKey(){
   (hodlActiveKey>=0?W("#key-tabs").children[hodlActiveKey]:W("#add-key"))?.focus();
 }
 var hodlNextMsigId=1,hodlNextMsigNumber=1,hodlMsigs=[],hodlActiveMsig=-1;
-function hodlNewMsigState(name,msigId,msigNumber){let id=msigId??hodlNextMsigId++,number=msigNumber??hodlNextMsigNumber++;return{id,number,name:name||hodlDefaultMsigName(number),result:null,error:"",fields:{m:"2",n:"3",script:"p2wsh",legacyBip87:!1,xpubs:["","",""],network:"mainnet",count:"5"}}}
+function hodlNewMsigState(name,msigId,msigNumber){let id=msigId??hodlNextMsigId++,number=msigNumber??hodlNextMsigNumber++;return{id,number,name:name||hodlDefaultMsigName(number),result:null,error:"",fields:{m:"2",n:"3",script:"p2wsh",legacyBip87:!1,keyOrder:"sorted",xpubs:["","",""],network:"mainnet",count:"5"}}}
 function hodlMsigStateNeedsClear(state){
   if(!state)return!1;let fields=state.fields||{},xpubs=Array.isArray(fields.xpubs)?fields.xpubs:[];
   return Boolean(state.result)||String(state.error??"").length>0||xpubs.some(value=>String(value??"").length>0)||
-    String(fields.m??"2")!=="2"||String(fields.n??"3")!=="3"||String(fields.script??"p2wsh")!=="p2wsh"||Boolean(fields.legacyBip87)||String(fields.network??"mainnet")!=="mainnet"||String(fields.count??"5")!=="5"
+    String(fields.m??"2")!=="2"||String(fields.n??"3")!=="3"||String(fields.script??"p2wsh")!=="p2wsh"||Boolean(fields.legacyBip87)||String(fields.keyOrder??"sorted")!=="sorted"||String(fields.network??"mainnet")!=="mainnet"||String(fields.count??"5")!=="5"
 }
 function hodlSyncMsigClearButton(capture=!1){
   if(capture)hodlCaptureMsig();let button=document.getElementById("msig-wipe");if(!button)return;
@@ -6170,14 +6320,14 @@ function hodlSyncMsigClearButton(capture=!1){
 function hodlCaptureMsig(){
   if(hodlActiveMsig<0||!hodlMsigs[hodlActiveMsig])return;
   let state=hodlMsigs[hodlActiveMsig];
-  state.fields.n=document.getElementById("msig-n").value||"3";state.fields.m=document.getElementById("msig-m").value||"2";state.fields.script=hodlScriptKind();state.fields.legacyBip87=hodlSelectedLegacyMultisigStandard()==="bip87";hodlMergeMsigXpubs(state);state.fields.network=hodlSelectedNetwork(document.getElementById("msig-network"));state.fields.count=document.getElementById("msig-count").value||"5";
+  state.fields.n=document.getElementById("msig-n").value||"3";state.fields.m=document.getElementById("msig-m").value||"2";state.fields.script=hodlScriptKind();state.fields.legacyBip87=hodlSelectedLegacyMultisigStandard()==="bip87";state.fields.keyOrder=hodlMsigKeysSorted()?"sorted":"listed";hodlMergeMsigXpubs(state);state.fields.network=hodlSelectedNetwork(document.getElementById("msig-network"));state.fields.count=document.getElementById("msig-count").value||"5";
   state.result=re&&re.kind==="msig"?re:null;state.error=document.getElementById("msig-error").textContent||"";
 }
 function hodlRestoreMsig(){
   let state=hodlMsigs[hodlActiveMsig],panel=document.getElementById("msig-card");
   if(!state){re=null;Ge=!1;hodlResetMsigForm();dr.innerHTML="";panel.hidden=!0;hodlSyncMsigClearButton();return}
   hodlSetMsigThresholds(state.fields.m||"2",state.fields.n||"3");
-  let legacy=document.getElementById("msig-legacy-bip87");if(legacy)legacy.checked=Boolean(state.fields.legacyBip87);hodlSyncSelect(document.getElementById("msig-script-type"),state.fields.script||"p2wsh");hodlUpdateMsigLegacyControls();state.fields.network=state.fields.network==="testnet"?"testnet":"mainnet";hodlSyncSelect(document.getElementById("msig-network"),state.fields.network);hodlSyncSelect(document.getElementById("msig-count"),state.fields.count||"5");hodlFillKeys(state.fields.xpubs||[]);
+  let legacy=document.getElementById("msig-legacy-bip87");if(legacy)legacy.checked=Boolean(state.fields.legacyBip87);hodlSyncSelect(document.getElementById("msig-script-type"),state.fields.script||"p2wsh");hodlUpdateMsigLegacyControls();state.fields.keyOrder=state.fields.keyOrder==="listed"?"listed":"sorted";hodlSyncSelect(document.getElementById("msig-key-order"),state.fields.keyOrder);let advanced=document.getElementById("msig-advanced");if(advanced)advanced.open=state.fields.keyOrder==="listed";state.fields.network=state.fields.network==="testnet"?"testnet":"mainnet";hodlSyncSelect(document.getElementById("msig-network"),state.fields.network);hodlSyncSelect(document.getElementById("msig-count"),state.fields.count||"5");hodlFillKeys(state.fields.xpubs||[]);
   document.getElementById("msig-error").textContent=state.error||"";re=state.result;Ge=!1;panel.hidden=!1;
   if(re&&re.kind==="msig")hodlShowMsig();else dr.innerHTML="";hodlSyncMsigClearButton();
 }

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -814,8 +814,33 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
   transform: translateX(-50%); background: var(--border);
 }
 .msig-threshold-help { margin: 12px 0 0; text-align: center; }
-.msig-keys { display: grid; gap: var(--space-component); margin-top: var(--space-section); }
-.msig-keys .field { margin-top: 0; }
+ .msig-keys { display: grid; gap: var(--space-component); margin-top: var(--space-section); }
+ .msig-keys .field { margin-top: 0; }
+ .msig-key-order-status[hidden] { display: none; }
+ .msig-advanced { margin: 0; }
+ .msig-advanced summary {
+   width: fit-content; color: var(--muted); font-weight: 700; cursor: pointer;
+ }
+ .msig-advanced summary:hover { color: var(--fg); }
+ .msig-advanced summary:focus-visible { outline: 2px solid var(--accent); outline-offset: 4px; border-radius: 3px; }
+ .msig-advanced[open] summary { margin-bottom: 12px; color: var(--fg); }
+.msig-key-row { display: grid; gap: 8px; }
+.msig-key-row-head {
+  display: flex; align-items: center; justify-content: space-between; gap: 10px; flex-wrap: wrap;
+}
+.msig-key-position { color: var(--muted); font-size: 12px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; }
+.msig-keys-listed .msig-key-position { color: var(--fg); }
+.msig-key-move { display: flex; gap: 8px; }
+.msig-key-move-btn { min-height: 36px; padding: 0 12px; }
+.msig-key-move-btn:disabled { opacity: 0.42; cursor: not-allowed; }
+.msig-script-order {
+  margin: 0; padding-left: 1.25em; display: grid; gap: 8px;
+}
+.msig-script-order li { padding-left: 4px; }
+.msig-script-order-position {
+  display: block; color: var(--muted); font-size: 12px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase;
+}
+.msig-script-order code { font-size: 13px; overflow-wrap: anywhere; }
 @media (max-width: 520px) {
   .msig-threshold-control { --msig-slider-inset: 12px; padding: 14px 10px 12px; }
   .msig-threshold-labels { gap: 8px; margin-inline: 10px; }

--- a/src/index.html
+++ b/src/index.html
@@ -173,6 +173,7 @@ the first five dice of a word are skipped (reroll). After 23 words, pick
         <p class="field-note msig-threshold-help" id="msig-threshold-help">Enter values, drag either handle, or use the arrow keys. Editing one value past the other moves both.</p>
       </fieldset>
       <div id="msig-keys" class="msig-keys"><label class="field">Co-signer 1 multisig extended public key<textarea id="msig-x-0" placeholder="[fingerprint/48h/0h/0h/2h]Zpub…" autocomplete="off" spellcheck="false"></textarea></label><label class="field">Co-signer 2 multisig extended public key<textarea id="msig-x-1" placeholder="[fingerprint/48h/0h/0h/2h]Zpub…" autocomplete="off" spellcheck="false"></textarea></label><label class="field">Co-signer 3 multisig extended public key<textarea id="msig-x-2" placeholder="[fingerprint/48h/0h/0h/2h]Zpub…" autocomplete="off" spellcheck="false"></textarea></label></div>
+      <p class="hint" id="msig-key-order-status" hidden></p>
       <p class="hint ok" id="msig-hint">Spending will need 2 of these 3 keys. Receiving needs none of the private keys.</p>
       <div class="key-settings msig-output-settings">
         <label class="choice msig-legacy-account-toggle" id="msig-legacy-account-toggle" hidden>
@@ -198,6 +199,16 @@ the first five dice of a word are skipped (reroll). After 23 words, pick
             <select id="msig-count"><option value="5" selected="selected">5 + 5</option><option value="10">10 + 10</option><option value="20">20 + 20</option></select>
           </label>
         </div>
+        <details class="msig-advanced" id="msig-advanced">
+          <summary>Advanced</summary>
+          <label class="field">Key order
+            <select id="msig-key-order">
+              <option value="sorted" selected="selected">Sorted · sortedmulti</option>
+              <option value="listed">As listed · multi</option>
+            </select>
+            <span class="field-note" id="msig-key-order-help">Sorted is the default. Addresses stay the same no matter which co-signer you paste first. As listed uses multi: the order of the fields is part of the wallet. Taproot uses sortedmulti_a or multi_a.</span>
+          </label>
+        </details>
       </div>
       <div class="row current-item-actions">
         <button class="btn primary" id="msig-go" type="button" aria-describedby="msig-script-warning" disabled aria-disabled="true">Derive Multisig</button>

--- a/src/index.html
+++ b/src/index.html
@@ -181,7 +181,7 @@ the first five dice of a word are skipped (reroll). After 23 words, pick
         </label>
         <div class="key-settings-row">
           <label class="field">Script type
-            <select id="msig-script-type" aria-describedby="msig-script-warning"><option value="p2sh">Legacy · BIP45</option><option value="p2sh-p2wsh">Nested SegWit · BIP48</option><option value="p2wsh" selected="selected">Native SegWit · BIP48</option><option value="mixed" disabled data-custom-select-placeholder="true">Mixed · incompatible keys</option></select>
+            <select id="msig-script-type" aria-describedby="msig-script-warning"><option value="p2sh">Legacy · BIP45</option><option value="p2sh-p2wsh">Nested SegWit · BIP48</option><option value="p2wsh" selected="selected">Native SegWit · BIP48</option><option value="p2tr">Taproot · BIP86</option><option value="mixed" disabled data-custom-select-placeholder="true">Mixed · incompatible keys</option></select>
             <span class="field-note msig-script-warning" id="msig-script-warning" role="status" hidden></span>
           </label>
           <label class="field">Network

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -144,7 +144,7 @@ var vr=[16,20,24,28,32],Rc={0:"00",1:"01",2:"10",3:"11",4:"0",5:"1"};function kr
         </label>
         <div class="key-settings-row">
           <label class="field">Script type
-            <select id="msig-script-type" aria-describedby="msig-script-warning"><option value="p2sh">Legacy · BIP45</option><option value="p2sh-p2wsh">Nested SegWit · BIP48</option><option value="p2wsh" selected>Native SegWit · BIP48</option><option value="mixed" disabled data-custom-select-placeholder="true">Mixed · incompatible keys</option></select>
+            <select id="msig-script-type" aria-describedby="msig-script-warning"><option value="p2sh">Legacy · BIP45</option><option value="p2sh-p2wsh">Nested SegWit · BIP48</option><option value="p2wsh" selected>Native SegWit · BIP48</option><option value="p2tr">Taproot · BIP86</option><option value="mixed" disabled data-custom-select-placeholder="true">Mixed · incompatible keys</option></select>
             <span class="field-note msig-script-warning" id="msig-script-warning" role="status" hidden></span>
           </label>
           <label class="field">Network
@@ -318,7 +318,8 @@ function hodlBuildMultisigCosignerExports(root,network,accountIndex,masterFinger
     {accountId:"bip44",kind:"p2sh",standard:"bip45",label:"Legacy · BIP45 · No account",family:"x",accountPath:"m/45'",originPath:"45h"},
     {accountId:"bip44",kind:"p2sh",standard:"bip87",label:`Legacy · BIP87 · Account ${accountIndex}`,family:"x",accountPath:`m/87'/${coinType}'/${accountIndex}'`,originPath:`87h/${coinType}h/${accountIndex}h`},
     {accountId:"bip49",kind:"p2sh-p2wsh",label:"Nested SegWit · BIP48",family:"y",scriptIndex:1},
-    {accountId:"bip84",kind:"p2wsh",label:"Native SegWit · BIP48",family:"z",scriptIndex:2}
+    {accountId:"bip84",kind:"p2wsh",label:"Native SegWit · BIP48",family:"z",scriptIndex:2},
+    {accountId:"bip86",kind:"p2tr",label:"Taproot · BIP86",family:"x",accountPath:`m/86'/${coinType}'/${accountIndex}'`,originPath:`86h/${coinType}h/${accountIndex}h`}
   ].map(definition=>{
     let accountPath=definition.accountPath||`m/48'/${coinType}'/${accountIndex}'/${definition.scriptIndex}'`,originPath=definition.originPath||`48h/${coinType}h/${accountIndex}h/${definition.scriptIndex}h`;
     let node=root.derive(accountPath),publicKey=definition.family==="x"?hodlSerializeExtendedKey(node.publicExtendedKey,network,"x",!1):hodlSerializeMultisigExtendedKey(node.publicExtendedKey,network,definition.family);
@@ -2106,12 +2107,30 @@ function hodlOriginMatchesParsedKey(origin,parsed){
 function hodlMultisigDerivationStandard(origin){
   let steps=hodlNormalizeOriginPath(origin?.path).split("/").filter(Boolean);
   if(steps[0]==="45h")return"bip45";
+  if(steps[0]==="86h")return"bip86";
   if(steps[0]==="87h")return"bip87";
   if(steps[0]==="48h")return"bip48";
   return null
 }
 function hodlOriginScriptError(origin,kind,network,legacyStandard="bip45"){
   let steps=hodlNormalizeOriginPath(origin.path).split("/");
+  if(kind==="p2tr"){
+    let coin=network==="testnet"?"1h":"0h";
+    if(steps[0]==="86h"){
+      if(steps[1]!==coin)return`This ${network} Taproot origin should use ${coin} as the coin type.`;
+      if(steps.length!==3)return"BIP86 origin must be 86h/coin/account.";
+      if(!/^\d+h$/.test(steps[2]))return"BIP86 account index must be hardened.";
+      return""
+    }
+    if(steps[0]==="48h"){
+      if(steps[1]!==coin)return`This ${network} origin should use ${coin} as the coin type.`;
+      if(steps.length!==4)return"BIP48 Taproot origin must be 48h/coin/account/3h.";
+      if(!/^\d+h$/.test(steps[2]))return"BIP48 account index must be hardened.";
+      if(steps[3]!=="3h")return"BIP48 Taproot origin must end in 3h.";
+      return""
+    }
+    return"Taproot origin must be 86h/coin/account or 48h/coin/account/3h."
+  }
   if(kind==="p2wsh"||kind==="p2sh-p2wsh"){
     if(steps[0]!=="48h")return"This script type's origin must start at 48h.";
     let coin=network==="testnet"?"1h":"0h";
@@ -2136,7 +2155,7 @@ function hodlOriginScriptError(origin,kind,network,legacyStandard="bip45"){
 function hodlMultisigAccountNumber(origin,kind){
   let steps=hodlNormalizeOriginPath(origin?.path).split("/");
   if(kind==="p2sh"&&steps[0]==="45h")return null;
-  let standard=kind==="p2sh"?"BIP87":"BIP48",match=steps[2]?.match(/^(\d+)h$/);
+  let standard=kind==="p2tr"?(steps[0]==="48h"?"BIP48":"BIP86"):kind==="p2sh"?"BIP87":"BIP48",match=steps[2]?.match(/^(\d+)h$/);
   if(!match)throw new Error(`${standard} account index must be hardened.`);
   let account=Number(match[1]);
   if(!Number.isSafeInteger(account)||account<0||account>0x7fffffff)throw new Error(`${standard} account index is out of range.`);
@@ -2152,9 +2171,11 @@ function hodlMultisigAccountWarning(summary){
 function hodlMultisigOriginScriptKind(origin){
   let steps=hodlNormalizeOriginPath(origin?.path).split("/").filter(Boolean);
   if(steps.length===1&&steps[0]==="45h")return"p2sh";
+  if(steps[0]==="86h"&&steps.length===3)return"p2tr";
   if(steps[0]!=="48h"||steps.length!==4)return null;
   if(steps[3]==="1h")return"p2sh-p2wsh";
   if(steps[3]==="2h")return"p2wsh";
+  if(steps[3]==="3h")return"p2tr";
   return null
 }
 function hodlMultisigScriptEvidence(parsed){
@@ -2162,7 +2183,7 @@ function hodlMultisigScriptEvidence(parsed){
   return{prefixKind,originKind:hodlMultisigOriginScriptKind(parsed?.origin),standard:hodlMultisigDerivationStandard(parsed?.origin)}
 }
 function hodlSummarizeMultisigScriptKinds(kinds){
-  let supported=["p2sh","p2sh-p2wsh","p2wsh"],unique=[...new Set((kinds||[]).filter(kind=>supported.includes(kind)))];
+  let supported=["p2sh","p2sh-p2wsh","p2wsh","p2tr"],unique=[...new Set((kinds||[]).filter(kind=>supported.includes(kind)))];
   return{kind:unique.length>1?"mixed":unique[0]||null,kinds:unique,mixed:unique.length>1}
 }
 function hodlParseMultisigCosigner(raw){
@@ -2179,7 +2200,7 @@ function hodlDetectMsigScriptSummary(values=hodlReadMsigXpubs()){
   let summary=hodlSummarizeMultisigScriptKinds(kinds),standards=[...new Set(legacyStandards)],legacyScriptConflict=standards.includes("bip87")&&summary.kinds.some(kind=>kind!=="p2sh");
   return{...summary,legacyStandard:standards.length===1?standards[0]:null,legacyStandards:standards,legacyMixed:standards.length>1,legacyScriptConflict}
 }
-function hodlMultisigScriptLabel(kind){return kind==="p2sh"?"Legacy":kind==="p2sh-p2wsh"?"Nested SegWit":kind==="p2wsh"?"Native SegWit":"Unknown"}
+function hodlMultisigScriptLabel(kind){return kind==="p2sh"?"Legacy":kind==="p2sh-p2wsh"?"Nested SegWit":kind==="p2wsh"?"Native SegWit":kind==="p2tr"?"Taproot":"Unknown"}
 function hodlSelectedLegacyMultisigStandard(){return document.getElementById("msig-legacy-bip87")?.checked?"bip87":"bip45"}
 function hodlUpdateMsigLegacyControls(){
   let checkbox=document.getElementById("msig-legacy-bip87"),toggle=document.getElementById("msig-legacy-account-toggle"),option=document.querySelector('#msig-script-type option[value="p2sh"]'),legacy=hodlScriptKind()==="p2sh";
@@ -2192,6 +2213,7 @@ function hodlMultisigKeyPlaceholder(kind,network,legacyStandard="bip45"){
   if(kind==="p2sh")return`[fingerprint/45h]${testnet?"tpub":"xpub"}…`;
   if(kind==="p2sh-p2wsh")return`[fingerprint/48h/${coin}/0h/1h]${testnet?"Upub":"Ypub"}…`;
   if(kind==="p2wsh")return`[fingerprint/48h/${coin}/0h/2h]${testnet?"Vpub":"Zpub"}…`;
+  if(kind==="p2tr")return`[fingerprint/86h/${coin}/0h]${testnet?"tpub":"xpub"}…`;
   return"Use matching multisig extended public keys"
 }
 function hodlUpdateMsigKeyPlaceholders(){
@@ -2312,12 +2334,18 @@ function hodlFillKeys(values){
   hodlUpdateMsigScriptDetection();box.querySelectorAll("textarea").forEach(ta=>{if(ta.value)hodlCheckXpub(ta)});hodlUpdateMsigHint();hodlUpdateMsigAccount()
 }
 function hodlMultisigPrefixCompatible(parsed,kind){
+  if(kind==="p2tr")return parsed.family==="x";
   if(parsed.scope==="singlesig")return parsed.family==="x";
   if(kind==="p2sh-p2wsh")return parsed.family==="y";
   if(kind==="p2wsh")return parsed.family==="z";
   return!1
 }
 function hodlMultisigAccountKeyError(parsed,kind,legacyStandard="bip45"){
+  if(kind==="p2tr"){
+    if(parsed.depth===3){if(parsed.childNumber<0x80000000)return"A BIP86 account index must be hardened.";return""}
+    if(parsed.depth===4){if(parsed.childNumber!==0x80000003)return"BIP48 Taproot requires a script-account key ending in /3h.";return""}
+    return"Taproot requires a BIP86 account key at m/86h/coinh/accounth, or BIP48 script 3h."
+  }
   if(kind==="p2wsh"||kind==="p2sh-p2wsh"){
     let scriptIndex=kind==="p2wsh"?2:1,label=kind==="p2wsh"?"Native SegWit":"Nested SegWit",expected=0x80000000+scriptIndex;
     if(parsed.depth!==4)return`${label} requires a depth-4 BIP48 script-account key ending in /${scriptIndex}h; this key is depth ${parsed.depth}.`;
@@ -2347,7 +2375,20 @@ function hodlResetMsigForm(){hodlSetMsigThresholds(2,3);hodlSyncSelect(document.
 function hodlInitMsig(){hodlBindMsigThresholdSlider();let recheck=()=>{hodlUpdateMsigScriptDetection();hodlInvalidateMsig();document.querySelectorAll("#msig-keys textarea").forEach(hodlCheckXpub)},script=document.getElementById("msig-script-type"),legacy=document.getElementById("msig-legacy-bip87");script.addEventListener("change",()=>{if(script.value!=="mixed")script.dataset.lastConcrete=script.value;recheck()});if(legacy)legacy.addEventListener("change",()=>{hodlUpdateMsigLegacyControls();hodlUpdateMsigKeyPlaceholders();hodlInvalidateMsig();document.querySelectorAll("#msig-keys textarea").forEach(hodlCheckXpub);hodlSyncMsigClearButton(!0)});document.getElementById("msig-network").addEventListener("change",recheck);document.getElementById("msig-count").addEventListener("change",hodlInvalidateMsig);hodlResetMsigForm();W("#msig-go").onclick=hodlBuildMsig;W("#msig-wipe").onclick=hodlWipeActiveMsig}
 function hodlCmpBytes(a,b){let n=Math.min(a.length,b.length);for(let i=0;i<n;i++)if(a[i]!==b[i])return a[i]-b[i];return a.length-b.length}
 function hodlScriptKind(){return document.getElementById("msig-script-type")?.value||"p2wsh"}
-function hodlMsigAddr(pubkeys,m,network,kind){let sorted=[...pubkeys].sort(hodlCmpBytes);let ms=Oe.encode({type:"ms",m,pubkeys:sorted});let net=_s(network);if(kind==="p2wsh"){let hash=tr(ms);return{address:or(net).encode({type:"wsh",hash}),scriptHex:M.encode(ms),kind}}if(kind==="p2sh-p2wsh"){let hash=tr(ms);let wshScript=Oe.encode({type:"wsh",hash});let wrapped=Jr({script:wshScript,witnessScript:ms},net);return{address:wrapped.address,scriptHex:M.encode(ms),kind}}let wrapped=Jr({script:ms},net);return{address:wrapped.address,scriptHex:M.encode(ms),kind}}
+function hodlTaprootNumsKey(){return M.decode("50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0")}
+function hodlXOnlyPubkey(pubkey){if(!pubkey||pubkey.length<32)throw new Error("Could not derive a public key");return pubkey.length===33?pubkey.slice(1):pubkey.slice(0,32)}
+function hodlMsigAddr(pubkeys,m,network,kind){
+  let net=_s(network);
+  if(kind==="p2tr"){
+    let xonly=[...pubkeys].map(hodlXOnlyPubkey).sort(hodlCmpBytes),script=Oe.encode({type:"tr_ms",m,pubkeys:xonly}),out=en(hodlTaprootNumsKey(),{script},net);
+    if(!out?.address)throw new Error("Failed to build Taproot multisig address");
+    return{address:out.address,scriptHex:M.encode(script),kind}
+  }
+  let sorted=[...pubkeys].sort(hodlCmpBytes);let ms=Oe.encode({type:"ms",m,pubkeys:sorted});
+  if(kind==="p2wsh"){let hash=tr(ms);return{address:or(net).encode({type:"wsh",hash}),scriptHex:M.encode(ms),kind}}
+  if(kind==="p2sh-p2wsh"){let hash=tr(ms);let wshScript=Oe.encode({type:"wsh",hash});let wrapped=Jr({script:wshScript,witnessScript:ms},net);return{address:wrapped.address,scriptHex:M.encode(ms),kind}}
+  let wrapped=Jr({script:ms},net);return{address:wrapped.address,scriptHex:M.encode(ms),kind}
+}
 function hodlValidatedMsigInputs(){
   let network=hodlSelectedNetwork(document.getElementById("msig-network")),count=Number(document.getElementById("msig-count")?.value),n=Number(document.getElementById("msig-n")?.value),m=Number(document.getElementById("msig-m")?.value);
   if(!(m>=1&&n>=1&&m<=n&&n<=15))throw new Error("Pick how many signatures out of how many keys.");
@@ -2376,8 +2417,9 @@ function hodlBuildMsig(){
     let{network,count,n,m,kind,legacyStandard,nodes,xpubs,keyTokens,accountSummary,accountWarning}=hodlValidatedMsigInputs(),bip45=kind==="p2sh"&&legacyStandard==="bip45";
     let receiveSuffix=bip45?"/0/0/*":"/0/*",changeSuffix=bip45?"/0/1/*":"/1/*";
     let inner=keyTokens.map(key=>key+receiveSuffix).join(","),innerChange=keyTokens.map(key=>key+changeSuffix).join(",");
-    let descriptor=kind==="p2wsh"?`wsh(sortedmulti(${m},${inner}))`:kind==="p2sh-p2wsh"?`sh(wsh(sortedmulti(${m},${inner})))`:`sh(sortedmulti(${m},${inner}))`;
-    let changeDescriptor=kind==="p2wsh"?`wsh(sortedmulti(${m},${innerChange}))`:kind==="p2sh-p2wsh"?`sh(wsh(sortedmulti(${m},${innerChange})))`:`sh(sortedmulti(${m},${innerChange}))`;
+    let nums="50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0";
+    let descriptor=kind==="p2tr"?`tr(${nums},sortedmulti_a(${m},${inner}))`:kind==="p2wsh"?`wsh(sortedmulti(${m},${inner}))`:kind==="p2sh-p2wsh"?`sh(wsh(sortedmulti(${m},${inner})))`:`sh(sortedmulti(${m},${inner}))`;
+    let changeDescriptor=kind==="p2tr"?`tr(${nums},sortedmulti_a(${m},${innerChange}))`:kind==="p2wsh"?`wsh(sortedmulti(${m},${innerChange}))`:kind==="p2sh-p2wsh"?`sh(wsh(sortedmulti(${m},${innerChange})))`:`sh(sortedmulti(${m},${innerChange}))`;
     let receive=[],change=[],receivePath=bip45?"m/0/0/":"m/0/",changePath=bip45?"m/0/1/":"m/1/";for(let index=0;index<count;index++){
       let receivePublicKeys=nodes.map(node=>{let key=node.derive(receivePath+index).publicKey;if(!key)throw new Error("Could not derive a public key");return key});
       let changePublicKeys=nodes.map(node=>{let key=node.derive(changePath+index).publicKey;if(!key)throw new Error("Could not derive a public key");return key});
@@ -2387,7 +2429,8 @@ function hodlBuildMsig(){
     let notes=["This is watch-only. Private keys never entered this calculator.","Each key origin lets a signer match its seed to one co-signer.","A signer is only needed when you spend."];
     if(bip45)notes.push("Legacy BIP45 addresses use co-signer branch 0 for this receive and change set.");
     if(kind==="p2sh"&&legacyStandard==="bip87")notes.push("Legacy P2SH uses the selected BIP87 account paths. Keep the descriptor with every seed backup.");
-    re={kind:"msig",network,m,n,script:kind,scriptStandard:kind==="p2sh"?legacyStandard:"bip48",account:accountSummary.account,accountMixed:accountSummary.mixed,nodes,xpubs,receiveDescriptor:Le(descriptor),changeDescriptor:Le(changeDescriptor),walletDescriptor:hodlWatchOnlyMultipathDescriptor(Le(descriptor)),receive,change,notes,warnings:accountWarning?[accountWarning]:[]};
+    if(kind==="p2tr")notes.push("Taproot script-path multisig. The internal key is the BIP341 NUMS point, so spending is only possible through the multi_a script path.");
+    re={kind:"msig",network,m,n,script:kind,scriptStandard:kind==="p2tr"?"bip86":kind==="p2sh"?legacyStandard:"bip48",account:accountSummary.account,accountMixed:accountSummary.mixed,nodes,xpubs,receiveDescriptor:Le(descriptor),changeDescriptor:Le(changeDescriptor),walletDescriptor:hodlWatchOnlyMultipathDescriptor(Le(descriptor)),receive,change,notes,warnings:accountWarning?[accountWarning]:[]};
     hodlCaptureMsig();hodlShowMsig();hodlFocusWalletResult()
   }catch(exception){re=null;dr.innerHTML="";error.textContent=exception.message||String(exception);hodlCaptureMsig()}
 }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2126,21 +2126,12 @@ function hodlMultisigDerivationStandard(origin){
 function hodlOriginScriptError(origin,kind,network,legacyStandard="bip45"){
   let steps=hodlNormalizeOriginPath(origin.path).split("/");
   if(kind==="p2tr"){
+    if(steps[0]!=="86h")return"BIP86 origin must start at 86h.";
     let coin=network==="testnet"?"1h":"0h";
-    if(steps[0]==="86h"){
-      if(steps[1]!==coin)return`This ${network} Taproot origin should use ${coin} as the coin type.`;
-      if(steps.length!==3)return"BIP86 origin must be 86h/coin/account.";
-      if(!/^\d+h$/.test(steps[2]))return"BIP86 account index must be hardened.";
-      return""
-    }
-    if(steps[0]==="48h"){
-      if(steps[1]!==coin)return`This ${network} origin should use ${coin} as the coin type.`;
-      if(steps.length!==4)return"BIP48 Taproot origin must be 48h/coin/account/3h.";
-      if(!/^\d+h$/.test(steps[2]))return"BIP48 account index must be hardened.";
-      if(steps[3]!=="3h")return"BIP48 Taproot origin must end in 3h.";
-      return""
-    }
-    return"Taproot origin must be 86h/coin/account or 48h/coin/account/3h."
+    if(steps[1]!==coin)return`This ${network} BIP86 origin should use ${coin} as the coin type.`;
+    if(steps.length!==3)return"BIP86 origin must be 86h/coin/account.";
+    if(!/^\d+h$/.test(steps[2]))return"BIP86 account index must be hardened.";
+    return""
   }
   if(kind==="p2wsh"||kind==="p2sh-p2wsh"){
     if(steps[0]!=="48h")return"This script type's origin must start at 48h.";
@@ -2166,7 +2157,7 @@ function hodlOriginScriptError(origin,kind,network,legacyStandard="bip45"){
 function hodlMultisigAccountNumber(origin,kind){
   let steps=hodlNormalizeOriginPath(origin?.path).split("/");
   if(kind==="p2sh"&&steps[0]==="45h")return null;
-  let standard=kind==="p2tr"?(steps[0]==="48h"?"BIP48":"BIP86"):kind==="p2sh"?"BIP87":"BIP48",match=steps[2]?.match(/^(\d+)h$/);
+  let standard=kind==="p2tr"?"BIP86":kind==="p2sh"?"BIP87":"BIP48",match=steps[2]?.match(/^(\d+)h$/);
   if(!match)throw new Error(`${standard} account index must be hardened.`);
   let account=Number(match[1]);
   if(!Number.isSafeInteger(account)||account<0||account>0x7fffffff)throw new Error(`${standard} account index is out of range.`);
@@ -2186,7 +2177,6 @@ function hodlMultisigOriginScriptKind(origin){
   if(steps[0]!=="48h"||steps.length!==4)return null;
   if(steps[3]==="1h")return"p2sh-p2wsh";
   if(steps[3]==="2h")return"p2wsh";
-  if(steps[3]==="3h")return"p2tr";
   return null
 }
 function hodlMultisigScriptEvidence(parsed){
@@ -2422,9 +2412,9 @@ function hodlMultisigPrefixCompatible(parsed,kind){
 }
 function hodlMultisigAccountKeyError(parsed,kind,legacyStandard="bip45"){
   if(kind==="p2tr"){
-    if(parsed.depth===3){if(parsed.childNumber<0x80000000)return"A BIP86 account index must be hardened.";return""}
-    if(parsed.depth===4){if(parsed.childNumber!==0x80000003)return"BIP48 Taproot requires a script-account key ending in /3h.";return""}
-    return"Taproot requires a BIP86 account key at m/86h/coinh/accounth, or BIP48 script 3h."
+    if(parsed.depth!==3)return`Taproot BIP86 requires a depth-3 account key at m/86h/coinh/accounth; this key is depth ${parsed.depth}.`;
+    if(parsed.childNumber<0x80000000)return"A BIP86 account index must be hardened.";
+    return""
   }
   if(kind==="p2wsh"||kind==="p2sh-p2wsh"){
     let scriptIndex=kind==="p2wsh"?2:1,label=kind==="p2wsh"?"Native SegWit":"Nested SegWit",expected=0x80000000+scriptIndex;

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -136,6 +136,7 @@ var vr=[16,20,24,28,32],Rc={0:"00",1:"01",2:"10",3:"11",4:"0",5:"1"};function kr
         <p class="field-note msig-threshold-help" id="msig-threshold-help">Enter values, drag either handle, or use the arrow keys. Editing one value past the other moves both.</p>
       </fieldset>
       <div id="msig-keys" class="msig-keys"></div>
+      <p class="hint" id="msig-key-order-status" hidden></p>
       <p class="hint" id="msig-hint"></p>
       <div class="key-settings msig-output-settings">
         <label class="choice msig-legacy-account-toggle" id="msig-legacy-account-toggle" hidden>
@@ -161,6 +162,16 @@ var vr=[16,20,24,28,32],Rc={0:"00",1:"01",2:"10",3:"11",4:"0",5:"1"};function kr
             <select id="msig-count"><option value="5">5 + 5</option><option value="10">10 + 10</option><option value="20">20 + 20</option></select>
           </label>
         </div>
+        <details class="msig-advanced" id="msig-advanced">
+          <summary>Advanced</summary>
+          <label class="field">Key order
+            <select id="msig-key-order">
+              <option value="sorted" selected>Sorted · sortedmulti</option>
+              <option value="listed">As listed · multi</option>
+            </select>
+            <span class="field-note" id="msig-key-order-help">Sorted is the default. Addresses stay the same no matter which co-signer you paste first. As listed uses multi: the order of the fields is part of the wallet. Taproot uses sortedmulti_a or multi_a.</span>
+          </label>
+        </details>
       </div>
       <div class="row current-item-actions">
         <button class="btn primary" id="msig-go" type="button" aria-describedby="msig-script-warning" disabled aria-disabled="true">Derive Multisig</button>
@@ -466,9 +477,9 @@ function hodlMatchMsigAddressBeyond(address,start){
   let bip45=re.script==="p2sh"&&re.scriptStandard==="bip45",receivePath=bip45?"m/0/0/":"m/0/",changePath=bip45?"m/0/1/":"m/1/";
   for(let index=start;index<hodlAddressSearchLimit;index++){
     let receiveKeys=nodes.map(node=>{let key=node.derive(receivePath+index).publicKey;if(!key)throw new Error("Could not derive a public key");return key});
-    if(hodlAddressesEqual(address,hodlMsigAddr(receiveKeys,re.m,re.network,re.script).address))return{state:"match",chain:"receive",index,path:receivePath.slice(1)+index,beyond:!0};
+    if(hodlAddressesEqual(address,hodlMsigAddr(receiveKeys,re.m,re.network,re.script,re.sorted!==!1).address))return{state:"match",chain:"receive",index,path:receivePath.slice(1)+index,beyond:!0};
     let changeKeys=nodes.map(node=>{let key=node.derive(changePath+index).publicKey;if(!key)throw new Error("Could not derive a public key");return key});
-    if(hodlAddressesEqual(address,hodlMsigAddr(changeKeys,re.m,re.network,re.script).address))return{state:"match",chain:"change",index,path:changePath.slice(1)+index,beyond:!0}
+    if(hodlAddressesEqual(address,hodlMsigAddr(changeKeys,re.m,re.network,re.script,re.sorted!==!1).address))return{state:"match",chain:"change",index,path:changePath.slice(1)+index,beyond:!0}
   }
   return{state:"miss",searchedTo:hodlAddressSearchLimit-1}
 }
@@ -2324,14 +2335,83 @@ function hodlBindMsigThresholdSlider(){
   let finish=event=>{if(!drag||event.pointerId!==drag.pointerId)return;if(!drag.handle){slider.dataset.activeHandle="n";nInput.focus({preventScroll:!0})}drag=null};
   slider.addEventListener("pointerup",finish);slider.addEventListener("pointercancel",finish);slider.addEventListener("lostpointercapture",()=>{drag=null})
 }
+function hodlMsigKeysSorted(){return document.getElementById("msig-key-order")?.value!=="listed"}
+function hodlMsigPolicyOp(kind,sorted){return kind==="p2tr"?sorted?"sortedmulti_a":"multi_a":sorted?"sortedmulti":"multi"}
+function hodlMsigInnerDescriptor(kind,m,inner,sorted){
+  let core=`${hodlMsigPolicyOp(kind,sorted)}(${m},${inner})`;
+  if(kind==="p2tr")return `tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,${core})`;
+  if(kind==="p2wsh")return `wsh(${core})`;
+  if(kind==="p2sh-p2wsh")return `sh(wsh(${core}))`;
+  return `sh(${core})`
+}
+function hodlUpdateMsigKeyOrderStatus(){
+  let status=document.getElementById("msig-key-order-status");if(!status)return;
+  let sorted=hodlMsigKeysSorted();status.hidden=sorted;if(sorted){status.textContent="";status.className="hint";return}
+  let op=hodlMsigPolicyOp(hodlScriptKind(),!1);
+  let parts=[...document.querySelectorAll("#msig-keys textarea")].map((ta,index)=>{
+    let raw=ta.value.trim();
+    if(!raw)return "position "+(index+1);
+    try{let parsed=hodlParseMultisigCosigner(raw);if(parsed.origin?.fingerprint)return "position "+(index+1)+" "+parsed.origin.fingerprint}catch{}
+    return "position "+(index+1)
+  });
+  status.textContent=op+" uses this order: "+parts.join(", ")+". Use Move up or Move down to change a position.";
+  status.className="hint ok"
+}
+function hodlSyncMsigKeyMoveButtons(){
+  let rows=[...document.querySelectorAll("#msig-keys .msig-key-row")];
+  rows.forEach((row,index)=>{
+    let up=row.querySelector('[data-msig-move="-1"]'),down=row.querySelector('[data-msig-move="1"]');
+    if(up){up.disabled=index===0;up.setAttribute("aria-label","Move co-signer "+(index+1)+" up to position "+index)}
+    if(down){down.disabled=index===rows.length-1;down.setAttribute("aria-label","Move co-signer "+(index+1)+" down to position "+(index+2))}
+  })
+}
+function hodlReindexMsigKeys(){
+  [...document.querySelectorAll("#msig-keys .msig-key-row")].forEach((row,index)=>{
+    let ta=row.querySelector("textarea"),pos=row.querySelector(".msig-key-position"),lab=row.querySelector("label.field");
+    if(ta)ta.id="msig-x-"+index;
+    if(pos)pos.textContent="Position "+(index+1);
+    if(lab){let title=lab.childNodes[0];if(title&&title.nodeType===3)title.textContent="Co-signer "+(index+1)+" multisig extended public key"}
+  });
+  hodlSyncMsigKeyMoveButtons();hodlUpdateMsigKeyPlaceholders();hodlUpdateMsigKeyOrderStatus()
+}
+function hodlMoveMsigKeyRow(row,offset){
+  let box=document.getElementById("msig-keys"),rows=[...box.querySelectorAll(".msig-key-row")],index=rows.indexOf(row),next=index+offset;
+  if(index<0||next<0||next>=rows.length)return;
+  if(offset<0)box.insertBefore(row,rows[next]);else box.insertBefore(row,rows[next].nextSibling);
+  hodlReindexMsigKeys();hodlInvalidateMsig();hodlSyncMsigClearButton(!0)
+}
+function hodlBindMsigKeyReorder(box){
+  if(box.dataset.reorderBound)return;box.dataset.reorderBound="1";
+  box.addEventListener("click",event=>{
+    if(hodlMsigKeysSorted())return;
+    let button=event.target.closest("[data-msig-move]");if(!button||button.disabled)return;
+    hodlMoveMsigKeyRow(button.closest(".msig-key-row"),Number(button.dataset.msigMove))
+  })
+}
+function hodlMsigScriptOrder(keyTokens){
+  return keyTokens.map((token,index)=>{
+    let match=String(token).match(/^\[([0-9a-f]{8})\/([^\]]+)\]/i);
+    return{position:index+1,fingerprint:match?match[1]:"",path:match?match[2]:""}
+  })
+}
 function hodlFillKeys(values){
-  let n=Number(document.getElementById("msig-n").value||3),saved=Array.isArray(values)?values:hodlReadMsigXpubs(),box=document.getElementById("msig-keys");box.innerHTML="";
+  let n=Number(document.getElementById("msig-n").value||3),saved=Array.isArray(values)?values:hodlReadMsigXpubs(),box=document.getElementById("msig-keys"),listed=!hodlMsigKeysSorted();
+  box.classList.toggle("msig-keys-listed",listed);box.innerHTML="";
   for(let i=0;i<n;i++){
+    let row=document.createElement("div");row.className="msig-key-row";
+    if(listed){
+      let head=document.createElement("div");head.className="msig-key-row-head";
+      let pos=document.createElement("span");pos.className="msig-key-position";pos.textContent="Position "+(i+1);
+      let moves=document.createElement("div");moves.className="msig-key-move";
+      let up=document.createElement("button");up.type="button";up.className="btn secondary msig-key-move-btn";up.dataset.msigMove="-1";up.textContent="Move up";
+      let down=document.createElement("button");down.type="button";down.className="btn secondary msig-key-move-btn";down.dataset.msigMove="1";down.textContent="Move down";
+      moves.append(up,down);head.append(pos,moves);row.appendChild(head)
+    }
     let lab=document.createElement("label");lab.className="field";lab.textContent="Co-signer "+(i+1)+" multisig extended public key";
-    let ta=document.createElement("textarea");ta.id="msig-x-"+i;ta.autocomplete="off";ta.spellcheck=false;ta.value=saved[i]||"";lab.appendChild(ta);box.appendChild(lab);
-    ta.oninput=()=>{ta.value=hodlFilterXpub(ta.value);hodlUpdateMsigScriptDetection();document.querySelectorAll("#msig-keys textarea").forEach(hodlCheckXpub);hodlInvalidateMsig()}
+    let ta=document.createElement("textarea");ta.id="msig-x-"+i;ta.autocomplete="off";ta.spellcheck=false;ta.value=saved[i]||"";lab.appendChild(ta);row.appendChild(lab);box.appendChild(row);
+    ta.oninput=()=>{ta.value=hodlFilterXpub(ta.value);hodlUpdateMsigScriptDetection();document.querySelectorAll("#msig-keys textarea").forEach(hodlCheckXpub);hodlUpdateMsigKeyOrderStatus();hodlInvalidateMsig()}
   }
-  hodlUpdateMsigScriptDetection();box.querySelectorAll("textarea").forEach(ta=>{if(ta.value)hodlCheckXpub(ta)});hodlUpdateMsigHint();hodlUpdateMsigAccount()
+  hodlBindMsigKeyReorder(box);hodlSyncMsigKeyMoveButtons();hodlUpdateMsigScriptDetection();box.querySelectorAll("textarea").forEach(ta=>{if(ta.value)hodlCheckXpub(ta)});hodlUpdateMsigHint();hodlUpdateMsigAccount();hodlUpdateMsigKeyOrderStatus()
 }
 function hodlMultisigPrefixCompatible(parsed,kind){
   if(kind==="p2tr")return parsed.family==="x";
@@ -2371,20 +2451,21 @@ function hodlDuplicateMultisigKey(ta,parsed){
   return!1
 }
 function hodlCheckXpub(ta){let value=ta.value.trim();if(!value){hodlHint(ta,!0,"");return}try{let parsed=hodlParseMultisigCosigner(value),network=hodlSelectedNetwork(document.getElementById("msig-network")),kind=hodlScriptKind(),legacyStandard=hodlSelectedLegacyMultisigStandard();if(kind==="mixed")throw new Error("These keys do not define one compatible multisig policy. Use one script type and one Legacy derivation standard.");if(parsed.isPrivate)throw new Error("Paste an extended public key, never an extended private key.");if(parsed.network!==network)throw new Error(`${parsed.prefix} is for ${parsed.network}; the multisig is set to ${network}.`);if(!hodlMultisigPrefixCompatible(parsed,kind))throw new Error(parsed.scope==="singlesig"?"Use a generic xpub/tpub here, or a proper uppercase multisig SLIP-132 export.":`${parsed.prefix} does not match the selected multisig script type.`);let accountError=hodlMultisigAccountKeyError(parsed,kind,legacyStandard);if(accountError)throw new Error(accountError);if(!parsed.origin)throw new Error(`Paste ${hodlMultisigKeyPlaceholder(kind,network,legacyStandard)} so a signer can recognize this key.`);let originError=hodlOriginMatchesParsedKey(parsed.origin,parsed);if(originError)throw new Error(originError);let scriptOriginError=hodlOriginScriptError(parsed.origin,kind,network,legacyStandard);if(scriptOriginError)throw new Error(scriptOriginError);if(hodlDuplicateMultisigKey(ta,parsed))throw new Error("This duplicates another co-signer. Every co-signer must use a distinct extended public key.");hodlHint(ta,!0,`${parsed.prefix} origin, checksum, and derivation path look valid`)}catch(error){hodlHint(ta,!1,error.message||"Not a valid multisig extended public key")}}
-function hodlResetMsigForm(){hodlSetMsigThresholds(2,3);hodlSyncSelect(document.getElementById("msig-script-type"),"p2wsh");let legacy=document.getElementById("msig-legacy-bip87");if(legacy)legacy.checked=!1;hodlUpdateMsigLegacyControls();hodlSyncSelect(document.getElementById("msig-network"),"mainnet");hodlSyncSelect(document.getElementById("msig-count"),"5");hodlFillKeys([]);document.getElementById("msig-error").textContent=""}
-function hodlInitMsig(){hodlBindMsigThresholdSlider();let recheck=()=>{hodlUpdateMsigScriptDetection();hodlInvalidateMsig();document.querySelectorAll("#msig-keys textarea").forEach(hodlCheckXpub)},script=document.getElementById("msig-script-type"),legacy=document.getElementById("msig-legacy-bip87");script.addEventListener("change",()=>{if(script.value!=="mixed")script.dataset.lastConcrete=script.value;recheck()});if(legacy)legacy.addEventListener("change",()=>{hodlUpdateMsigLegacyControls();hodlUpdateMsigKeyPlaceholders();hodlInvalidateMsig();document.querySelectorAll("#msig-keys textarea").forEach(hodlCheckXpub);hodlSyncMsigClearButton(!0)});document.getElementById("msig-network").addEventListener("change",recheck);document.getElementById("msig-count").addEventListener("change",hodlInvalidateMsig);hodlResetMsigForm();W("#msig-go").onclick=hodlBuildMsig;W("#msig-wipe").onclick=hodlWipeActiveMsig}
+function hodlResetMsigForm(){hodlSetMsigThresholds(2,3);hodlSyncSelect(document.getElementById("msig-script-type"),"p2wsh");let legacy=document.getElementById("msig-legacy-bip87");if(legacy)legacy.checked=!1;hodlUpdateMsigLegacyControls();hodlSyncSelect(document.getElementById("msig-key-order"),"sorted");let advanced=document.getElementById("msig-advanced");if(advanced)advanced.open=!1;hodlSyncSelect(document.getElementById("msig-network"),"mainnet");hodlSyncSelect(document.getElementById("msig-count"),"5");hodlFillKeys([]);document.getElementById("msig-error").textContent=""}
+function hodlInitMsig(){hodlBindMsigThresholdSlider();let recheck=()=>{hodlUpdateMsigScriptDetection();hodlInvalidateMsig();document.querySelectorAll("#msig-keys textarea").forEach(hodlCheckXpub);hodlUpdateMsigKeyOrderStatus()},script=document.getElementById("msig-script-type"),legacy=document.getElementById("msig-legacy-bip87"),keyOrder=document.getElementById("msig-key-order");script.addEventListener("change",()=>{if(script.value!=="mixed")script.dataset.lastConcrete=script.value;recheck()});if(legacy)legacy.addEventListener("change",()=>{hodlUpdateMsigLegacyControls();hodlUpdateMsigKeyPlaceholders();hodlInvalidateMsig();document.querySelectorAll("#msig-keys textarea").forEach(hodlCheckXpub);hodlSyncMsigClearButton(!0)});if(keyOrder)keyOrder.addEventListener("change",()=>{let advanced=document.getElementById("msig-advanced");if(keyOrder.value==="listed"&&advanced)advanced.open=!0;hodlFillKeys();hodlInvalidateMsig();hodlSyncMsigClearButton(!0)});document.getElementById("msig-network").addEventListener("change",recheck);document.getElementById("msig-count").addEventListener("change",hodlInvalidateMsig);hodlResetMsigForm();W("#msig-go").onclick=hodlBuildMsig;W("#msig-wipe").onclick=hodlWipeActiveMsig}
 function hodlCmpBytes(a,b){let n=Math.min(a.length,b.length);for(let i=0;i<n;i++)if(a[i]!==b[i])return a[i]-b[i];return a.length-b.length}
 function hodlScriptKind(){return document.getElementById("msig-script-type")?.value||"p2wsh"}
 function hodlTaprootNumsKey(){return M.decode("50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0")}
 function hodlXOnlyPubkey(pubkey){if(!pubkey||pubkey.length<32)throw new Error("Could not derive a public key");return pubkey.length===33?pubkey.slice(1):pubkey.slice(0,32)}
-function hodlMsigAddr(pubkeys,m,network,kind){
+function hodlMsigAddr(pubkeys,m,network,kind,sorted=!0){
   let net=_s(network);
   if(kind==="p2tr"){
-    let xonly=[...pubkeys].map(hodlXOnlyPubkey).sort(hodlCmpBytes),script=Oe.encode({type:"tr_ms",m,pubkeys:xonly}),out=en(hodlTaprootNumsKey(),{script},net);
+    let xonly=[...pubkeys].map(hodlXOnlyPubkey);if(sorted)xonly.sort(hodlCmpBytes);
+    let script=Oe.encode({type:"tr_ms",m,pubkeys:xonly}),out=en(hodlTaprootNumsKey(),{script},net);
     if(!out?.address)throw new Error("Failed to build Taproot multisig address");
     return{address:out.address,scriptHex:M.encode(script),kind}
   }
-  let sorted=[...pubkeys].sort(hodlCmpBytes);let ms=Oe.encode({type:"ms",m,pubkeys:sorted});
+  let keys=[...pubkeys];if(sorted)keys.sort(hodlCmpBytes);let ms=Oe.encode({type:"ms",m,pubkeys:keys});
   if(kind==="p2wsh"){let hash=tr(ms);return{address:or(net).encode({type:"wsh",hash}),scriptHex:M.encode(ms),kind}}
   if(kind==="p2sh-p2wsh"){let hash=tr(ms);let wshScript=Oe.encode({type:"wsh",hash});let wrapped=Jr({script:wshScript,witnessScript:ms},net);return{address:wrapped.address,scriptHex:M.encode(ms),kind}}
   let wrapped=Jr({script:ms},net);return{address:wrapped.address,scriptHex:M.encode(ms),kind}
@@ -2416,30 +2497,30 @@ function hodlBuildMsig(){
   try{
     let{network,count,n,m,kind,legacyStandard,nodes,xpubs,keyTokens,accountSummary,accountWarning}=hodlValidatedMsigInputs(),bip45=kind==="p2sh"&&legacyStandard==="bip45";
     let receiveSuffix=bip45?"/0/0/*":"/0/*",changeSuffix=bip45?"/0/1/*":"/1/*";
-    let inner=keyTokens.map(key=>key+receiveSuffix).join(","),innerChange=keyTokens.map(key=>key+changeSuffix).join(",");
-    let nums="50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0";
-    let descriptor=kind==="p2tr"?`tr(${nums},sortedmulti_a(${m},${inner}))`:kind==="p2wsh"?`wsh(sortedmulti(${m},${inner}))`:kind==="p2sh-p2wsh"?`sh(wsh(sortedmulti(${m},${inner})))`:`sh(sortedmulti(${m},${inner}))`;
-    let changeDescriptor=kind==="p2tr"?`tr(${nums},sortedmulti_a(${m},${innerChange}))`:kind==="p2wsh"?`wsh(sortedmulti(${m},${innerChange}))`:kind==="p2sh-p2wsh"?`sh(wsh(sortedmulti(${m},${innerChange})))`:`sh(sortedmulti(${m},${innerChange}))`;
+    let sorted=hodlMsigKeysSorted(),inner=keyTokens.map(key=>key+receiveSuffix).join(","),innerChange=keyTokens.map(key=>key+changeSuffix).join(",");
+    let descriptor=hodlMsigInnerDescriptor(kind,m,inner,sorted),changeDescriptor=hodlMsigInnerDescriptor(kind,m,innerChange,sorted);
     let receive=[],change=[],receivePath=bip45?"m/0/0/":"m/0/",changePath=bip45?"m/0/1/":"m/1/";for(let index=0;index<count;index++){
       let receivePublicKeys=nodes.map(node=>{let key=node.derive(receivePath+index).publicKey;if(!key)throw new Error("Could not derive a public key");return key});
       let changePublicKeys=nodes.map(node=>{let key=node.derive(changePath+index).publicKey;if(!key)throw new Error("Could not derive a public key");return key});
-      receive.push(Object.assign({index,path:receivePath.slice(1)+index},hodlMsigAddr(receivePublicKeys,m,network,kind)));
-      change.push(Object.assign({index,path:changePath.slice(1)+index},hodlMsigAddr(changePublicKeys,m,network,kind)))
+      receive.push(Object.assign({index,path:receivePath.slice(1)+index},hodlMsigAddr(receivePublicKeys,m,network,kind,sorted)));
+      change.push(Object.assign({index,path:changePath.slice(1)+index},hodlMsigAddr(changePublicKeys,m,network,kind,sorted)))
     }
     let notes=["This is watch-only. Private keys never entered this calculator.","Each key origin lets a signer match its seed to one co-signer.","A signer is only needed when you spend."];
     if(bip45)notes.push("Legacy BIP45 addresses use co-signer branch 0 for this receive and change set.");
     if(kind==="p2sh"&&legacyStandard==="bip87")notes.push("Legacy P2SH uses the selected BIP87 account paths. Keep the descriptor with every seed backup.");
-    if(kind==="p2tr")notes.push("Taproot script-path multisig. The internal key is the BIP341 NUMS point, so spending is only possible through the multi_a script path.");
-    re={kind:"msig",network,m,n,script:kind,scriptStandard:kind==="p2tr"?"bip86":kind==="p2sh"?legacyStandard:"bip48",account:accountSummary.account,accountMixed:accountSummary.mixed,nodes,xpubs,receiveDescriptor:Le(descriptor),changeDescriptor:Le(changeDescriptor),walletDescriptor:hodlWatchOnlyMultipathDescriptor(Le(descriptor)),receive,change,notes,warnings:accountWarning?[accountWarning]:[]};
+    if(kind==="p2tr")notes.push("Taproot script-path multisig. The internal key is the BIP341 NUMS point, so spending is only possible through the "+(sorted?"sortedmulti_a":"multi_a")+" script path.");
+    if(!sorted)notes.push("This wallet uses "+hodlMsigPolicyOp(kind,!1)+", so the listed co-signer order is part of the script. Reordering keys changes addresses.");
+    re={kind:"msig",network,m,n,script:kind,sorted,scriptOrder:hodlMsigScriptOrder(keyTokens),scriptStandard:kind==="p2tr"?"bip86":kind==="p2sh"?legacyStandard:"bip48",account:accountSummary.account,accountMixed:accountSummary.mixed,nodes,xpubs,receiveDescriptor:Le(descriptor),changeDescriptor:Le(changeDescriptor),walletDescriptor:hodlWatchOnlyMultipathDescriptor(Le(descriptor)),receive,change,notes,warnings:accountWarning?[accountWarning]:[]};
     hodlCaptureMsig();hodlShowMsig();hodlFocusWalletResult()
   }catch(exception){re=null;dr.innerHTML="";error.textContent=exception.message||String(exception);hodlCaptureMsig()}
 }
 function hodlShowMsig(){if(!re||re.kind!=="msig")return;Ge=!1;let accountLabel=re.accountMixed?" · Account Mixed":re.account==null?"":` · Account ${re.account}`,standardLabel=re.scriptStandard?` · ${re.scriptStandard.toUpperCase()}`:"";dr.innerHTML=`
     <section class="card account-result-card">
-      <div class="kicker">${re.m}-of-${re.n} multisig${standardLabel} · ${re.network}${accountLabel}</div>
+      <div class="kicker">${re.m}-of-${re.n} multisig${standardLabel}${re.sorted===!1?" · listed order":""} · ${re.network}${accountLabel}</div>
       <h2 tabindex="-1">Your multisig receive wallet</h2>
       <p class="muted">Anyone can pay these addresses. Spending later needs ${re.m} signature${re.m===1?"":"s"} from the configured ${re.n} signing key${re.n===1?"":"s"}. This screen has no private keys.</p>
       ${hodlWalletMessages(re,"multisig")}
+      ${re.sorted===!1&&re.scriptOrder?.length?`<section class="account-result-section" aria-labelledby="multisig-order-heading"><div class="wallet-data-section-head"><h3 id="multisig-order-heading">Script key order</h3><p class="muted">${hodlMsigPolicyOp(re.script,!1)} uses the co-signers in this order. Changing the order creates a different wallet.</p></div><ol class="msig-script-order">${re.scriptOrder.map(item=>`<li><span class="msig-script-order-position">Position ${item.position}</span><code>${$t(item.fingerprint?item.fingerprint+"/"+item.path:item.fingerprint||"")}</code></li>`).join("")}</ol></section>`:""}
       <section class="account-result-section account-watch-section" aria-labelledby="multisig-watch-heading">
         <div class="wallet-data-section-head">
           <h3 id="multisig-watch-heading">Watch-only wallet data</h3>
@@ -2787,11 +2868,11 @@ function hodlDeleteActiveKey(){
   (hodlActiveKey>=0?W("#key-tabs").children[hodlActiveKey]:W("#add-key"))?.focus();
 }
 var hodlNextMsigId=1,hodlNextMsigNumber=1,hodlMsigs=[],hodlActiveMsig=-1;
-function hodlNewMsigState(name,msigId,msigNumber){let id=msigId??hodlNextMsigId++,number=msigNumber??hodlNextMsigNumber++;return{id,number,name:name||hodlDefaultMsigName(number),result:null,error:"",fields:{m:"2",n:"3",script:"p2wsh",legacyBip87:!1,xpubs:["","",""],network:"mainnet",count:"5"}}}
+function hodlNewMsigState(name,msigId,msigNumber){let id=msigId??hodlNextMsigId++,number=msigNumber??hodlNextMsigNumber++;return{id,number,name:name||hodlDefaultMsigName(number),result:null,error:"",fields:{m:"2",n:"3",script:"p2wsh",legacyBip87:!1,keyOrder:"sorted",xpubs:["","",""],network:"mainnet",count:"5"}}}
 function hodlMsigStateNeedsClear(state){
   if(!state)return!1;let fields=state.fields||{},xpubs=Array.isArray(fields.xpubs)?fields.xpubs:[];
   return Boolean(state.result)||String(state.error??"").length>0||xpubs.some(value=>String(value??"").length>0)||
-    String(fields.m??"2")!=="2"||String(fields.n??"3")!=="3"||String(fields.script??"p2wsh")!=="p2wsh"||Boolean(fields.legacyBip87)||String(fields.network??"mainnet")!=="mainnet"||String(fields.count??"5")!=="5"
+    String(fields.m??"2")!=="2"||String(fields.n??"3")!=="3"||String(fields.script??"p2wsh")!=="p2wsh"||Boolean(fields.legacyBip87)||String(fields.keyOrder??"sorted")!=="sorted"||String(fields.network??"mainnet")!=="mainnet"||String(fields.count??"5")!=="5"
 }
 function hodlSyncMsigClearButton(capture=!1){
   if(capture)hodlCaptureMsig();let button=document.getElementById("msig-wipe");if(!button)return;
@@ -2800,14 +2881,14 @@ function hodlSyncMsigClearButton(capture=!1){
 function hodlCaptureMsig(){
   if(hodlActiveMsig<0||!hodlMsigs[hodlActiveMsig])return;
   let state=hodlMsigs[hodlActiveMsig];
-  state.fields.n=document.getElementById("msig-n").value||"3";state.fields.m=document.getElementById("msig-m").value||"2";state.fields.script=hodlScriptKind();state.fields.legacyBip87=hodlSelectedLegacyMultisigStandard()==="bip87";hodlMergeMsigXpubs(state);state.fields.network=hodlSelectedNetwork(document.getElementById("msig-network"));state.fields.count=document.getElementById("msig-count").value||"5";
+  state.fields.n=document.getElementById("msig-n").value||"3";state.fields.m=document.getElementById("msig-m").value||"2";state.fields.script=hodlScriptKind();state.fields.legacyBip87=hodlSelectedLegacyMultisigStandard()==="bip87";state.fields.keyOrder=hodlMsigKeysSorted()?"sorted":"listed";hodlMergeMsigXpubs(state);state.fields.network=hodlSelectedNetwork(document.getElementById("msig-network"));state.fields.count=document.getElementById("msig-count").value||"5";
   state.result=re&&re.kind==="msig"?re:null;state.error=document.getElementById("msig-error").textContent||"";
 }
 function hodlRestoreMsig(){
   let state=hodlMsigs[hodlActiveMsig],panel=document.getElementById("msig-card");
   if(!state){re=null;Ge=!1;hodlResetMsigForm();dr.innerHTML="";panel.hidden=!0;hodlSyncMsigClearButton();return}
   hodlSetMsigThresholds(state.fields.m||"2",state.fields.n||"3");
-  let legacy=document.getElementById("msig-legacy-bip87");if(legacy)legacy.checked=Boolean(state.fields.legacyBip87);hodlSyncSelect(document.getElementById("msig-script-type"),state.fields.script||"p2wsh");hodlUpdateMsigLegacyControls();state.fields.network=state.fields.network==="testnet"?"testnet":"mainnet";hodlSyncSelect(document.getElementById("msig-network"),state.fields.network);hodlSyncSelect(document.getElementById("msig-count"),state.fields.count||"5");hodlFillKeys(state.fields.xpubs||[]);
+  let legacy=document.getElementById("msig-legacy-bip87");if(legacy)legacy.checked=Boolean(state.fields.legacyBip87);hodlSyncSelect(document.getElementById("msig-script-type"),state.fields.script||"p2wsh");hodlUpdateMsigLegacyControls();state.fields.keyOrder=state.fields.keyOrder==="listed"?"listed":"sorted";hodlSyncSelect(document.getElementById("msig-key-order"),state.fields.keyOrder);let advanced=document.getElementById("msig-advanced");if(advanced)advanced.open=state.fields.keyOrder==="listed";state.fields.network=state.fields.network==="testnet"?"testnet":"mainnet";hodlSyncSelect(document.getElementById("msig-network"),state.fields.network);hodlSyncSelect(document.getElementById("msig-count"),state.fields.count||"5");hodlFillKeys(state.fields.xpubs||[]);
   document.getElementById("msig-error").textContent=state.error||"";re=state.result;Ge=!1;panel.hidden=!1;
   if(re&&re.kind==="msig")hodlShowMsig();else dr.innerHTML="";hodlSyncMsigClearButton();
 }

--- a/test/descriptor.test.mjs
+++ b/test/descriptor.test.mjs
@@ -144,7 +144,13 @@ test("origin path must match key depth and script", () => {
     /87h/,
   );
   assert.equal(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "86h/0h/0h" }, "p2tr", "mainnet"), "");
-  assert.equal(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "48h/0h/0h/3h" }, "p2tr", "mainnet"), "");
+  assert.match(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "48h/0h/0h/3h" }, "p2tr", "mainnet"), /86h/);
+  assert.match(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "84h/0h/0h" }, "p2tr", "mainnet"), /86h/);
+  assert.match(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "48h/0h/0h/2h" }, "p2tr", "mainnet"), /86h/);
+  assert.match(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "44h/0h/0h" }, "p2tr", "mainnet"), /86h/);
+  assert.match(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "45h" }, "p2tr", "mainnet"), /86h/);
+  assert.match(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "87h/0h/0h" }, "p2tr", "mainnet"), /86h/);
+  assert.match(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "86h/0h/0h/0h" }, "p2tr", "mainnet"), /86h\/coin\/account/);
   assert.match(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "86h/1h/0h" }, "p2tr", "mainnet"), /0h/);
   assert.equal(hodlOriginPathIndexes("48h/1h/0h/2h").at(-1), 0x80000002);
 });
@@ -177,7 +183,7 @@ test("multisig script type is inferred from SLIP-132 prefixes and key origins", 
   assert.equal(hodlMultisigOriginScriptKind({ path: "48h/0h/0h/1h" }), "p2sh-p2wsh");
   assert.equal(hodlMultisigOriginScriptKind({ path: "48h/0h/0h/2h" }), "p2wsh");
   assert.equal(hodlMultisigOriginScriptKind({ path: "86h/0h/0h" }), "p2tr");
-  assert.equal(hodlMultisigOriginScriptKind({ path: "48h/0h/0h/3h" }), "p2tr");
+  assert.equal(hodlMultisigOriginScriptKind({ path: "48h/0h/0h/3h" }), null);
   assert.equal(hodlMultisigOriginScriptKind({ path: "84h/0h/0h" }), null);
   assert.equal(hodlMultisigDerivationStandard({ path: "45h" }), "bip45");
   assert.equal(hodlMultisigDerivationStandard({ path: "86h/0h/0h" }), "bip86");

--- a/test/descriptor.test.mjs
+++ b/test/descriptor.test.mjs
@@ -265,3 +265,22 @@ test("BIP48 script-path taproot origins keep the 3h leaf before receive and chan
   const wallet = hodlWatchOnlyMultipathDescriptor(Le(body));
   assert.match(wallet, /\[73c5da0a\/48h\/0h\/0h\/3h\]xpubABC\/<0;1>\/\*/);
 });
+
+test("listed-order watch-only descriptor keeps multi() key order", () => {
+  const body =
+    "wsh(multi(2,[73c5da0a/48h/1h/0h/2h]tpubABC/0/*,[b8688df1/48h/1h/0h/2h]tpubDEF/0/*))";
+  const wallet = hodlWatchOnlyMultipathDescriptor(Le(body));
+  assert.match(wallet, /wsh\(multi\(2,/);
+  assert.match(wallet, /\[73c5da0a\/48h\/1h\/0h\/2h\]tpubABC\/<0;1>\/\*/);
+  assert.match(wallet, /\[b8688df1\/48h\/1h\/0h\/2h\]tpubDEF\/<0;1>\/\*/);
+  assert.equal(wallet.includes("sortedmulti"), false);
+});
+
+test("listed-order taproot descriptor keeps multi_a() key order", () => {
+  const body =
+    "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,multi_a(2,[73c5da0a/86h/0h/0h]xpubABC/0/*,[b8688df1/86h/0h/0h]xpubDEF/0/*))";
+  const wallet = hodlWatchOnlyMultipathDescriptor(Le(body));
+  assert.match(wallet, /multi_a\(2,/);
+  assert.equal(wallet.includes("sortedmulti_a"), false);
+  assert.match(wallet, /\[73c5da0a\/86h\/0h\/0h\]xpubABC\/<0;1>\/\*/);
+});

--- a/test/descriptor.test.mjs
+++ b/test/descriptor.test.mjs
@@ -139,19 +139,20 @@ test("origin path must match key depth and script", () => {
   assert.match(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "45h/0" }, "p2sh", "mainnet"), /purpose origin/);
   const bip87 = { fingerprint: "73c5da0a", path: "87h/0h/7h" };
   assert.equal(hodlOriginMatchesParsedKey(bip87, { depth: 3, childNumber: 0x80000007 }), "");
-  assert.equal(hodlOriginScriptError(bip87, "p2sh", "mainnet", "bip87"), "");
-  assert.match(hodlOriginScriptError(bip87, "p2sh", "testnet", "bip87"), /1h/);
   assert.match(
     hodlOriginScriptError({ fingerprint: "73c5da0a", path: "45h" }, "p2sh", "mainnet", "bip87"),
     /87h/,
   );
+  assert.equal(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "86h/0h/0h" }, "p2tr", "mainnet"), "");
+  assert.equal(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "48h/0h/0h/3h" }, "p2tr", "mainnet"), "");
+  assert.match(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "86h/1h/0h" }, "p2tr", "mainnet"), /0h/);
   assert.equal(hodlOriginPathIndexes("48h/1h/0h/2h").at(-1), 0x80000002);
 });
-
 test("multisig account is derived from BIP48 and BIP87 origins", () => {
   assert.equal(hodlMultisigAccountNumber({ path: "48h/0h/7h/2h" }, "p2wsh"), 7);
   assert.equal(hodlMultisigAccountNumber({ path: "48h/0h/3h/1h" }, "p2sh-p2wsh"), 3);
   assert.equal(hodlMultisigAccountNumber({ path: "87h/0h/9h" }, "p2sh"), 9);
+  assert.equal(hodlMultisigAccountNumber({ path: "86h/0h/4h" }, "p2tr"), 4);
   assert.equal(hodlMultisigAccountNumber({ path: "45h" }, "p2sh"), null);
   assert.throws(
     () => hodlMultisigAccountNumber({ path: "48h/0h/7/2h" }, "p2wsh"),
@@ -175,8 +176,11 @@ test("multisig script type is inferred from SLIP-132 prefixes and key origins", 
   assert.equal(hodlMultisigOriginScriptKind({ path: "87h/0h/0h" }), null);
   assert.equal(hodlMultisigOriginScriptKind({ path: "48h/0h/0h/1h" }), "p2sh-p2wsh");
   assert.equal(hodlMultisigOriginScriptKind({ path: "48h/0h/0h/2h" }), "p2wsh");
+  assert.equal(hodlMultisigOriginScriptKind({ path: "86h/0h/0h" }), "p2tr");
+  assert.equal(hodlMultisigOriginScriptKind({ path: "48h/0h/0h/3h" }), "p2tr");
   assert.equal(hodlMultisigOriginScriptKind({ path: "84h/0h/0h" }), null);
   assert.equal(hodlMultisigDerivationStandard({ path: "45h" }), "bip45");
+  assert.equal(hodlMultisigDerivationStandard({ path: "86h/0h/0h" }), "bip86");
   assert.equal(hodlMultisigDerivationStandard({ path: "87h/0h/0h" }), "bip87");
   assert.equal(hodlMultisigDerivationStandard({ path: "48h/0h/0h/2h" }), "bip48");
 
@@ -242,4 +246,22 @@ test("originated 2-of-3 payload keeps fingerprints and fits a static QR", () => 
   assert.equal(wallet.includes("/0/*"), false);
   assert.ok(wallet.length < 1000);
   assert.equal(wallet.slice(-8), independentChecksum(wallet.slice(0, wallet.lastIndexOf("#"))));
+});
+
+test("taproot watch-only descriptor uses NUMS internal key and sortedmulti_a", () => {
+  const body =
+    "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,sortedmulti_a(2,[73c5da0a/86h/0h/0h]xpubABC/0/*,[b8688df1/86h/0h/0h]xpubDEF/0/*))";
+  const wallet = hodlWatchOnlyMultipathDescriptor(Le(body));
+  assert.match(wallet, /^tr\(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,sortedmulti_a\(/);
+  assert.match(wallet, /\[73c5da0a\/86h\/0h\/0h\]xpubABC\/<0;1>\/\*/);
+  assert.match(wallet, /\[b8688df1\/86h\/0h\/0h\]xpubDEF\/<0;1>\/\*/);
+  assert.equal(wallet.includes("/0/*"), false);
+  assert.equal(wallet.slice(-8), independentChecksum(wallet.slice(0, wallet.lastIndexOf("#"))));
+});
+
+test("BIP48 script-path taproot origins keep the 3h leaf before receive and change", () => {
+  const body =
+    "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,sortedmulti_a(1,[73c5da0a/48h/0h/0h/3h]xpubABC/0/*))";
+  const wallet = hodlWatchOnlyMultipathDescriptor(Le(body));
+  assert.match(wallet, /\[73c5da0a\/48h\/0h\/0h\/3h\]xpubABC\/<0;1>\/\*/);
 });

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -230,6 +230,7 @@ test("key derivation and multisig use the accurate Script type label", () => {
     assert.match(markup, /id="script-type-field">Script type\s*<select/);
     assert.match(markup, /<label class="field">Script type\s*<select id="msig-script-type"[^>]*>/);
     assert.match(markup, /<option value="p2wsh" selected(?:="selected")?>Native SegWit · BIP48<\/option>/);
+    assert.match(markup, /<option value="p2tr">Taproot · BIP86<\/option>/);
     assert.doesNotMatch(markup, /name="msig-script"|Matches BIP48 script type|Bare P2SH/);
     assert.doesNotMatch(markup, />Address type</);
   }
@@ -244,9 +245,9 @@ test("multisig script type and placeholders follow detected co-signer exports", 
   assert.match(template, /placeholder="\[fingerprint\/48h\/0h\/0h\/2h\]Zpub…"/);
   assert.match(app, /function hodlMultisigKeyPlaceholder\(kind,network,legacyStandard="bip45"\)/);
   assert.match(app, /kind==="p2sh"\)return`\[fingerprint\/45h\]\$\{testnet\?"tpub":"xpub"\}…`/);
-  assert.match(app, /kind==="p2sh"&&legacyStandard==="bip87"\)return`\[fingerprint\/87h\/\$\{coin\}\/0h\]\$\{testnet\?"tpub":"xpub"\}…`/);
   assert.match(app, /testnet\?"Upub":"Ypub"/);
   assert.match(app, /testnet\?"Vpub":"Zpub"/);
+  assert.match(app, /kind==="p2tr"\)return`\[fingerprint\/86h\/\$\{coin\}\/0h\]\$\{testnet\?"tpub":"xpub"\}…`/);
   assert.match(app, /summary\.legacyMixed\?"Legacy co-signer exports mix BIP45 and BIP87/);
   assert.match(app, /summary\.legacyScriptConflict\?"BIP87 account keys are script-agnostic/);
   assert.match(app, /BIP87 keys do not encode a script type\. Select Legacy P2SH/);
@@ -260,7 +261,7 @@ test("key derivation shows the relevant paste-ready multisig co-signer exports",
   assert.match(app, /accountId:"bip44",kind:"p2sh",standard:"bip87",label:`Legacy · BIP87 · Account \$\{accountIndex\}`,family:"x",accountPath:`m\/87'\/\$\{coinType\}'\/\$\{accountIndex\}'`,originPath:`87h\/\$\{coinType\}h\/\$\{accountIndex\}h`/);
   assert.match(app, /accountId:"bip49",kind:"p2sh-p2wsh",label:"Nested SegWit · BIP48",family:"y",scriptIndex:1/);
   assert.match(app, /accountId:"bip84",kind:"p2wsh",label:"Native SegWit · BIP48",family:"z",scriptIndex:2/);
-  assert.doesNotMatch(app, /accountId:"bip86"/);
+  assert.match(app, /accountId:"bip86",kind:"p2tr",label:"Taproot · BIP86",family:"x"/);
   assert.match(app, /accountPath=definition\.accountPath\|\|`m\/48'\/\$\{coinType\}'\/\$\{accountIndex\}'\/\$\{definition\.scriptIndex\}'`/);
   assert.match(app, /value:`\[\$\{masterFingerprint\}\/\$\{originPath\}\]\$\{publicKey\}`/);
   assert.match(app, /multisigCosignerExports:root\.privateKey\?hodlBuildMultisigCosignerExports\(root,network,accountIndex,masterFingerprint\):\[\]/);
@@ -273,6 +274,9 @@ test("key derivation shows the relevant paste-ready multisig co-signer exports",
   assert.match(app, /receiveSuffix=bip45\?"\/0\/0\/\*":"\/0\/\*"/);
   assert.match(app, /Legacy BIP45 addresses use co-signer branch 0/);
   assert.match(app, /Legacy P2SH uses the selected BIP87 account paths/);
+  assert.match(app, /kind==="p2tr"\?`tr\(\$\{nums\},sortedmulti_a\(\$\{m\},\$\{inner\}\)\)`/);
+  assert.match(app, /function hodlTaprootNumsKey\(\)/);
+  assert.match(app, /function hodlXOnlyPubkey\(pubkey\)/);
 });
 
 test("derived wallets offer an address match check", () => {
@@ -303,7 +307,7 @@ test("Legacy multisig defaults to BIP45 and offers BIP87 accounts only for Legac
   assert.match(app, /if\(toggle\)toggle\.hidden=!legacy/);
   assert.match(app, /checkbox\?\.checked\?"Legacy · BIP87":"Legacy · BIP45"/);
   assert.match(app, /legacyBip87:!1/);
-  assert.match(app, /scriptStandard:kind==="p2sh"\?legacyStandard:"bip48"/);
+  assert.match(app, /scriptStandard:kind==="p2tr"\?"bip86":kind==="p2sh"\?legacyStandard:"bip48"/);
   assert.match(app, /legacyScriptConflict=standards\.includes\("bip87"\)&&summary\.kinds\.some\(kind=>kind!=="p2sh"\)/);
 });
 

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -248,6 +248,10 @@ test("multisig script type and placeholders follow detected co-signer exports", 
   assert.match(app, /testnet\?"Upub":"Ypub"/);
   assert.match(app, /testnet\?"Vpub":"Zpub"/);
   assert.match(app, /kind==="p2tr"\)return`\[fingerprint\/86h\/\$\{coin\}\/0h\]\$\{testnet\?"tpub":"xpub"\}…`/);
+  assert.match(app, /if\(steps\[0\]!=="86h"\)return"BIP86 origin must start at 86h."/);
+  assert.match(app, /Taproot BIP86 requires a depth-3 account key at m\/86h\/coinh\/accounth/);
+  assert.doesNotMatch(app, /or BIP48 script 3h/);
+  assert.doesNotMatch(app, /if\(steps\[3\]==="3h"\)return"p2tr"/);
   assert.match(app, /summary\.legacyMixed\?"Legacy co-signer exports mix BIP45 and BIP87/);
   assert.match(app, /summary\.legacyScriptConflict\?"BIP87 account keys are script-agnostic/);
   assert.match(app, /BIP87 keys do not encode a script type\. Select Legacy P2SH/);

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -220,7 +220,7 @@ test("seed phrase mode has a lowercase Jade-style on-screen keyboard", () => {
 });
 
 test("multisig derivation settings follow the key inputs", () => {
-  const fieldOrder = /id="msig-keys"[\s\S]*id="msig-hint"[\s\S]*id="msig-script-type"[\s\S]*id="msig-network"[\s\S]*id="msig-account"[\s\S]*id="msig-count"[\s\S]*id="msig-go"/;
+  const fieldOrder = /id="msig-keys"[\s\S]*id="msig-key-order-status"[\s\S]*id="msig-hint"[\s\S]*id="msig-script-type"[\s\S]*id="msig-network"[\s\S]*id="msig-account"[\s\S]*id="msig-count"[\s\S]*id="msig-key-order"[\s\S]*id="msig-go"/;
   assert.match(template, fieldOrder);
   assert.match(app, fieldOrder);
 });
@@ -274,7 +274,10 @@ test("key derivation shows the relevant paste-ready multisig co-signer exports",
   assert.match(app, /receiveSuffix=bip45\?"\/0\/0\/\*":"\/0\/\*"/);
   assert.match(app, /Legacy BIP45 addresses use co-signer branch 0/);
   assert.match(app, /Legacy P2SH uses the selected BIP87 account paths/);
-  assert.match(app, /kind==="p2tr"\?`tr\(\$\{nums\},sortedmulti_a\(\$\{m\},\$\{inner\}\)\)`/);
+  assert.match(app, /function hodlMsigInnerDescriptor\(kind,m,inner,sorted\)/);
+  assert.match(app, /function hodlMsigPolicyOp\(kind,sorted\)/);
+  assert.match(app, /kind==="p2tr"\?sorted\?"sortedmulti_a":"multi_a":sorted\?"sortedmulti":"multi"/);
+  assert.match(app, /hodlMsigAddr\(receivePublicKeys,m,network,kind,sorted\)/);
   assert.match(app, /function hodlTaprootNumsKey\(\)/);
   assert.match(app, /function hodlXOnlyPubkey\(pubkey\)/);
 });
@@ -293,6 +296,27 @@ test("derived wallets offer an address match check", () => {
   assert.match(app, /hodlAddressTable\(account\.change,"Change addresses",hasPrivate\)\}\s*\$\{hodlAddressMatchMarkup\(\)/);
   assert.match(app, /hodlAddressTable\(re\.change,"Multisig change addresses"\)\}\s*\$\{hodlAddressMatchMarkup\(\)/);
   assert.match(css, /\.address-match-field/);
+});
+
+test("multisig key order is sorted by default and listed order is advanced", () => {
+  for (const markup of [template, app]) {
+    assert.match(markup, /id="msig-advanced"/);
+    assert.match(markup, /id="msig-key-order"/);
+    assert.match(markup, /<option value="sorted" selected(?:="selected")?>Sorted · sortedmulti<\/option>/);
+    assert.match(markup, /<option value="listed">As listed · multi<\/option>/);
+    assert.match(markup, /id="msig-key-order-status" hidden/);
+  }
+  assert.match(css, /\.msig-advanced summary/);
+  assert.match(css, /\.msig-key-move-btn/);
+  assert.match(app, /function hodlMsigKeysSorted\(\)/);
+  assert.match(app, /function hodlBindMsigKeyReorder\(box\)/);
+  assert.match(app, /function hodlMoveMsigKeyRow\(row,offset\)/);
+  assert.match(app, /textContent="Move up"/);
+  assert.match(app, /textContent="Move down"/);
+  assert.match(app, /function hodlMsigScriptOrder\(keyTokens\)/);
+  assert.match(app, /id="multisig-order-heading">Script key order/);
+  assert.match(app, /keyOrder:"sorted"/);
+  assert.match(app, /if\(!sorted\)notes\.push\("This wallet uses "/);
 });
 
 test("Legacy multisig defaults to BIP45 and offers BIP87 accounts only for Legacy", () => {


### PR DESCRIPTION
Adds Taproot as a multisig script type, next to Legacy / Nested SegWit / Native SegWit.

Key derivation on Taproot · BIP86 now emits a paste-ready co-signer export:

`[fingerprint/86h/coinh/accounth]xpub…`

Multisig accepts those origins, and also BIP48 script-path keys at `48h/…/3h`. Script type auto-selects when the co-signer keys agree.

The watch-only descriptor is script-path only:

`tr(<BIP341 NUMS>,sortedmulti_a(m,keys/<0;1>/*))#checksum`

Internal key is the BIP341 NUMS point, so spending is only possible through the `multi_a` leaf. Addresses are `bc1p…`. The existing descriptor QR is used as-is.

`test/descriptor.test.mjs` and `test/ui-defaults.test.mjs` cover origin detection, the NUMS/`sortedmulti_a` payload, and the new script-type option. A local 2-of-2 from the abandon and zoo 12-word vectors derived `bc1psm7mx7ng7wc52eetrsnk0z864hdqpjqtfrw0vpvs2jyal59s5g7ql267q4`. Sparrow/signer import is not in this PR.