### PR TITLE
Fix CI: install dependencies in jobs that build the site

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -77,6 +77,9 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - name: Install locked dependencies
+        run: npm ci --ignore-scripts
       - name: Build static site
         run: npm run build
       - name: Run headless Firefox tests
@@ -106,6 +109,9 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - name: Install locked dependencies
+        run: npm ci --ignore-scripts
       - name: Build static site
         run: npm run build
       - name: Run browser-check tests
@@ -135,6 +141,9 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - name: Install locked dependencies
+        run: npm ci --ignore-scripts
       - name: Run source-invariant tests
         run: npm run test:invariants
 
@@ -221,6 +230,9 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - name: Install locked dependencies
+        run: npm ci --ignore-scripts
       - name: Build static site
         run: npm run build
       - name: Verify site artifact


### PR DESCRIPTION
## Problem

The merged #68 added `npm run build` steps to `test-browser`, `test-browser-check`, and `verify`, and made `test-invariants` build implicitly (auto-build in `validate.test.mjs`) — but none of those jobs run `npm ci`, and `scripts/build.mjs` imports `esbuild`. Result on main:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'esbuild' imported from scripts/build.mjs
```

Failed jobs: test-invariants, test-browser-check, test-browser, verify (deploy + artifact skipped).

## Fix

Add `cache: npm` + `npm ci --ignore-scripts` to those four jobs, matching the pattern already used by `build`, `test-ci`, `test-ui`, and `test-seedqr`.

Verified: workflow YAML parses, `npm run test:validate` 51/51 (includes the workflow-topology assertions).

Note: the failures on runs for #67/#61/#50 were the old committed-artifact reproducibility check, which #68 removed by design — no other outstanding CI issues on main.