### PR TITLE
Add an address match check on derived wallets

### DIFF
--- a/entropylab-0.1.3.html
+++ b/entropylab-0.1.3.html
@@ -913,6 +913,9 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .wallet-result-messages h3 { margin: 0 0 8px; }
 .wallet-result-messages ul { display: grid; gap: 7px; margin: 0; padding-left: 20px; }
 .wallet-result-messages li { color: var(--muted); font-size: 13px; line-height: 1.5; }
+.address-match-field { margin: 22px 0 0; }
+.address-match-field input { font-family: var(--mono); }
+.address-match-field .hint { display: block; margin-top: var(--space-control); }
 .wallet-result-messages li.is-warning { color: var(--fg); }
 .wallet-result-messages li.is-warning::marker { color: var(--warn); }
 .wallet-data-fields { margin-top: 16px; }
@@ -3802,6 +3805,61 @@ function hodlRenderMultisigCosignerExport(exports,accountId){
   let items=Array.isArray(exports)?exports.filter(candidate=>candidate.accountId===accountId):[];
   return items.map(item=>ye(`Multisig co-signer ${item.prefix} · ${item.label}`,item.value)).join("")
 }
+function hodlNormalizeAddressCheck(value){
+  let text=String(value??"").trim();
+  if(!text)return"";
+  text=text.replace(/^bitcoin:/i,"").replace(/\?.*$/,"").trim();
+  if(/^(bc1|tb1|bcrt1)/i.test(text)){
+    if(/[A-Z]/.test(text)&&/[a-z]/.test(text))return text;
+    return text.toLowerCase();
+  }
+  return text
+}
+function hodlAddressesEqual(left,right){
+  if(!left||!right)return!1;
+  if(/^(bc1|tb1|bcrt1)/i.test(left)|| /^(bc1|tb1|bcrt1)/i.test(right))return left.toLowerCase()===right.toLowerCase();
+  return left===right
+}
+function hodlMatchDerivedAddress(raw,receive=[],change=[]){
+  let address=hodlNormalizeAddressCheck(raw);
+  if(!address)return{state:"empty"};
+  let find=(rows,chain)=>{
+    for(let row of rows||[])if(hodlAddressesEqual(address,String(row.address||"")))return{state:"match",chain,index:row.index,path:row.path,address:row.address};
+    return null
+  };
+  return find(receive,"receive")||find(change,"change")||{state:"miss",receiveCount:(receive||[]).length,changeCount:(change||[]).length}
+}
+function hodlAddressCheckRows(){
+  if(re?.kind==="msig")return{receive:re.receive||[],change:re.change||[]};
+  if(re?.kind==="hd"){
+    let id=hodlSelectedScriptType(),account=re.accounts.find(candidate=>candidate.def.id===id)||re.accounts[0];
+    return{receive:account?.receive||[],change:account?.change||[]}
+  }
+  return{receive:[],change:[]}
+}
+function hodlAddressMatchMarkup(){
+  return `<label class="field address-match-field">Check an address
+    <input id="address-match" autocomplete="off" spellcheck="false" placeholder="Paste bc1… or a 1… / 3… address">
+    <span class="field-note">Paste a receive or change address shown by another wallet. A match means that wallet computed the same derivation as this one.</span>
+    <span class="hint" id="address-match-status" role="status"></span>
+  </label>`
+}
+function hodlBindAddressMatch(){
+  let input=document.getElementById("address-match"),status=document.getElementById("address-match-status");
+  if(!input||!status)return;
+  let update=()=>{
+    let rows=hodlAddressCheckRows(),result=hodlMatchDerivedAddress(input.value,rows.receive,rows.change);
+    if(result.state==="empty"){status.textContent="";status.className="hint";return}
+    if(result.state==="match"){
+      let chain=result.chain==="receive"?"Receive":"Change";
+      status.textContent=`${chain} address #${result.index} of this wallet · ${hodlDisplayDerivationPath(result.path)}`;
+      status.className="hint ok";return
+    }
+    status.textContent=`No match in the ${result.receiveCount} receive + ${result.changeCount} change addresses derived here. Raise Addresses and derive again, or this is a different wallet.`;
+    status.className="hint bad"
+  };
+  input.oninput=update;update()
+}
 function hodlAddressTable(rows,label="Addresses",includeWif=false){
   let safeLabel=$t(includeWif?`${label} with WIF private keys`:label),tableClass=includeWif?"wallet-table-private":"wallet-table-public";
   let wifHeading=includeWif?'<th scope="col">WIF</th>':"";
@@ -3849,8 +3907,10 @@ function Qs(id){
         ${hodlAddressTable(account.receive,"Receive addresses",hasPrivate)}
         <h4 class="wallet-data-subtitle">Change</h4>
         ${hodlAddressTable(account.change,"Change addresses",hasPrivate)}
+        ${hodlAddressMatchMarkup()}
       </section>
-    </section>`
+    </section>`;
+  hodlBindAddressMatch()
 }
 function ye(label,value){return`<p><span class="muted">${$t(label)}</span><br><span class="mono">${$t(value??"\u2014")}</span></p>`}
 function hodlPrivateValue(value,className="secret private-field-value"){let mask="************",text=String(value??"\u2014");if(Ge)return`<span class="${className}">${$t(text)}</span>`;let bullets="\u2022".repeat(Math.max(Array.from(text).length,mask.length));return`<span class="${className} secret-placeholder"><span class="secret-placeholder-mask" aria-hidden="true">${bullets}</span><span class="secret-placeholder-message" aria-hidden="true">${mask}</span><span class="secret-placeholder-label">Private value hidden</span></span>`}
@@ -4012,6 +4072,7 @@ function hodlBindWalletResultActions(){
   if(save){let clean=save.cloneNode(!0);save.replaceWith(clean);clean.addEventListener("click",hodlDownloadRecoverySheet)}
   let walletDat=document.getElementById("download-wallet-dat");
   if(walletDat){let clean=walletDat.cloneNode(!0);walletDat.replaceWith(clean);clean.addEventListener("click",hodlDownloadWalletDat)}
+  hodlBindAddressMatch()
 }
 function hodlFocusWalletResult(){
   requestAnimationFrame(()=>dr.querySelector(".wallet-data-intro h2, .account-result-card > h2")?.focus({preventScroll:!1}))
@@ -5658,9 +5719,12 @@ function hodlShowMsig(){if(!re||re.kind!=="msig")return;Ge=!1;let accountLabel=r
         ${hodlAddressTable(re.receive,"Multisig receive addresses")}
         <h4 class="wallet-data-subtitle">Change</h4>
         ${hodlAddressTable(re.change,"Multisig change addresses")}
+        ${hodlAddressMatchMarkup()}
       </section>
       <p class="muted">Import the watch-only wallet descriptor into Sparrow or another wallet.</p>
-    </section>`}
+    </section>`;
+  hodlBindAddressMatch()
+}
 
 function hodlDiceCompare(){}
 var hodlPsbtPriv=null,hodlPsbtHd=null,hodlPsbtSource="",hodlPsbtNote="No session key. Inspect-only mode.";

--- a/entropylab-0.1.3.html
+++ b/entropylab-0.1.3.html
@@ -3840,22 +3840,57 @@ function hodlAddressCheckRows(){
 function hodlAddressMatchMarkup(){
   return `<label class="field address-match-field">Check an address
     <input id="address-match" autocomplete="off" spellcheck="false" placeholder="Paste bc1… or a 1… / 3… address">
-    <span class="field-note">Paste a receive or change address shown by another wallet. A match means that wallet computed the same derivation as this one.</span>
+    <span class="field-note">Paste a receive or change address shown by another wallet. A match means that wallet computed the same derivation, even if the index is beyond the table above.</span>
     <span class="hint" id="address-match-status" role="status"></span>
   </label>`
+}
+var hodlAddressSearchLimit=1000;
+function hodlMatchHdAddressBeyond(address,account,start){
+  let xpub=account?.xpub||account?.genericPublic;if(!xpub||!account?.def)return{state:"miss",searchedTo:start};
+  let node=Gt.fromExtendedKey(xpub),network=account.network||re.network,script=account.def.script,base=account.accountPath||"m";
+  for(let index=start;index<hodlAddressSearchLimit;index++){
+    for(let [chain,role] of [[0,"receive"],[1,"change"]]){
+      let child=node.derive(`m/${chain}/${index}`),pk=child.publicKey;if(!pk)continue;
+      if(hodlAddressesEqual(address,pf(script,pk,network)))return{state:"match",chain:role,index,path:`${base}/${chain}/${index}`,beyond:!0}
+    }
+  }
+  return{state:"miss",searchedTo:hodlAddressSearchLimit-1}
+}
+function hodlMatchMsigAddressBeyond(address,start){
+  let nodes=re?.nodes;if(!nodes?.length)return{state:"miss",searchedTo:start};
+  let bip45=re.script==="p2sh"&&re.scriptStandard==="bip45",receivePath=bip45?"m/0/0/":"m/0/",changePath=bip45?"m/0/1/":"m/1/";
+  for(let index=start;index<hodlAddressSearchLimit;index++){
+    let receiveKeys=nodes.map(node=>{let key=node.derive(receivePath+index).publicKey;if(!key)throw new Error("Could not derive a public key");return key});
+    if(hodlAddressesEqual(address,hodlMsigAddr(receiveKeys,re.m,re.network,re.script).address))return{state:"match",chain:"receive",index,path:receivePath.slice(1)+index,beyond:!0};
+    let changeKeys=nodes.map(node=>{let key=node.derive(changePath+index).publicKey;if(!key)throw new Error("Could not derive a public key");return key});
+    if(hodlAddressesEqual(address,hodlMsigAddr(changeKeys,re.m,re.network,re.script).address))return{state:"match",chain:"change",index,path:changePath.slice(1)+index,beyond:!0}
+  }
+  return{state:"miss",searchedTo:hodlAddressSearchLimit-1}
 }
 function hodlBindAddressMatch(){
   let input=document.getElementById("address-match"),status=document.getElementById("address-match-status");
   if(!input||!status)return;
   let update=()=>{
-    let rows=hodlAddressCheckRows(),result=hodlMatchDerivedAddress(input.value,rows.receive,rows.change);
+    let rows=hodlAddressCheckRows(),shown=Math.max(rows.receive.length,rows.change.length),result=hodlMatchDerivedAddress(input.value,rows.receive,rows.change);
     if(result.state==="empty"){status.textContent="";status.className="hint";return}
-    if(result.state==="match"){
-      let chain=result.chain==="receive"?"Receive":"Change";
-      status.textContent=`${chain} address #${result.index} of this wallet · ${hodlDisplayDerivationPath(result.path)}`;
-      status.className="hint ok";return
-    }
-    status.textContent=`No match in the ${result.receiveCount} receive + ${result.changeCount} change addresses derived here. Raise Addresses and derive again, or this is a different wallet.`;
+    let showMatch=hit=>{
+      let chain=hit.chain==="receive"?"Receive":"Change",extra=hit.beyond?` (beyond the ${shown} shown)`:"";
+      status.textContent=`${chain} address #${hit.index} of this wallet · ${hodlDisplayDerivationPath(hit.path)}${extra}`;
+      status.className="hint ok"
+    };
+    if(result.state==="match"){showMatch(result);return}
+    let address=hodlNormalizeAddressCheck(input.value);
+    status.textContent=`Not in the ${shown} shown addresses. Checking further indices…`;
+    status.className="hint";
+    let beyond={state:"miss",searchedTo:shown};
+    try{
+      if(re?.kind==="hd"){
+        let id=hodlSelectedScriptType(),account=re.accounts.find(candidate=>candidate.def.id===id)||re.accounts[0];
+        beyond=hodlMatchHdAddressBeyond(address,account,shown)
+      }else if(re?.kind==="msig")beyond=hodlMatchMsigAddressBeyond(address,shown)
+    }catch(error){beyond={state:"miss",searchedTo:shown}}
+    if(beyond.state==="match"){showMatch(beyond);return}
+    status.textContent=`No match in receive or change indices 0–${beyond.searchedTo??hodlAddressSearchLimit-1} of this derivation.`;
     status.className="hint bad"
   };
   input.oninput=update;update()
@@ -5692,7 +5727,7 @@ function hodlBuildMsig(){
     let notes=["This is watch-only. Private keys never entered this calculator.","Each key origin lets a signer match its seed to one co-signer.","A signer is only needed when you spend."];
     if(bip45)notes.push("Legacy BIP45 addresses use co-signer branch 0 for this receive and change set.");
     if(kind==="p2sh"&&legacyStandard==="bip87")notes.push("Legacy P2SH uses the selected BIP87 account paths. Keep the descriptor with every seed backup.");
-    re={kind:"msig",network,m,n,script:kind,scriptStandard:kind==="p2sh"?legacyStandard:"bip48",account:accountSummary.account,accountMixed:accountSummary.mixed,xpubs,receiveDescriptor:Le(descriptor),changeDescriptor:Le(changeDescriptor),walletDescriptor:hodlWatchOnlyMultipathDescriptor(Le(descriptor)),receive,change,notes,warnings:accountWarning?[accountWarning]:[]};
+    re={kind:"msig",network,m,n,script:kind,scriptStandard:kind==="p2sh"?legacyStandard:"bip48",account:accountSummary.account,accountMixed:accountSummary.mixed,nodes,xpubs,receiveDescriptor:Le(descriptor),changeDescriptor:Le(changeDescriptor),walletDescriptor:hodlWatchOnlyMultipathDescriptor(Le(descriptor)),receive,change,notes,warnings:accountWarning?[accountWarning]:[]};
     hodlCaptureMsig();hodlShowMsig();hodlFocusWalletResult()
   }catch(exception){re=null;dr.innerHTML="";error.textContent=exception.message||String(exception);hodlCaptureMsig()}
 }

--- a/index.html
+++ b/index.html
@@ -913,6 +913,9 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .wallet-result-messages h3 { margin: 0 0 8px; }
 .wallet-result-messages ul { display: grid; gap: 7px; margin: 0; padding-left: 20px; }
 .wallet-result-messages li { color: var(--muted); font-size: 13px; line-height: 1.5; }
+.address-match-field { margin: 22px 0 0; }
+.address-match-field input { font-family: var(--mono); }
+.address-match-field .hint { display: block; margin-top: var(--space-control); }
 .wallet-result-messages li.is-warning { color: var(--fg); }
 .wallet-result-messages li.is-warning::marker { color: var(--warn); }
 .wallet-data-fields { margin-top: 16px; }
@@ -3802,6 +3805,61 @@ function hodlRenderMultisigCosignerExport(exports,accountId){
   let items=Array.isArray(exports)?exports.filter(candidate=>candidate.accountId===accountId):[];
   return items.map(item=>ye(`Multisig co-signer ${item.prefix} · ${item.label}`,item.value)).join("")
 }
+function hodlNormalizeAddressCheck(value){
+  let text=String(value??"").trim();
+  if(!text)return"";
+  text=text.replace(/^bitcoin:/i,"").replace(/\?.*$/,"").trim();
+  if(/^(bc1|tb1|bcrt1)/i.test(text)){
+    if(/[A-Z]/.test(text)&&/[a-z]/.test(text))return text;
+    return text.toLowerCase();
+  }
+  return text
+}
+function hodlAddressesEqual(left,right){
+  if(!left||!right)return!1;
+  if(/^(bc1|tb1|bcrt1)/i.test(left)|| /^(bc1|tb1|bcrt1)/i.test(right))return left.toLowerCase()===right.toLowerCase();
+  return left===right
+}
+function hodlMatchDerivedAddress(raw,receive=[],change=[]){
+  let address=hodlNormalizeAddressCheck(raw);
+  if(!address)return{state:"empty"};
+  let find=(rows,chain)=>{
+    for(let row of rows||[])if(hodlAddressesEqual(address,String(row.address||"")))return{state:"match",chain,index:row.index,path:row.path,address:row.address};
+    return null
+  };
+  return find(receive,"receive")||find(change,"change")||{state:"miss",receiveCount:(receive||[]).length,changeCount:(change||[]).length}
+}
+function hodlAddressCheckRows(){
+  if(re?.kind==="msig")return{receive:re.receive||[],change:re.change||[]};
+  if(re?.kind==="hd"){
+    let id=hodlSelectedScriptType(),account=re.accounts.find(candidate=>candidate.def.id===id)||re.accounts[0];
+    return{receive:account?.receive||[],change:account?.change||[]}
+  }
+  return{receive:[],change:[]}
+}
+function hodlAddressMatchMarkup(){
+  return `<label class="field address-match-field">Check an address
+    <input id="address-match" autocomplete="off" spellcheck="false" placeholder="Paste bc1… or a 1… / 3… address">
+    <span class="field-note">Paste a receive or change address shown by another wallet. A match means that wallet computed the same derivation as this one.</span>
+    <span class="hint" id="address-match-status" role="status"></span>
+  </label>`
+}
+function hodlBindAddressMatch(){
+  let input=document.getElementById("address-match"),status=document.getElementById("address-match-status");
+  if(!input||!status)return;
+  let update=()=>{
+    let rows=hodlAddressCheckRows(),result=hodlMatchDerivedAddress(input.value,rows.receive,rows.change);
+    if(result.state==="empty"){status.textContent="";status.className="hint";return}
+    if(result.state==="match"){
+      let chain=result.chain==="receive"?"Receive":"Change";
+      status.textContent=`${chain} address #${result.index} of this wallet · ${hodlDisplayDerivationPath(result.path)}`;
+      status.className="hint ok";return
+    }
+    status.textContent=`No match in the ${result.receiveCount} receive + ${result.changeCount} change addresses derived here. Raise Addresses and derive again, or this is a different wallet.`;
+    status.className="hint bad"
+  };
+  input.oninput=update;update()
+}
 function hodlAddressTable(rows,label="Addresses",includeWif=false){
   let safeLabel=$t(includeWif?`${label} with WIF private keys`:label),tableClass=includeWif?"wallet-table-private":"wallet-table-public";
   let wifHeading=includeWif?'<th scope="col">WIF</th>':"";
@@ -3849,8 +3907,10 @@ function Qs(id){
         ${hodlAddressTable(account.receive,"Receive addresses",hasPrivate)}
         <h4 class="wallet-data-subtitle">Change</h4>
         ${hodlAddressTable(account.change,"Change addresses",hasPrivate)}
+        ${hodlAddressMatchMarkup()}
       </section>
-    </section>`
+    </section>`;
+  hodlBindAddressMatch()
 }
 function ye(label,value){return`<p><span class="muted">${$t(label)}</span><br><span class="mono">${$t(value??"\u2014")}</span></p>`}
 function hodlPrivateValue(value,className="secret private-field-value"){let mask="************",text=String(value??"\u2014");if(Ge)return`<span class="${className}">${$t(text)}</span>`;let bullets="\u2022".repeat(Math.max(Array.from(text).length,mask.length));return`<span class="${className} secret-placeholder"><span class="secret-placeholder-mask" aria-hidden="true">${bullets}</span><span class="secret-placeholder-message" aria-hidden="true">${mask}</span><span class="secret-placeholder-label">Private value hidden</span></span>`}
@@ -4012,6 +4072,7 @@ function hodlBindWalletResultActions(){
   if(save){let clean=save.cloneNode(!0);save.replaceWith(clean);clean.addEventListener("click",hodlDownloadRecoverySheet)}
   let walletDat=document.getElementById("download-wallet-dat");
   if(walletDat){let clean=walletDat.cloneNode(!0);walletDat.replaceWith(clean);clean.addEventListener("click",hodlDownloadWalletDat)}
+  hodlBindAddressMatch()
 }
 function hodlFocusWalletResult(){
   requestAnimationFrame(()=>dr.querySelector(".wallet-data-intro h2, .account-result-card > h2")?.focus({preventScroll:!1}))
@@ -5658,9 +5719,12 @@ function hodlShowMsig(){if(!re||re.kind!=="msig")return;Ge=!1;let accountLabel=r
         ${hodlAddressTable(re.receive,"Multisig receive addresses")}
         <h4 class="wallet-data-subtitle">Change</h4>
         ${hodlAddressTable(re.change,"Multisig change addresses")}
+        ${hodlAddressMatchMarkup()}
       </section>
       <p class="muted">Import the watch-only wallet descriptor into Sparrow or another wallet.</p>
-    </section>`}
+    </section>`;
+  hodlBindAddressMatch()
+}
 
 function hodlDiceCompare(){}
 var hodlPsbtPriv=null,hodlPsbtHd=null,hodlPsbtSource="",hodlPsbtNote="No session key. Inspect-only mode.";

--- a/index.html
+++ b/index.html
@@ -3840,22 +3840,57 @@ function hodlAddressCheckRows(){
 function hodlAddressMatchMarkup(){
   return `<label class="field address-match-field">Check an address
     <input id="address-match" autocomplete="off" spellcheck="false" placeholder="Paste bc1… or a 1… / 3… address">
-    <span class="field-note">Paste a receive or change address shown by another wallet. A match means that wallet computed the same derivation as this one.</span>
+    <span class="field-note">Paste a receive or change address shown by another wallet. A match means that wallet computed the same derivation, even if the index is beyond the table above.</span>
     <span class="hint" id="address-match-status" role="status"></span>
   </label>`
+}
+var hodlAddressSearchLimit=1000;
+function hodlMatchHdAddressBeyond(address,account,start){
+  let xpub=account?.xpub||account?.genericPublic;if(!xpub||!account?.def)return{state:"miss",searchedTo:start};
+  let node=Gt.fromExtendedKey(xpub),network=account.network||re.network,script=account.def.script,base=account.accountPath||"m";
+  for(let index=start;index<hodlAddressSearchLimit;index++){
+    for(let [chain,role] of [[0,"receive"],[1,"change"]]){
+      let child=node.derive(`m/${chain}/${index}`),pk=child.publicKey;if(!pk)continue;
+      if(hodlAddressesEqual(address,pf(script,pk,network)))return{state:"match",chain:role,index,path:`${base}/${chain}/${index}`,beyond:!0}
+    }
+  }
+  return{state:"miss",searchedTo:hodlAddressSearchLimit-1}
+}
+function hodlMatchMsigAddressBeyond(address,start){
+  let nodes=re?.nodes;if(!nodes?.length)return{state:"miss",searchedTo:start};
+  let bip45=re.script==="p2sh"&&re.scriptStandard==="bip45",receivePath=bip45?"m/0/0/":"m/0/",changePath=bip45?"m/0/1/":"m/1/";
+  for(let index=start;index<hodlAddressSearchLimit;index++){
+    let receiveKeys=nodes.map(node=>{let key=node.derive(receivePath+index).publicKey;if(!key)throw new Error("Could not derive a public key");return key});
+    if(hodlAddressesEqual(address,hodlMsigAddr(receiveKeys,re.m,re.network,re.script).address))return{state:"match",chain:"receive",index,path:receivePath.slice(1)+index,beyond:!0};
+    let changeKeys=nodes.map(node=>{let key=node.derive(changePath+index).publicKey;if(!key)throw new Error("Could not derive a public key");return key});
+    if(hodlAddressesEqual(address,hodlMsigAddr(changeKeys,re.m,re.network,re.script).address))return{state:"match",chain:"change",index,path:changePath.slice(1)+index,beyond:!0}
+  }
+  return{state:"miss",searchedTo:hodlAddressSearchLimit-1}
 }
 function hodlBindAddressMatch(){
   let input=document.getElementById("address-match"),status=document.getElementById("address-match-status");
   if(!input||!status)return;
   let update=()=>{
-    let rows=hodlAddressCheckRows(),result=hodlMatchDerivedAddress(input.value,rows.receive,rows.change);
+    let rows=hodlAddressCheckRows(),shown=Math.max(rows.receive.length,rows.change.length),result=hodlMatchDerivedAddress(input.value,rows.receive,rows.change);
     if(result.state==="empty"){status.textContent="";status.className="hint";return}
-    if(result.state==="match"){
-      let chain=result.chain==="receive"?"Receive":"Change";
-      status.textContent=`${chain} address #${result.index} of this wallet · ${hodlDisplayDerivationPath(result.path)}`;
-      status.className="hint ok";return
-    }
-    status.textContent=`No match in the ${result.receiveCount} receive + ${result.changeCount} change addresses derived here. Raise Addresses and derive again, or this is a different wallet.`;
+    let showMatch=hit=>{
+      let chain=hit.chain==="receive"?"Receive":"Change",extra=hit.beyond?` (beyond the ${shown} shown)`:"";
+      status.textContent=`${chain} address #${hit.index} of this wallet · ${hodlDisplayDerivationPath(hit.path)}${extra}`;
+      status.className="hint ok"
+    };
+    if(result.state==="match"){showMatch(result);return}
+    let address=hodlNormalizeAddressCheck(input.value);
+    status.textContent=`Not in the ${shown} shown addresses. Checking further indices…`;
+    status.className="hint";
+    let beyond={state:"miss",searchedTo:shown};
+    try{
+      if(re?.kind==="hd"){
+        let id=hodlSelectedScriptType(),account=re.accounts.find(candidate=>candidate.def.id===id)||re.accounts[0];
+        beyond=hodlMatchHdAddressBeyond(address,account,shown)
+      }else if(re?.kind==="msig")beyond=hodlMatchMsigAddressBeyond(address,shown)
+    }catch(error){beyond={state:"miss",searchedTo:shown}}
+    if(beyond.state==="match"){showMatch(beyond);return}
+    status.textContent=`No match in receive or change indices 0–${beyond.searchedTo??hodlAddressSearchLimit-1} of this derivation.`;
     status.className="hint bad"
   };
   input.oninput=update;update()
@@ -5692,7 +5727,7 @@ function hodlBuildMsig(){
     let notes=["This is watch-only. Private keys never entered this calculator.","Each key origin lets a signer match its seed to one co-signer.","A signer is only needed when you spend."];
     if(bip45)notes.push("Legacy BIP45 addresses use co-signer branch 0 for this receive and change set.");
     if(kind==="p2sh"&&legacyStandard==="bip87")notes.push("Legacy P2SH uses the selected BIP87 account paths. Keep the descriptor with every seed backup.");
-    re={kind:"msig",network,m,n,script:kind,scriptStandard:kind==="p2sh"?legacyStandard:"bip48",account:accountSummary.account,accountMixed:accountSummary.mixed,xpubs,receiveDescriptor:Le(descriptor),changeDescriptor:Le(changeDescriptor),walletDescriptor:hodlWatchOnlyMultipathDescriptor(Le(descriptor)),receive,change,notes,warnings:accountWarning?[accountWarning]:[]};
+    re={kind:"msig",network,m,n,script:kind,scriptStandard:kind==="p2sh"?legacyStandard:"bip48",account:accountSummary.account,accountMixed:accountSummary.mixed,nodes,xpubs,receiveDescriptor:Le(descriptor),changeDescriptor:Le(changeDescriptor),walletDescriptor:hodlWatchOnlyMultipathDescriptor(Le(descriptor)),receive,change,notes,warnings:accountWarning?[accountWarning]:[]};
     hodlCaptureMsig();hodlShowMsig();hodlFocusWalletResult()
   }catch(exception){re=null;dr.innerHTML="";error.textContent=exception.message||String(exception);hodlCaptureMsig()}
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "node scripts/build.mjs",
     "clean": "node scripts/build.mjs --clean",
     "test": "node --test test/*.test.mjs",
-    "test:ci": "node --test test/network-check.test.mjs test/browser-check.test.mjs test/ui-defaults.test.mjs test/validate.test.mjs test/descriptor.test.mjs test/seedqr.test.mjs test/cards.test.mjs test/copy-seed.test.mjs test/number-bases.test.mjs test/psbt-low-r.test.mjs test/sqlite-writer.test.mjs test/wallet-export.test.mjs test/psbt-anti-exfil.test.mjs",
+    "test:ci": "node --test test/network-check.test.mjs test/browser-check.test.mjs test/ui-defaults.test.mjs test/validate.test.mjs test/descriptor.test.mjs test/seedqr.test.mjs test/cards.test.mjs test/copy-seed.test.mjs test/number-bases.test.mjs test/psbt-low-r.test.mjs test/sqlite-writer.test.mjs test/wallet-export.test.mjs test/psbt-anti-exfil.test.mjs test/address-match.test.mjs",
     "test:network": "node --test test/network-check.test.mjs",
     "test:browser-check": "node --test test/browser-check.test.mjs",
     "test:ui": "node --test test/ui-defaults.test.mjs",

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -911,6 +911,9 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .wallet-result-messages h3 { margin: 0 0 8px; }
 .wallet-result-messages ul { display: grid; gap: 7px; margin: 0; padding-left: 20px; }
 .wallet-result-messages li { color: var(--muted); font-size: 13px; line-height: 1.5; }
+.address-match-field { margin: 22px 0 0; }
+.address-match-field input { font-family: var(--mono); }
+.address-match-field .hint { display: block; margin-top: var(--space-control); }
 .wallet-result-messages li.is-warning { color: var(--fg); }
 .wallet-result-messages li.is-warning::marker { color: var(--warn); }
 .wallet-data-fields { margin-top: 16px; }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -444,22 +444,57 @@ function hodlAddressCheckRows(){
 function hodlAddressMatchMarkup(){
   return `<label class="field address-match-field">Check an address
     <input id="address-match" autocomplete="off" spellcheck="false" placeholder="Paste bc1… or a 1… / 3… address">
-    <span class="field-note">Paste a receive or change address shown by another wallet. A match means that wallet computed the same derivation as this one.</span>
+    <span class="field-note">Paste a receive or change address shown by another wallet. A match means that wallet computed the same derivation, even if the index is beyond the table above.</span>
     <span class="hint" id="address-match-status" role="status"></span>
   </label>`
+}
+var hodlAddressSearchLimit=1000;
+function hodlMatchHdAddressBeyond(address,account,start){
+  let xpub=account?.xpub||account?.genericPublic;if(!xpub||!account?.def)return{state:"miss",searchedTo:start};
+  let node=Gt.fromExtendedKey(xpub),network=account.network||re.network,script=account.def.script,base=account.accountPath||"m";
+  for(let index=start;index<hodlAddressSearchLimit;index++){
+    for(let [chain,role] of [[0,"receive"],[1,"change"]]){
+      let child=node.derive(`m/${chain}/${index}`),pk=child.publicKey;if(!pk)continue;
+      if(hodlAddressesEqual(address,pf(script,pk,network)))return{state:"match",chain:role,index,path:`${base}/${chain}/${index}`,beyond:!0}
+    }
+  }
+  return{state:"miss",searchedTo:hodlAddressSearchLimit-1}
+}
+function hodlMatchMsigAddressBeyond(address,start){
+  let nodes=re?.nodes;if(!nodes?.length)return{state:"miss",searchedTo:start};
+  let bip45=re.script==="p2sh"&&re.scriptStandard==="bip45",receivePath=bip45?"m/0/0/":"m/0/",changePath=bip45?"m/0/1/":"m/1/";
+  for(let index=start;index<hodlAddressSearchLimit;index++){
+    let receiveKeys=nodes.map(node=>{let key=node.derive(receivePath+index).publicKey;if(!key)throw new Error("Could not derive a public key");return key});
+    if(hodlAddressesEqual(address,hodlMsigAddr(receiveKeys,re.m,re.network,re.script).address))return{state:"match",chain:"receive",index,path:receivePath.slice(1)+index,beyond:!0};
+    let changeKeys=nodes.map(node=>{let key=node.derive(changePath+index).publicKey;if(!key)throw new Error("Could not derive a public key");return key});
+    if(hodlAddressesEqual(address,hodlMsigAddr(changeKeys,re.m,re.network,re.script).address))return{state:"match",chain:"change",index,path:changePath.slice(1)+index,beyond:!0}
+  }
+  return{state:"miss",searchedTo:hodlAddressSearchLimit-1}
 }
 function hodlBindAddressMatch(){
   let input=document.getElementById("address-match"),status=document.getElementById("address-match-status");
   if(!input||!status)return;
   let update=()=>{
-    let rows=hodlAddressCheckRows(),result=hodlMatchDerivedAddress(input.value,rows.receive,rows.change);
+    let rows=hodlAddressCheckRows(),shown=Math.max(rows.receive.length,rows.change.length),result=hodlMatchDerivedAddress(input.value,rows.receive,rows.change);
     if(result.state==="empty"){status.textContent="";status.className="hint";return}
-    if(result.state==="match"){
-      let chain=result.chain==="receive"?"Receive":"Change";
-      status.textContent=`${chain} address #${result.index} of this wallet · ${hodlDisplayDerivationPath(result.path)}`;
-      status.className="hint ok";return
-    }
-    status.textContent=`No match in the ${result.receiveCount} receive + ${result.changeCount} change addresses derived here. Raise Addresses and derive again, or this is a different wallet.`;
+    let showMatch=hit=>{
+      let chain=hit.chain==="receive"?"Receive":"Change",extra=hit.beyond?` (beyond the ${shown} shown)`:"";
+      status.textContent=`${chain} address #${hit.index} of this wallet · ${hodlDisplayDerivationPath(hit.path)}${extra}`;
+      status.className="hint ok"
+    };
+    if(result.state==="match"){showMatch(result);return}
+    let address=hodlNormalizeAddressCheck(input.value);
+    status.textContent=`Not in the ${shown} shown addresses. Checking further indices…`;
+    status.className="hint";
+    let beyond={state:"miss",searchedTo:shown};
+    try{
+      if(re?.kind==="hd"){
+        let id=hodlSelectedScriptType(),account=re.accounts.find(candidate=>candidate.def.id===id)||re.accounts[0];
+        beyond=hodlMatchHdAddressBeyond(address,account,shown)
+      }else if(re?.kind==="msig")beyond=hodlMatchMsigAddressBeyond(address,shown)
+    }catch(error){beyond={state:"miss",searchedTo:shown}}
+    if(beyond.state==="match"){showMatch(beyond);return}
+    status.textContent=`No match in receive or change indices 0–${beyond.searchedTo??hodlAddressSearchLimit-1} of this derivation.`;
     status.className="hint bad"
   };
   input.oninput=update;update()
@@ -2296,7 +2331,7 @@ function hodlBuildMsig(){
     let notes=["This is watch-only. Private keys never entered this calculator.","Each key origin lets a signer match its seed to one co-signer.","A signer is only needed when you spend."];
     if(bip45)notes.push("Legacy BIP45 addresses use co-signer branch 0 for this receive and change set.");
     if(kind==="p2sh"&&legacyStandard==="bip87")notes.push("Legacy P2SH uses the selected BIP87 account paths. Keep the descriptor with every seed backup.");
-    re={kind:"msig",network,m,n,script:kind,scriptStandard:kind==="p2sh"?legacyStandard:"bip48",account:accountSummary.account,accountMixed:accountSummary.mixed,xpubs,receiveDescriptor:Le(descriptor),changeDescriptor:Le(changeDescriptor),walletDescriptor:hodlWatchOnlyMultipathDescriptor(Le(descriptor)),receive,change,notes,warnings:accountWarning?[accountWarning]:[]};
+    re={kind:"msig",network,m,n,script:kind,scriptStandard:kind==="p2sh"?legacyStandard:"bip48",account:accountSummary.account,accountMixed:accountSummary.mixed,nodes,xpubs,receiveDescriptor:Le(descriptor),changeDescriptor:Le(changeDescriptor),walletDescriptor:hodlWatchOnlyMultipathDescriptor(Le(descriptor)),receive,change,notes,warnings:accountWarning?[accountWarning]:[]};
     hodlCaptureMsig();hodlShowMsig();hodlFocusWalletResult()
   }catch(exception){re=null;dr.innerHTML="";error.textContent=exception.message||String(exception);hodlCaptureMsig()}
 }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -409,6 +409,61 @@ function hodlRenderMultisigCosignerExport(exports,accountId){
   let items=Array.isArray(exports)?exports.filter(candidate=>candidate.accountId===accountId):[];
   return items.map(item=>ye(`Multisig co-signer ${item.prefix} · ${item.label}`,item.value)).join("")
 }
+function hodlNormalizeAddressCheck(value){
+  let text=String(value??"").trim();
+  if(!text)return"";
+  text=text.replace(/^bitcoin:/i,"").replace(/\?.*$/,"").trim();
+  if(/^(bc1|tb1|bcrt1)/i.test(text)){
+    if(/[A-Z]/.test(text)&&/[a-z]/.test(text))return text;
+    return text.toLowerCase();
+  }
+  return text
+}
+function hodlAddressesEqual(left,right){
+  if(!left||!right)return!1;
+  if(/^(bc1|tb1|bcrt1)/i.test(left)|| /^(bc1|tb1|bcrt1)/i.test(right))return left.toLowerCase()===right.toLowerCase();
+  return left===right
+}
+function hodlMatchDerivedAddress(raw,receive=[],change=[]){
+  let address=hodlNormalizeAddressCheck(raw);
+  if(!address)return{state:"empty"};
+  let find=(rows,chain)=>{
+    for(let row of rows||[])if(hodlAddressesEqual(address,String(row.address||"")))return{state:"match",chain,index:row.index,path:row.path,address:row.address};
+    return null
+  };
+  return find(receive,"receive")||find(change,"change")||{state:"miss",receiveCount:(receive||[]).length,changeCount:(change||[]).length}
+}
+function hodlAddressCheckRows(){
+  if(re?.kind==="msig")return{receive:re.receive||[],change:re.change||[]};
+  if(re?.kind==="hd"){
+    let id=hodlSelectedScriptType(),account=re.accounts.find(candidate=>candidate.def.id===id)||re.accounts[0];
+    return{receive:account?.receive||[],change:account?.change||[]}
+  }
+  return{receive:[],change:[]}
+}
+function hodlAddressMatchMarkup(){
+  return `<label class="field address-match-field">Check an address
+    <input id="address-match" autocomplete="off" spellcheck="false" placeholder="Paste bc1… or a 1… / 3… address">
+    <span class="field-note">Paste a receive or change address shown by another wallet. A match means that wallet computed the same derivation as this one.</span>
+    <span class="hint" id="address-match-status" role="status"></span>
+  </label>`
+}
+function hodlBindAddressMatch(){
+  let input=document.getElementById("address-match"),status=document.getElementById("address-match-status");
+  if(!input||!status)return;
+  let update=()=>{
+    let rows=hodlAddressCheckRows(),result=hodlMatchDerivedAddress(input.value,rows.receive,rows.change);
+    if(result.state==="empty"){status.textContent="";status.className="hint";return}
+    if(result.state==="match"){
+      let chain=result.chain==="receive"?"Receive":"Change";
+      status.textContent=`${chain} address #${result.index} of this wallet · ${hodlDisplayDerivationPath(result.path)}`;
+      status.className="hint ok";return
+    }
+    status.textContent=`No match in the ${result.receiveCount} receive + ${result.changeCount} change addresses derived here. Raise Addresses and derive again, or this is a different wallet.`;
+    status.className="hint bad"
+  };
+  input.oninput=update;update()
+}
 function hodlAddressTable(rows,label="Addresses",includeWif=false){
   let safeLabel=$t(includeWif?`${label} with WIF private keys`:label),tableClass=includeWif?"wallet-table-private":"wallet-table-public";
   let wifHeading=includeWif?'<th scope="col">WIF</th>':"";
@@ -456,8 +511,10 @@ function Qs(id){
         ${hodlAddressTable(account.receive,"Receive addresses",hasPrivate)}
         <h4 class="wallet-data-subtitle">Change</h4>
         ${hodlAddressTable(account.change,"Change addresses",hasPrivate)}
+        ${hodlAddressMatchMarkup()}
       </section>
-    </section>`
+    </section>`;
+  hodlBindAddressMatch()
 }
 function ye(label,value){return`<p><span class="muted">${$t(label)}</span><br><span class="mono">${$t(value??"\u2014")}</span></p>`}
 function hodlPrivateValue(value,className="secret private-field-value"){let mask="************",text=String(value??"\u2014");if(Ge)return`<span class="${className}">${$t(text)}</span>`;let bullets="\u2022".repeat(Math.max(Array.from(text).length,mask.length));return`<span class="${className} secret-placeholder"><span class="secret-placeholder-mask" aria-hidden="true">${bullets}</span><span class="secret-placeholder-message" aria-hidden="true">${mask}</span><span class="secret-placeholder-label">Private value hidden</span></span>`}
@@ -619,6 +676,7 @@ function hodlBindWalletResultActions(){
   if(save){let clean=save.cloneNode(!0);save.replaceWith(clean);clean.addEventListener("click",hodlDownloadRecoverySheet)}
   let walletDat=document.getElementById("download-wallet-dat");
   if(walletDat){let clean=walletDat.cloneNode(!0);walletDat.replaceWith(clean);clean.addEventListener("click",hodlDownloadWalletDat)}
+  hodlBindAddressMatch()
 }
 function hodlFocusWalletResult(){
   requestAnimationFrame(()=>dr.querySelector(".wallet-data-intro h2, .account-result-card > h2")?.focus({preventScroll:!1}))
@@ -2265,9 +2323,12 @@ function hodlShowMsig(){if(!re||re.kind!=="msig")return;Ge=!1;let accountLabel=r
         ${hodlAddressTable(re.receive,"Multisig receive addresses")}
         <h4 class="wallet-data-subtitle">Change</h4>
         ${hodlAddressTable(re.change,"Multisig change addresses")}
+        ${hodlAddressMatchMarkup()}
       </section>
       <p class="muted">Import the watch-only wallet descriptor into Sparrow or another wallet.</p>
-    </section>`}
+    </section>`;
+  hodlBindAddressMatch()
+}
 
 function hodlDiceCompare(){}
 var hodlPsbtPriv=null,hodlPsbtHd=null,hodlPsbtSource="",hodlPsbtNote="No session key. Inspect-only mode.";

--- a/test/address-match.test.mjs
+++ b/test/address-match.test.mjs
@@ -1,0 +1,68 @@
+// Paste-an-address check against derived receive/change lists.
+// Run with `npm test`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const app = readFileSync(join(root, "src/js/app.js"), "utf8");
+
+function extract(startNeedle, endNeedle) {
+  const start = app.indexOf(startNeedle);
+  const end = app.indexOf(endNeedle, start);
+  if (start < 0 || end < 0) throw new Error(`extract failed: ${startNeedle}`);
+  return app.slice(start, end);
+}
+
+const path = join(root, "test", `.address-match-slice-${Math.random().toString(16).slice(2)}.mjs`);
+writeFileSync(
+  path,
+  `${extract("function hodlNormalizeAddressCheck", "function hodlAddressCheckRows")}\nexport { hodlNormalizeAddressCheck, hodlMatchDerivedAddress };\n`,
+);
+const { hodlNormalizeAddressCheck, hodlMatchDerivedAddress } = await import(pathToFileURL(path).href);
+unlinkSync(path);
+
+const receive = [
+  { index: 0, path: "0/0", address: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq" },
+  { index: 1, path: "0/1", address: "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4" },
+];
+const change = [{ index: 0, path: "1/0", address: "3J98t1WpEZ73CNmYviecrnyiWrnqRhWNLy" }];
+
+test("empty paste is empty state", () => {
+  assert.equal(hodlMatchDerivedAddress("  ", receive, change).state, "empty");
+});
+
+test("receive match reports chain and index", () => {
+  const result = hodlMatchDerivedAddress(
+    "bitcoin:BC1QAR0SRRR7XFKVY5L643LYDNW9RE59GTZZWF5MDQ",
+    receive,
+    change,
+  );
+  assert.equal(result.state, "match");
+  assert.equal(result.chain, "receive");
+  assert.equal(result.index, 0);
+});
+
+test("change match keeps base58 case", () => {
+  const result = hodlMatchDerivedAddress(change[0].address, receive, change);
+  assert.equal(result.state, "match");
+  assert.equal(result.chain, "change");
+  assert.equal(result.index, 0);
+});
+
+test("unknown address is a miss with derived counts", () => {
+  const result = hodlMatchDerivedAddress("bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh", receive, change);
+  assert.equal(result.state, "miss");
+  assert.equal(result.receiveCount, 2);
+  assert.equal(result.changeCount, 1);
+});
+
+test("normalize strips bitcoin URIs and lowercases bech32", () => {
+  assert.equal(
+    hodlNormalizeAddressCheck("bitcoin:BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4?amount=1"),
+    "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+  );
+  assert.equal(hodlNormalizeAddressCheck("  3J98t1WpEZ73CNmYviecrnyiWrnqRhWNLy  "), "3J98t1WpEZ73CNmYviecrnyiWrnqRhWNLy");
+});

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -275,6 +275,18 @@ test("key derivation shows the relevant paste-ready multisig co-signer exports",
   assert.match(app, /Legacy P2SH uses the selected BIP87 account paths/);
 });
 
+test("derived wallets offer an address match check", () => {
+  assert.match(app, /function hodlAddressMatchMarkup\(\)/);
+  assert.match(app, /id="address-match"/);
+  assert.match(app, /id="address-match-status"/);
+  assert.match(app, /address-match-field">Check an address/);
+  assert.match(app, /Paste a receive or change address shown by another wallet/);
+  assert.doesNotMatch(app, /Address from Sparrow/);
+  assert.match(app, /hodlAddressTable\(account\.change,"Change addresses",hasPrivate\)\}\s*\$\{hodlAddressMatchMarkup\(\)/);
+  assert.match(app, /hodlAddressTable\(re\.change,"Multisig change addresses"\)\}\s*\$\{hodlAddressMatchMarkup\(\)/);
+  assert.match(css, /\.address-match-field/);
+});
+
 test("Legacy multisig defaults to BIP45 and offers BIP87 accounts only for Legacy", () => {
   for (const markup of [template, app]) {
     assert.match(markup, /id="msig-legacy-account-toggle" hidden/);

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -281,7 +281,11 @@ test("derived wallets offer an address match check", () => {
   assert.match(app, /id="address-match-status"/);
   assert.match(app, /address-match-field">Check an address/);
   assert.match(app, /Paste a receive or change address shown by another wallet/);
+  assert.match(app, /even if the index is beyond the table above/);
   assert.doesNotMatch(app, /Address from Sparrow/);
+  assert.match(app, /var hodlAddressSearchLimit=1000/);
+  assert.match(app, /function hodlMatchHdAddressBeyond\(address,account,start\)/);
+  assert.match(app, /function hodlMatchMsigAddressBeyond\(address,start\)/);
   assert.match(app, /hodlAddressTable\(account\.change,"Change addresses",hasPrivate\)\}\s*\$\{hodlAddressMatchMarkup\(\)/);
   assert.match(app, /hodlAddressTable\(re\.change,"Multisig change addresses"\)\}\s*\$\{hodlAddressMatchMarkup\(\)/);
   assert.match(css, /\.address-match-field/);

--- a/test/wallet-export.test.mjs
+++ b/test/wallet-export.test.mjs
@@ -464,6 +464,7 @@ const le = (text, version) => {
 const cr = { mainnet: { x: { pub: 0x0488b21e } } };
 const Gt = { fromExtendedKey: (text) => hdNodeFrom(b58checkDecode(text)) };
 const xe = { getPublicKey: (secret) => publicKeyForPrivate(secret) };
+function hodlBindAddressMatch(){}
 ${extract("function hodlPrivateDataControls", "function hodlWalletMessages")}
 ${extract("function hodlWalletDatDeps", "function hodlFocusWalletResult")}
 ${sqliteSrc}


### PR DESCRIPTION
After derive, paste a receive or change address from another wallet. EntropyLab reports whether it is receive or change index N of this derivation, or that it is not in the addresses just generated.

The field sits under the receive and change tables on both singlesig and multisig results.