### PR TITLE
Catch malformed Jade transcripts in PSBT inspect

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -5924,7 +5924,8 @@ function hodlRfc6979Compare(sighash, privateKey, r) {
 }
 function hodlRenderPsbt(psbt) {
   let network = hodlSelectedNetwork(document.getElementById("psbt-network")),
-    transcript = hodlParseAntiExfil(document.getElementById("psbt-ax-transcript")?.value || ""),
+    transcript = null,
+    transcriptError = "",
     tx = psbt.tx,
     inputSum = 0n,
     knownInputs = 0,
@@ -5934,6 +5935,11 @@ function hodlRenderPsbt(psbt) {
     tapSignatureCount = 0,
     ecdsaIndex = 0,
     uninspected = 0;
+  try {
+    transcript = hodlParseAntiExfil(document.getElementById("psbt-ax-transcript")?.value || "");
+  } catch (exception) {
+    transcriptError = exception.message || String(exception);
+  }
   html.push("<p class='label'>Where this transaction sends bitcoin</p>");
   tx.outputs.forEach((output, index) => {
     html.push("<p class='psbt-kv'><strong>Output " + index + "</strong> \xB7 " + hodlSats(output.amount) + " BTC<br>" + $t(hodlAddr(output.script, network)) + "</p>");
@@ -6032,6 +6038,7 @@ function hodlRenderPsbt(psbt) {
   } else html.push("<p class='muted'>Fee unknown — some inputs do not include a claimed witness UTXO amount.</p>");
   html.push("<p class='muted'>Input amounts and any fee are unverified PSBT claims. This tool does not check them against previous transactions or the blockchain.</p>");
   html.push("<p class='label'>ECDSA nonce check</p>");
+  if (transcriptError) html.push("<p class='psbt-warn'><strong>Jade anti-exfil transcript not used:</strong> " + $t(transcriptError) + "</p>");
   let {
     reused,
     possible

--- a/test/psbt-anti-exfil.test.mjs
+++ b/test/psbt-anti-exfil.test.mjs
@@ -115,6 +115,18 @@ test("anti-exfil commit check is try/caught so a bad opening cannot wipe the PSB
   );
 });
 
+test("malformed anti-exfil transcript is try/caught so parse errors cannot wipe the PSBT report", () => {
+  const render = loadSlice("hodlRenderPsbt");
+  assert.match(
+    render,
+    /try\s*\{\s*transcript\s*=\s*hodlParseAntiExfil\(document\.getElementById\("psbt-ax-transcript"\)\?\.value\s*\|\|\s*""\)\s*;?\s*\}\s*catch\s*\(\s*exception\s*\)\s*\{\s*transcriptError\s*=\s*exception\.message\s*\|\|\s*String\(\s*exception\s*\)\s*;?\s*\}/,
+  );
+  assert.match(
+    render,
+    /if\s*\(\s*transcriptError\s*\)\s*html\.push\("<p class='psbt-warn'><strong>Jade anti-exfil transcript not used:<\/strong> "\s*\+\s*\$t\(\s*transcriptError\s*\)\s*\+\s*"<\/p>"\)/,
+  );
+});
+
 test("compressed 02\/03 openings parse even when x is off-curve (validity is the commit check's job)", () => {
   const host = "11".repeat(32);
   const opening = "02" + "00".repeat(31) + "01";


### PR DESCRIPTION
hodlParseAntiExfil throws on incomplete or uncompressed input. That call sat uncaught at the top of hodlRenderPsbt, so a half-typed transcript emptied the whole report the same way an off-curve opening used to. Catch it, warn, and still inspect the PSBT.