### PR TITLE
Support all five BIP39 phrase lengths for every entropy input

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Official website: [entropylab.online](https://entropylab.online)
 
 - Accepts dice rolls, coin flips, hexadecimal entropy, BIP39 seed phrases,
   extended keys, WIF keys, raw private keys, and Casascius mini private keys.
+  All five BIP39 phrase lengths (12, 15, 18, 21, and 24 words) are supported
+  for every entropy entry method.
 - Derives BIP39 seeds, BIP32 extended keys, wallet fingerprints, addresses,
   and Bitcoin Core-compatible descriptors. Each master fingerprint is shown
   next to its deterministic [LifeHash](https://lifehash.info) icon so two

--- a/src/index.html
+++ b/src/index.html
@@ -77,12 +77,12 @@ This matches the method used by Keystone, and all rolls are included.</span></sp
         <span><strong>BitBox diceware / Direct word selection</strong>
         <span class="desc">Same as the BitBox02 lookup table: five dice
 showing 1–4, then a coin (or 6th die: 1–3 tails, 4–6 heads). 5 and 6 on
-the first five dice of a word are skipped (reroll). After 23 words, pick
- one of the 8 checksum words.</span></span>
+the first five dice of a word are skipped (reroll). After the lookup-table
+words, pick one of the checksum words.</span></span>
       </label>
       <label class="choice"><input type="radio" name="dm" value="dplus">
         <span><strong>D++ / Direct word selection</strong>
-        <span class="desc">For a 24-word seed, roll one D8 and two D16 dice for each of the first 23 words, then a final D8 for the checksum word.</span></span>
+        <span class="desc">Roll one D8 and two D16 dice for each lookup-table word, then use the per-size final rolls for the checksum word.</span></span>
       </label>
       </div>
       <p class="label" id="dice-label">Dice rolls (faces 1–6 only)</p>

--- a/src/index.html
+++ b/src/index.html
@@ -53,7 +53,9 @@
         <p class="label" id="seed-length-label">Seed phrase length</p>
         <div class="row seed-length-options segmented-control" role="group" aria-label="Seed phrase length">
           <button type="button" class="tab" data-seed-words="12" aria-pressed="false">12 words</button>
+          <button type="button" class="tab" data-seed-words="15" aria-pressed="false">15 words</button>
           <button type="button" class="tab" data-seed-words="18" aria-pressed="false">18 words</button>
+          <button type="button" class="tab" data-seed-words="21" aria-pressed="false">21 words</button>
           <button type="button" class="tab active" data-seed-words="24" aria-pressed="true">24 words</button>
         </div>
         <p class="muted" id="seed-length-help">24 words use 256 bits of BIP39 entropy.</p>

--- a/src/index.html
+++ b/src/index.html
@@ -76,7 +76,7 @@ This matches the method used by Keystone, and all rolls are included.</span></sp
       <label class="choice"><input type="radio" name="dm" value="bitbox">
         <span><strong>BitBox diceware / Direct word selection</strong>
         <span class="desc">Same as the BitBox02 lookup table: five dice
-showing 1–4, then a coin (or 6th die: 1–3 tails, 4–6 heads). 5 and 6 on
+showing 1–4, then a coin (or 6th die: 1–3 heads, 4–6 tails). 5 and 6 on
 the first five dice of a word are skipped (reroll). After the lookup-table
 words, pick one of the checksum words.</span></span>
       </label>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2422,15 +2422,16 @@ function hodlUpdateDiceButtons(input, analysis) {
     }
     if (ge === "bitbox") {
       // The sixth roll is the coin, so on that turn the six keys become two:
-      // Tails over 1-3 and Heads over 4-6. Tapping enters the first face of its
-      // range; the range is what decides the bit, so any face in it builds the
-      // same word, and the actual roll can still be typed rather than tapped.
+      // Heads over 1-3 and Tails over 4-6, matching the BitBox lookup table
+      // column labels. Tapping enters the first face of its range; the range is
+      // what decides the bit, so any face in it builds the same word, and the
+      // actual roll can still be typed rather than tapped.
       let flipping = analysis.coinTurn && face >= 1 && face <= 6,
         leads = face === 1 || face === 4;
       button.hidden = flipping && !leads;
       button.classList.toggle("dice-key-wide", flipping && leads);
       if (flipping && leads) {
-        let side = face === 1 ? "Tails" : "Heads",
+        let side = face === 1 ? "Heads" : "Tails",
           range = face === 1 ? "1 – 3" : "4 – 6",
           caption = document.createElement("span");
         caption.className = "dice-key-caption";
@@ -3227,7 +3228,8 @@ function hodlBitBoxRolls(value, targetWords = Pt) {
       diceInWord.push(face);
       continue;
     }
-    // The sixth roll is the coin: 1-3 is Tails, 4-6 is Heads.
+    // The sixth roll is the coin: 1-3 is Heads, 4-6 is Tails (BitBox lookup
+    // table columns: "1 2 3 heads" is the +0 column, "4 5 6 tails" is +1).
     let coin = input === "1" || input === "2" || input === "3" ? 0 : 1;
     words.push(mi(diceInWord, coin));
     diceInWord = [];
@@ -3573,7 +3575,7 @@ function hodlRenderKeyForm() {
         return `<button type="button" data-d="${face}" aria-label="${aria}">${label}</button>`
       }).join("");
     let diceLabel = ge === "dplus" ? `D++ rolls (D8, D16, D16; then ${hodlDPlusFinalDescription(config.words)})` : ge === "bitbox" ? "Dice rolls (1\u20134, then a 6th die interpreted as a coin flip)" : "Dice rolls (faces 1\u20136 only)";
-    let diceHelp = ge === "dplus" ? `For each of the first ${config.partialWords} words, enter the D8 result, then both D16 results. ${hodlDPlusFinalHelp(config.words)}` : ge === "bitbox" ? `${config.partialWords} lookup-table words fill one slot at a time, then choose a confirmed final checksum word. Use 1\u20134 for the first five rolls (if you get 5 or 6, roll again). The sixth roll is treated as the coin: 1–3 is Tails, 4–6 is Heads. Or flip a real coin!` : ge === "coleman" ? `Every rolled 6 becomes 0 before the complete digit string is hashed with SHA-256. This Dice [1-6] method matches the method used by Keystone. Any nonempty count produces a phrase, but use at least ${config.hashRolls} fair rolls before relying on it.` : `The original dice digit string is hashed with SHA-256. This Base 10 [0-9] method matches COLDCARD and SeedSigner. Any nonempty count produces a phrase, but use at least ${config.hashRolls} fair rolls before relying on it.`;
+    let diceHelp = ge === "dplus" ? `For each of the first ${config.partialWords} words, enter the D8 result, then both D16 results. ${hodlDPlusFinalHelp(config.words)}` : ge === "bitbox" ? `${config.partialWords} lookup-table words fill one slot at a time, then choose a confirmed final checksum word. Use 1\u20134 for the first five rolls (if you get 5 or 6, roll again). The sixth roll is treated as the coin: 1–3 is Heads, 4–6 is Tails. Or flip a real coin!` : ge === "coleman" ? `Every rolled 6 becomes 0 before the complete digit string is hashed with SHA-256. This Dice [1-6] method matches the method used by Keystone. Any nonempty count produces a phrase, but use at least ${config.hashRolls} fair rolls before relying on it.` : `The original dice digit string is hashed with SHA-256. This Base 10 [0-9] method matches COLDCARD and SeedSigner. Any nonempty count produces a phrase, but use at least ${config.hashRolls} fair rolls before relying on it.`;
     let dicePlaceholder = ge === "dplus" ? "100 2AF…" : ge === "bitbox" ? "111111 222224\u2026" : "415263415263\u2026";
     let dicePad = ge === "dplus" ? `<div class="dice-input-pad dplus">${dplusPad}</div>` : `<div class="dice-input-pad faces-1-6">${[1,2,3,4,5,6].map(face=>`<button type="button" data-d="${face}">${face}</button>`).join("")}</div>`;
     let dplusConvention = ge === "dplus" ? `<p class="label" id="dplus-die-label">Which type of D16 dice are you rolling?</p><div class="card-suit-pad dplus-die-pad" id="dplus-die" role="group" aria-labelledby="dplus-die-label"><button type="button" class="${hodlDPlusNumberedD16?"":"active"}" data-dplus-die="hex" aria-pressed="${hodlDPlusNumberedD16?"false":"true"}"><strong>Hex</strong> \xB7 0\u2013F</button><button type="button" class="${hodlDPlusNumberedD16?"active":""}" data-dplus-die="numbered" aria-pressed="${hodlDPlusNumberedD16?"true":"false"}"><strong>Decimal</strong> \xB7 1\u201316</button></div>` : "";
@@ -3587,7 +3589,7 @@ function hodlRenderKeyForm() {
         <span><strong>Hashed rolls / Dice [1-6]</strong><span class="desc">Convert each 6 to 0 and SHA-256 the complete mapped digit string, matching the method used by Keystone. Use the first ${config.bits} bits; ${config.hashRolls} rolls are recommended, and every entered roll is included.</span></span>
       </label>
       <label class="choice"><input type="radio" name="dm" value="bitbox" ${ge === "bitbox" ? "checked" : ""} />
-        <span><strong>BitBox diceware / Direct word selection</strong><span class="desc">Use five dice showing 1\u20134, then a coin (or 6th die: 1\u20133 tails, 4\u20136 heads). Build ${config.partialWords} lookup-table words, then choose 1 of ${config.candidates} valid final checksum words.</span></span>
+        <span><strong>BitBox diceware / Direct word selection</strong><span class="desc">Use five dice showing 1\u20134, then a coin (or 6th die: 1\u20133 heads, 4\u20136 tails). Build ${config.partialWords} lookup-table words, then choose 1 of ${config.candidates} valid final checksum words.</span></span>
       </label>
       <label class="choice"><input type="radio" name="dm" value="dplus" ${ge==="dplus"?"checked":""} />
         <span><strong>D++ / Direct word selection</strong><span class="desc">Roll one 8-sided die and two 16-sided dice for each of the first ${config.partialWords} words, then ${hodlDPlusFinalDescription(config.words)} to select the valid checksum final word.</span></span>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -412,7 +412,9 @@ ec.innerHTML = `
         <p class="label" id="seed-length-label">Seed phrase length</p>
         <div class="row seed-length-options segmented-control" role="group" aria-label="Seed phrase length">
           <button type="button" class="tab" data-seed-words="12" aria-pressed="false">12 words</button>
+          <button type="button" class="tab" data-seed-words="15" aria-pressed="false">15 words</button>
           <button type="button" class="tab" data-seed-words="18" aria-pressed="false">18 words</button>
+          <button type="button" class="tab" data-seed-words="21" aria-pressed="false">21 words</button>
           <button type="button" class="tab active" data-seed-words="24" aria-pressed="true">24 words</button>
         </div>
         <p class="muted" id="seed-length-help">24 words use 256 bits of BIP39 entropy.</p>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2397,7 +2397,7 @@ function hodlUpdateDiceButtons(input, analysis) {
       }
     }
     if (ge === "dplus") {
-      // The 18-word seed ends on a D8 read as a coin. On that turn the eight D8
+      // A coin-flip step reads a D8 as one bit. On that turn the eight D8
       // keys collapse into one Tails key and one Heads key, each naming the
       // faces it stands for. Tapping enters the first face of its range; the
       // range is what decides the bit, so any face in it derives the same word,
@@ -2465,7 +2465,7 @@ function hodlBitsToTargetEntropy(bitString, sourceBits, method, notes, warnings,
 }
 function hodlDiceEntropy(value, method, targetWords = Pt) {
   let config = hodlSeedConfig(targetWords), notes = [], warnings = [];
-  if (method === "dplus") return { ok: false, error: `D++ directly selects ${config.partialWords} BIP39 words, then ${config.words === 24 ? "uses a final D8 roll" : "uses a checksum-valid word selection"} for the final word.`, notes, warnings };
+    if (method === "dplus") return { ok: false, error: `D++ directly selects ${config.partialWords} BIP39 words; ${hodlDPlusFinalDescription(config.words)} to finish with the final checksum word.`, notes, warnings };
   let parsed = Br(value), rolls = parsed.rolls;
   if (method === "bitbox") return { ok: false, error: `BitBox diceware uses ${config.partialWords} lookup-table words and a final checksum pick for a ${config.words}-word seed.`, notes, warnings };
   if (parsed.leftover.length) return { ok: false, error: `Dice must be faces 1\u20136. Ignored characters: ${JSON.stringify(parsed.leftover.slice(0, 24))}`, notes, warnings };

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2501,7 +2501,9 @@ function hodlBinaryEntropy(value, targetWords = Pt) {
 function hodlCardNeeded(targetWords = Pt) {
   let bits = hodlSeedConfig(targetWords).bits;
   if (bits <= 128) return { first: 25, extra: 0 };
+  if (bits <= 160) return { first: 31, extra: 0 };
   if (bits <= 192) return { first: 39, extra: 0 };
+  if (bits <= 224) return { first: 50, extra: 0 };
   return { first: 52, extra: 6 };
 }
 function hodlCardWithoutReplacementBits(count) {

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1825,6 +1825,51 @@ function hodlUsableSinglesigImport(value, network) {
   return hodlSinglesigImportStatus(value, network).ok;
 }
 
+// The D++ checksum-word pick ends its transcript with the fewest rolls that
+// cover the candidate count: one D16 (21 words), one D8 (24), two D8s (15),
+// a D8 and a D16 (12), or a D16 and a coin flip (18). Every pick consumes
+// its roll results left to right, the high bits first.
+var hodlDPlusFinalSpecs = Object.freeze({
+  12: Object.freeze(["d8", "d16"]),
+  15: Object.freeze(["d8", "d8"]),
+  18: Object.freeze(["d16", "coin"]),
+  21: Object.freeze(["d16"]),
+  24: Object.freeze(["d8"])
+});
+function hodlDPlusStepBits(step) {
+  return step === "d8" ? 3 : step === "d16" ? 4 : 1;
+}
+function hodlDPlusStepLabel(step) {
+  return step === "d8" ? "D8" : step === "d16" ? "D16" : "a coin flip";
+}
+function hodlDPlusStepValue(step, face) {
+  if (step === "d8") return /^[1-8]$/.test(face) ? Number(face) - 1 : null;
+  if (step === "d16") return hodlDPlusD16Value(face);
+  return /^[1-8]$/.test(face) ? (Number(face) >= 5 ? 1 : 0) : null;
+}
+function hodlDPlusFinalSteps(words = Pt) {
+  let config = hodlSeedConfig(words);
+  return hodlDPlusFinalSpecs[config.words] || hodlDPlusFinalSpecs[24];
+}
+function hodlDPlusFinalDescription(words = Pt) {
+  let steps = hodlDPlusFinalSteps(words), labels = steps.map(hodlDPlusStepLabel);
+  if (steps.length === 1) return `roll the ${labels[0]} once more`;
+  if (labels[0] === labels[1]) return `roll a final ${labels[0]} twice`;
+  return `roll a final ${labels.join(" and ")}`;
+}
+function hodlDPlusFinalHelp(words = Pt) {
+  let steps = hodlDPlusFinalSteps(words), labels = steps.map((step) => step === "coin" ? "coin flip" : hodlDPlusStepLabel(step));
+  let coin = steps.includes("coin") ? " The final D8 is interpreted as a coin flip: 1\u20134 is Tails, 5\u20138 is Heads. Or flip a real coin!" : "";
+  if (steps.length === 1) return `One final ${labels[0]} roll selects the checksum word.`;
+  if (labels[0] === labels[1]) return `Two final ${labels[0]} rolls select the checksum word.`;
+  return `One final ${labels[0]} roll and one final ${labels[1]} roll select the checksum word.${coin}`;
+}
+function hodlDPlusStepChecksumLabel(step) {
+  return step === "coin" ? "the final coin flip" : `the final ${hodlDPlusStepLabel(step)} checksum roll`;
+}
+// The roll turns each position in the final-word spec into a numbered pick:
+// d8 carries three bits (faces 1-8), d16 four bits (faces 0-F / 1-16), and a
+// coin one bit (faces 1-4 Tails, 5-8 Heads).
 function hodlDPlusD16Value(face) {
   let normalized = String(face ?? "").toUpperCase();
   return /^[0-9A-F]$/.test(normalized) ? Number.parseInt(normalized, 16) : null
@@ -1901,102 +1946,70 @@ function hodlDPlusRolls(value, targetWords = Pt, numberedD16 = hodlDPlusNumbered
     allRolledComplete = rolledEntries.length === rolledCharacterTarget,
     rolledInvalidCount = invalidRequiredCount,
     allRolledValid = allRolledComplete && rolledInvalidCount === 0 && validWordCount === rolledTarget;
-  let finalEntry = config.words === 24 || config.words === 12 ? entries[rolledCharacterTarget] || null : null,
-    finalRoll = "";
-  // 18-word seeds leave 5 free bits in the final word (6 of its 11 bits are
-  // the BIP39 checksum), so the last word is chosen by a D16 plus a coin flip.
-  let finalD16Entry = config.words === 18 ? entries[rolledCharacterTarget] || null : config.words === 12 ? entries[rolledCharacterTarget + 1] || null : null,
-    finalCoinEntry = config.words === 18 ? entries[rolledCharacterTarget + 1] || null : null,
-    finalD16 = "",
-    finalCoin = "";
-  if (finalD16Entry) {
-    if (hodlDPlusD16Value(finalD16Entry.face) !== null) {
-      finalD16 = finalD16Entry.face;
-      acceptedCharacters.push(finalD16Entry.face);
-      bits += 4
-    } else {
-      invalidRanges.push([finalD16Entry.start, finalD16Entry.end]);
-      invalidRequiredCount += 1;
-      rejectedD16 += 1;
-      if (!firstInvalid) firstInvalid = {
-        groupIndex: rolledTarget,
-        position: 0,
-        face: finalD16Entry.face,
-        start: finalD16Entry.start,
-        end: finalD16Entry.end,
-        final: !0
+  // The checksum pick uses the spec's fixed roll sequence: each entry maps
+  // through its step and contributes the high bits of the selection.
+  let finalSteps = hodlDPlusFinalSteps(config.words),
+    finalInfo = finalSteps.map((step, position) => {
+      let entry = entries[rolledCharacterTarget + position] || null, value = "";
+      if (entry) {
+        let picked = hodlDPlusStepValue(step, entry.face);
+        if (picked !== null) {
+          value = entry.face;
+          acceptedCharacters.push(entry.face);
+          bits += hodlDPlusStepBits(step);
+        } else {
+          invalidRanges.push([entry.start, entry.end]);
+          invalidRequiredCount += 1;
+          if (step === "d8") rejectedD8 += 1;
+          else if (step === "d16") rejectedD16 += 1;
+          if (!firstInvalid) firstInvalid = { groupIndex: rolledTarget, position, face: entry.face, start: entry.start, end: entry.end, final: true };
+        }
       }
-    }
-  }
-  if (finalCoinEntry) {
-    if (/^[1-8]$/.test(finalCoinEntry.face)) {
-      finalCoin = finalCoinEntry.face;
-      acceptedCharacters.push(finalCoinEntry.face);
-      bits += 1
-    } else {
-      invalidRanges.push([finalCoinEntry.start, finalCoinEntry.end]);
-      invalidRequiredCount += 1;
-      if (!firstInvalid) firstInvalid = {
-        groupIndex: rolledTarget,
-        position: 1,
-        face: finalCoinEntry.face,
-        start: finalCoinEntry.start,
-        end: finalCoinEntry.end,
-        final: !0
-      }
-    }
-  }
-  if (finalEntry) {
-    if (/^[1-8]$/.test(finalEntry.face)) {
-      finalRoll = finalEntry.face;
-      acceptedCharacters.push(finalEntry.face);
-      bits += 3;
-    } else {
-      invalidRanges.push([finalEntry.start, finalEntry.end]);
-      invalidRequiredCount += 1;
-      rejectedD8 += 1;
-      if (!firstInvalid) firstInvalid = { groupIndex: rolledTarget, position: 0, face: finalEntry.face, start: finalEntry.start, end: finalEntry.end, final: true };
-    }
-  }
-  let expectedCharacters = rolledCharacterTarget + (config.words === 24 ? 1 : 2),
+      return { step, entry, value };
+    });
+  let expectedCharacters = rolledCharacterTarget + finalSteps.length,
     extraEntries = entries.slice(expectedCharacters),
     extraAfter = extraEntries.length;
   extraEntries.forEach(token => invalidRanges.push([token.start, token.end]));
   let finalOptions = allRolledValid ? hodlTargetLastWords(wordSlots.join(" "), config.words) : null,
     candidates = finalOptions && !finalOptions.error ? finalOptions.candidates : [],
-    finalWord = config.words === 12 ? finalRoll && finalD16 ? candidates[(Number(finalRoll) - 1) * 16 + hodlDPlusD16Value(finalD16)] || "" : "" : finalRoll ? candidates[Number(finalRoll) - 1] || "" : finalD16 && finalCoin ? candidates[hodlDPlusD16Value(finalD16) * 2 + (Number(finalCoin) >= 5 ? 1 : 0)] || "" : "";
-  let currentPosition = rolledEntries.length < rolledCharacterTarget ? rolledEntries.length % 3 : null,
-    activeGroupIndex = rolledEntries.length < rolledCharacterTarget ? Math.floor(rolledEntries.length / 3) : rolledTarget - 1,
+    finalIndex = 0,
+    complete = false,
     waiting;
+  if (allRolledValid) {
+    for (let position = 0; position < finalSteps.length; position++) {
+      let info = finalInfo[position];
+      if (!info.entry) { waiting = `checksum-${info.step}`; break; }
+      if (info.value === "") { waiting = "correction"; break; }
+      finalIndex = finalIndex * (info.step === "d8" ? 8 : info.step === "d16" ? 16 : 2) + hodlDPlusStepValue(info.step, info.entry.face);
+      if (position === finalSteps.length - 1) { waiting = "complete"; complete = true; }
+    }
+  }
+  let currentPosition = rolledEntries.length < rolledCharacterTarget ? rolledEntries.length % 3 : null,
+    activeGroupIndex = rolledEntries.length < rolledCharacterTarget ? Math.floor(rolledEntries.length / 3) : rolledTarget - 1;
   if (!allRolledComplete) waiting = currentPosition === 0 ? "d8" : currentPosition === 1 ? "d16-first" : "d16-second";
   else if (!allRolledValid) waiting = "correction";
-  else if (config.words === 18) waiting = !finalD16Entry ? "checksum-d16" : !finalD16 ? "correction" : !finalCoinEntry ? "checksum-coin" : finalCoin ? "complete" : "correction";
-  else if (config.words === 12) waiting = !finalEntry ? "checksum-d8" : !finalRoll ? "correction" : !finalD16Entry ? "checksum-d16" : finalD16 ? "complete" : "correction";
-  else if (!finalEntry) waiting = "checksum-d8";
-  else waiting = finalRoll ? "complete" : "correction";
+  let finalWord = complete ? candidates[finalIndex] || "" : "";
   let partialLength = rolledEntries.length % 3,
     group = partialLength ? rolledEntries.slice(-partialLength).map(token => token.face) : [],
     words = wordSlots.filter(Boolean),
     notes = [`D++: ${completedGroups} of ${rolledTarget} positional D8 + D16 + D16 groups entered; ${validWordCount} valid (${rolledEntries.length} of ${rolledCharacterTarget} required results).`],
     warnings = [];
   notes.push(numberedD16 ? "Decimal D16 notation: results read 1 through 16, where 16 is the zero of the underlying 0-15 range." : "Custom D++ D16 notation: results use hexadecimal 0 through F.");
-  if (config.words === 24 && finalRoll && finalWord) notes.push(`Final D8 result ${finalRoll} selected checksum option ${finalRoll} of 8: ${finalWord}.`);
-  if (finalRoll && finalD16 && finalWord) notes.push(`Final D8 result ${finalRoll} and D16 result ${finalD16} selected checksum option ${(Number(finalRoll)-1)*16+hodlDPlusD16Value(finalD16)+1} of ${config.candidates}: ${finalWord}.`);
-  if (finalD16 && finalCoin && finalWord) notes.push(`Final D16 result ${finalD16} and final D8 result ${finalCoin}, read as ${Number(finalCoin)>=5?"Heads":"Tails"} selected checksum option ${hodlDPlusD16Value(finalD16)*2+(Number(finalCoin)>=5?1:0)+1} of ${config.candidates}: ${finalWord}.`);
+  if (complete && finalWord) {
+    let labels = finalInfo.map((info) => info.step === "coin" ? `D8 result ${info.value} read as ${Number(info.value) >= 5 ? "Heads" : "Tails"}` : `${hodlDPlusStepLabel(info.step)} result ${info.value}`).join(" and ");
+    notes.push(`Final ${labels} selected checksum option ${finalIndex + 1} of ${candidates.length}: ${finalWord}.`);
+  }
   if (waiting === "last-word") notes.push(`Choose 1 of ${config.candidates} checksum-valid final words to complete the ${config.words}-word seed.`);
   if (rejectedD8) notes.push(`Rejected ${rejectedD8} result${rejectedD8===1?"":"s"} that cannot be used for a D8 roll.`);
   if (rejectedD16) notes.push(`Rejected ${rejectedD16} result${rejectedD16===1?"":"s"} that ${rejectedD16===1?"is":"are"} not valid for the selected D16 convention (${numberedD16?"1\u201316":"0\u2013F"}).`);
-  if (extraAfter) warnings.push(`${extraAfter} extra input${extraAfter===1?" was":"s were"} ignored after ${config.words===24?"the final D8 roll":config.words===18?"the final D16 roll and coin flip":"the final D8 and D16 rolls"}.`);
+  if (extraAfter) warnings.push(`${extraAfter} extra input${extraAfter===1?" was":"s were"} ignored after ${hodlDPlusFinalDescription(config.words)}.`);
   return {
     words,
     wordSlots,
     groups,
     group,
     entries,
-    finalEntry: finalEntry?.face || "",
-    finalRoll,
-    finalD16,
-    finalCoin,
     finalWord,
     candidates,
     waiting,
@@ -2022,7 +2035,7 @@ function hodlDPlusRolls(value, targetWords = Pt, numberedD16 = hodlDPlusNumbered
     targetWords: config.words,
     neededPartial: rolledTarget,
     numberedD16,
-    complete: allRolledValid && Boolean(finalWord)
+    complete: complete && Boolean(finalWord)
   }
 }
 
@@ -3555,8 +3568,8 @@ function hodlRenderKeyForm() {
           aria = hodlDPlusNumberedD16 ? `D16 result ${decimal}, entered as ${face}` : `D16 result ${face}${/^[A-F]$/.test(face)?`, decimal ${decimal}`:""}`;
         return `<button type="button" data-d="${face}" aria-label="${aria}">${label}</button>`
       }).join("");
-    let diceLabel = ge === "dplus" ? (config.words === 24 ? "D++ rolls (D8, D16, D16; then a final D8)" : "D++ rolls (D8, D16, D16)") : ge === "bitbox" ? "Dice rolls (1\u20134, then a 6th die interpreted as a coin flip)" : "Dice rolls (faces 1\u20136 only)";
-    let diceHelp = ge === "dplus" ? `For each of the first ${config.partialWords} words, enter the D8 result, then both D16 results. ${config.words===24?"One final D8 roll selects the checksum word.":config.words===12?"One final D8 roll and one D16 roll select the checksum word.":"One final D16 roll and one final D8 roll select the checksum word. The final D8 is interpreted as a coin flip: 1\u20134 is Tails, 5\u20138 is Heads. Or flip a real coin!"}` : ge === "bitbox" ? `${config.partialWords} lookup-table words fill one slot at a time, then choose a confirmed final checksum word. Use 1\u20134 for the first five rolls (if you get 5 or 6, roll again). The sixth roll is treated as the coin: 1–3 is Tails, 4–6 is Heads. Or flip a real coin!` : ge === "coleman" ? `Every rolled 6 becomes 0 before the complete digit string is hashed with SHA-256. This Dice [1-6] method matches the method used by Keystone. Any nonempty count produces a phrase, but use at least ${config.hashRolls} fair rolls before relying on it.` : `The original dice digit string is hashed with SHA-256. This Base 10 [0-9] method matches COLDCARD and SeedSigner. Any nonempty count produces a phrase, but use at least ${config.hashRolls} fair rolls before relying on it.`;
+    let diceLabel = ge === "dplus" ? `D++ rolls (D8, D16, D16; then ${hodlDPlusFinalDescription(config.words)})` : ge === "bitbox" ? "Dice rolls (1\u20134, then a 6th die interpreted as a coin flip)" : "Dice rolls (faces 1\u20136 only)";
+    let diceHelp = ge === "dplus" ? `For each of the first ${config.partialWords} words, enter the D8 result, then both D16 results. ${hodlDPlusFinalHelp(config.words)}` : ge === "bitbox" ? `${config.partialWords} lookup-table words fill one slot at a time, then choose a confirmed final checksum word. Use 1\u20134 for the first five rolls (if you get 5 or 6, roll again). The sixth roll is treated as the coin: 1–3 is Tails, 4–6 is Heads. Or flip a real coin!` : ge === "coleman" ? `Every rolled 6 becomes 0 before the complete digit string is hashed with SHA-256. This Dice [1-6] method matches the method used by Keystone. Any nonempty count produces a phrase, but use at least ${config.hashRolls} fair rolls before relying on it.` : `The original dice digit string is hashed with SHA-256. This Base 10 [0-9] method matches COLDCARD and SeedSigner. Any nonempty count produces a phrase, but use at least ${config.hashRolls} fair rolls before relying on it.`;
     let dicePlaceholder = ge === "dplus" ? "100 2AF…" : ge === "bitbox" ? "111111 222224\u2026" : "415263415263\u2026";
     let dicePad = ge === "dplus" ? `<div class="dice-input-pad dplus">${dplusPad}</div>` : `<div class="dice-input-pad faces-1-6">${[1,2,3,4,5,6].map(face=>`<button type="button" data-d="${face}">${face}</button>`).join("")}</div>`;
     let dplusConvention = ge === "dplus" ? `<p class="label" id="dplus-die-label">Which type of D16 dice are you rolling?</p><div class="card-suit-pad dplus-die-pad" id="dplus-die" role="group" aria-labelledby="dplus-die-label"><button type="button" class="${hodlDPlusNumberedD16?"":"active"}" data-dplus-die="hex" aria-pressed="${hodlDPlusNumberedD16?"false":"true"}"><strong>Hex</strong> \xB7 0\u2013F</button><button type="button" class="${hodlDPlusNumberedD16?"active":""}" data-dplus-die="numbered" aria-pressed="${hodlDPlusNumberedD16?"true":"false"}"><strong>Decimal</strong> \xB7 1\u201316</button></div>` : "";
@@ -3573,7 +3586,7 @@ function hodlRenderKeyForm() {
         <span><strong>BitBox diceware / Direct word selection</strong><span class="desc">Use five dice showing 1\u20134, then a coin (or 6th die: 1\u20133 tails, 4\u20136 heads). Build ${config.partialWords} lookup-table words, then choose 1 of ${config.candidates} valid final checksum words.</span></span>
       </label>
       <label class="choice"><input type="radio" name="dm" value="dplus" ${ge==="dplus"?"checked":""} />
-        <span><strong>D++ / Direct word selection</strong><span class="desc">Roll one 8-sided die and two 16-sided dice for each of the first ${config.partialWords} words, then ${config.words===24?"roll the D8 once more":config.words===12?"roll a final D8 and D16":"roll a final D16 and D8"} to select the valid checksum final word.</span></span>
+        <span><strong>D++ / Direct word selection</strong><span class="desc">Roll one 8-sided die and two 16-sided dice for each of the first ${config.partialWords} words, then ${hodlDPlusFinalDescription(config.words)} to select the valid checksum final word.</span></span>
       </label>
       </div>
       ${dplusConvention}
@@ -3878,7 +3891,8 @@ function hodlUpdateDice() {
       rollRange = ` (${d16Range})`
     } else if (result.waiting === "correction") {
       let invalid = result.firstInvalid,
-        position = invalid?.final ? (config.words === 18 ? (invalid.position === 1 ? "the final coin flip" : "the final D16 checksum roll") : "the final D8 checksum roll") : `word ${(invalid?.groupIndex??0)+1}'s ${invalid?.position===0?"D8":invalid?.position===1?"first D16":"second D16"} roll`;
+        specSteps = hodlDPlusFinalSteps(config.words),
+        position = invalid?.final ? hodlDPlusStepChecksumLabel(specSteps[invalid.position]) : `word ${(invalid?.groupIndex??0)+1}'s ${invalid?.position===0?"D8":invalid?.position===1?"first D16":"second D16"} roll`;
       status = `${result.completedGroups} of ${config.partialWords} groups entered \xB7 correct ${result.invalidRequiredCount} highlighted invalid result${result.invalidRequiredCount===1?"":"s"}, starting with ${position}`
     } else if (selectingFinal) status = selectedFinal ? `${config.words} of ${config.words} seed words \xB7 checksum valid \xB7 ready to derive` : `${rollsComplete} \xB7 choose the final checksum word`;
     else if (result.waiting === "checksum-d8") {
@@ -4321,14 +4335,15 @@ function hodlCalculateKey() {
         let parsed = hodlDPlusRolls(document.getElementById("dice").value, Pt);
         if (parsed.firstInvalid) {
           let invalid = parsed.firstInvalid,
-            position = invalid.final ? (Pt === 18 ? (invalid.position === 1 ? "the final coin flip" : "the final D16 checksum roll") : "the final D8 checksum roll") : `word ${invalid.groupIndex+1}'s ${invalid.position===0?"D8":invalid.position===1?"first D16":"second D16"} roll`;
+            specSteps = hodlDPlusFinalSteps(Pt),
+            position = invalid.final ? hodlDPlusStepChecksumLabel(specSteps[invalid.position]) : `word ${invalid.groupIndex+1}'s ${invalid.position===0?"D8":invalid.position===1?"first D16":"second D16"} roll`;
           throw new Error(`Correct the highlighted invalid result in ${position}. Each D++ word keeps its original three-character group.`)
         }
         if (parsed.waiting === "d8") throw new Error(`Complete word ${parsed.activeGroupIndex + 1}: roll the D8, then both D16 dice.`);
         if (parsed.waiting === "d16-first") throw new Error(`Complete word ${parsed.activeGroupIndex + 1}: enter the first D16 roll.`);
         if (parsed.waiting === "d16-second") throw new Error(`Complete word ${parsed.activeGroupIndex + 1}: enter the second D16 roll.`);
-        if (parsed.waiting === "checksum-d8") throw new Error("Roll the final D8 to select one of the eight checksum-valid 24th words.");
-        if (parsed.waiting === "checksum-d16") throw new Error(Pt === 12 ? `Roll the final D16 to select one of the ${hodlSeedConfig().candidates} checksum-valid 12th words.` : `Roll the final D16, then flip the coin, to select one of the ${hodlSeedConfig().candidates} checksum-valid 18th words.`);
+        if (parsed.waiting === "checksum-d8") throw new Error(`Roll the final D8 to select the checksum word.`);
+        if (parsed.waiting === "checksum-d16") throw new Error(`Roll the final D16 to ${hodlDPlusFinalSteps(Pt).length > 1 ? "continue" : "select"} the checksum pick.`);
         if (parsed.waiting === "checksum-coin") throw new Error("Roll the final D8 to finish selecting the checksum word: 1\u20134 is Tails, 5\u20138 is Heads.");
         let rollsFinalWord = !0,
           finalWord = rollsFinalWord ? parsed.finalWord : ft;

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1779,7 +1779,9 @@ function hodlSeedQrExport(mnemonic, options = {}) {
 }
 var hodlSeedLengths = Object.freeze({
   12: Object.freeze({ words: 12, bits: 128, bytes: 16, hexChars: 32, hashRolls: 50, partialWords: 11, candidates: 128 }),
+  15: Object.freeze({ words: 15, bits: 160, bytes: 20, hexChars: 40, hashRolls: 62, partialWords: 14, candidates: 64 }),
   18: Object.freeze({ words: 18, bits: 192, bytes: 24, hexChars: 48, hashRolls: 75, partialWords: 17, candidates: 32 }),
+  21: Object.freeze({ words: 21, bits: 224, bytes: 28, hexChars: 56, hashRolls: 87, partialWords: 20, candidates: 16 }),
   24: Object.freeze({ words: 24, bits: 256, bytes: 32, hexChars: 64, hashRolls: 99, partialWords: 23, candidates: 8 })
 });
 var hodlEntropyFormats = Object.freeze({

--- a/test/bitbox.test.mjs
+++ b/test/bitbox.test.mjs
@@ -1,0 +1,74 @@
+// BitBox diceware / Direct word selection for every target word size.
+// Run with: npm test
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { wordlist as Ae } from "@scure/bip39/wordlists/english.js";
+import { validateMnemonic as Pn } from "@scure/bip39";
+
+const root = dirname(fileURLToPath(import.meta.url));
+const app = readFileSync(join(root, "..", "src/js/app.js"), "utf8");
+
+function loadSlice(name) {
+  const start = app.indexOf(`function ${name}(`);
+  assert.ok(start >= 0, name);
+  let depth = 0;
+  let end = -1;
+  for (let i = app.indexOf("{", start); i < app.length; i++) {
+    if (app[i] === "{") depth++;
+    else if (app[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        end = i + 1;
+        break;
+      }
+    }
+  }
+  assert.ok(end > start, name);
+  return app.slice(start, end);
+}
+function loadVariable(name, nextName) {
+  const start = app.search(new RegExp(`var\\s+${name}\\s*=`));
+  const end = app.search(new RegExp(`var\\s+${nextName}\\s*=`));
+  assert.ok(start >= 0 && end > start, name);
+  return app.slice(start, end);
+}
+
+const Z = (input) => new Uint8Array(createHash("sha256").update(input).digest());
+const api = new Function(
+  "Ae",
+  "Pn",
+  "Z",
+  `
+  var Pt = 24;
+  ${loadVariable("hodlSeedLengths", "hodlEntropyFormats")}
+  ${["hodlSeedConfig", "mi", "hodlTargetLastWords", "hodlComputeTargetLastWords", "Rn", "Mt", "hodlBitBoxRolls", "hodlValidateTargetMnemonic", "hodlSeedCountStatus"].map(loadSlice).join("\n")}
+  var hodlLastWordCache = new Map();
+  var hodlBip39WordSet = new Set(Ae);
+  var hodlBip39WordIndex = new Map(Ae.map((word, index) => [word, index]));
+  return { hodlBitBoxRolls, hodlTargetLastWords, hodlValidateTargetMnemonic, hodlSeedConfig };
+  `,
+)(Ae, Pn, Z);
+
+const SIZES = [12, 15, 18, 21, 24];
+
+test("BitBox diceware reaches the checksum pick for every target size", () => {
+  for (const words of SIZES) {
+    const config = api.hodlSeedConfig(words);
+    // Each word: a stray 5 skipped as a reroll, five dice showing 1-4, then
+    // the sixth die (4-6 means Heads) as its coin flip.
+    const word = "5" + "12341" + "6";
+    const parsed = api.hodlBitBoxRolls(word.repeat(config.partialWords), words);
+    assert.equal(parsed.waiting, "last-word", `${words}: waiting=${parsed.waiting}`);
+    assert.equal(parsed.words.length, config.partialWords, `${words}: ${parsed.words.length}`);
+    assert.ok(parsed.skippedHigh >= config.partialWords, `${words}: reroll faces were not skipped`);
+    const options = api.hodlTargetLastWords(parsed.words.join(" "), words);
+    assert.equal(options.candidates.length, config.candidates, `${words}-word candidates`);
+    for (const candidate of options.candidates) {
+      assert.equal(api.hodlValidateTargetMnemonic([...parsed.words, candidate].join(" "), words).ok, true, `${words}: ${candidate}`);
+    }
+  }
+});

--- a/test/bitbox.test.mjs
+++ b/test/bitbox.test.mjs
@@ -49,7 +49,7 @@ const api = new Function(
   var hodlLastWordCache = new Map();
   var hodlBip39WordSet = new Set(Ae);
   var hodlBip39WordIndex = new Map(Ae.map((word, index) => [word, index]));
-  return { hodlBitBoxRolls, hodlTargetLastWords, hodlValidateTargetMnemonic, hodlSeedConfig };
+  return { hodlBitBoxRolls, hodlTargetLastWords, hodlValidateTargetMnemonic, hodlSeedConfig, mi };
   `,
 )(Ae, Pn, Z);
 
@@ -59,8 +59,8 @@ test("BitBox diceware reaches the checksum pick for every target size", () => {
   for (const words of SIZES) {
     const config = api.hodlSeedConfig(words);
     // Each word: a stray 5 skipped as a reroll, five dice showing 1-4, then
-    // the sixth die (4-6 means Heads) as its coin flip.
-    const word = "5" + "12341" + "6";
+    // the sixth die (1-3 means Heads) as its coin flip.
+    const word = "5" + "12341" + "3";
     const parsed = api.hodlBitBoxRolls(word.repeat(config.partialWords), words);
     assert.equal(parsed.waiting, "last-word", `${words}: waiting=${parsed.waiting}`);
     assert.equal(parsed.words.length, config.partialWords, `${words}: ${parsed.words.length}`);
@@ -71,4 +71,48 @@ test("BitBox diceware reaches the checksum pick for every target size", () => {
       assert.equal(api.hodlValidateTargetMnemonic([...parsed.words, candidate].join(" "), words).ok, true, `${words}: ${candidate}`);
     }
   }
+});
+
+// Rows transcribed from the official BitBox02 Diceware lookup table
+// (BitBox_Diceware_LookupTable.pdf): die 1 selects the page, dice 1-4 the row,
+// and die 5 plus the coin the column. "1 2 3 heads" is the even column of a
+// pair, "4 5 6 tails" the odd one.
+const OFFICIAL_ROWS = [
+  [[1, 1, 1, 1], ["abandon", "ability", "able", "about", "above", "absent", "absorb", "abstract"]],
+  [[1, 4, 4, 3], ["dignity", "dilemma", "dinner", "dinosaur", "direct", "dirt", "disagree", "discover"]],
+  [[2, 4, 4, 2], ["laptop", "large", "later", "latin", "laugh", "laundry", "lava", "law"]],
+  [[3, 4, 4, 1], ["rose", "rotate", "rough", "round", "route", "royal", "rubber", "rude"]],
+  [[4, 4, 3, 3], ["wheel", "when", "where", "whip", "whisper", "wide", "width", "wife"]],
+  [[4, 4, 4, 4], ["yellow", "you", "young", "youth", "zebra", "zero", "zone", "zoo"]],
+];
+
+test("BitBox rolls map to the official lookup-table words", () => {
+  for (const [dice, words] of OFFICIAL_ROWS) {
+    const transcript = words.map((_, column) => {
+      const die5 = (column >> 1) + 1;
+      const coin = column & 1 ? 4 : 3; // heads column via a 3, tails via a 4
+      return [...dice, die5, coin].join("");
+    }).join(" ");
+    assert.deepEqual(api.hodlBitBoxRolls(transcript, 24).words, words, `row ${dice.join("")}`);
+  }
+});
+
+test("every dice combination lands on the table's BIP39-order index", () => {
+  // The table is the BIP39 English list in order: page (die 1) * 512 +
+  // row (dice 2-4) * 8 + column (die 5) * 2 + coin (heads 0, tails 1).
+  for (let d1 = 1; d1 <= 4; d1++) for (let d2 = 1; d2 <= 4; d2++) for (let d3 = 1; d3 <= 4; d3++) for (let d4 = 1; d4 <= 4; d4++) {
+    for (let d5 = 1; d5 <= 4; d5++) {
+      for (const coin of [0, 1]) {
+        const index = (d1 - 1) * 512 + (d2 - 1) * 128 + (d3 - 1) * 32 + (d4 - 1) * 8 + (d5 - 1) * 2 + coin;
+        assert.equal(api.mi([d1, d2, d3, d4, d5], coin), Ae[index], `${d1}${d2}${d3}${d4}${d5} coin ${coin}`);
+      }
+    }
+  }
+});
+
+test("checksum pick matches the BitBox02 lastword choices", () => {
+  // What a BitBox02 displays after 23 x "abandon" (firmware lastword_choices:
+  // word index = suffix << 8 | sha256(seed)[0], suffix ascending).
+  const options = api.hodlTargetLastWords(Array(23).fill("abandon").join(" "), 24);
+  assert.deepEqual(options.candidates, ["art", "diesel", "false", "kite", "organ", "ready", "surface", "trouble"]);
 });

--- a/test/cards.test.mjs
+++ b/test/cards.test.mjs
@@ -35,7 +35,9 @@ const hodlCardTypedCharactersAllowed = new Function(`${loadSlice("hodlCardTypedC
 const hodlCardWithoutReplacementBits = new Function(`${loadSlice("hodlCardWithoutReplacementBits")}; return hodlCardWithoutReplacementBits;`)();
 const hodlSeedLengths = {
   12: { words: 12, bits: 128, bytes: 16 },
+  15: { words: 15, bits: 160, bytes: 20 },
   18: { words: 18, bits: 192, bytes: 24 },
+  21: { words: 21, bits: 224, bytes: 28 },
   24: { words: 24, bits: 256, bytes: 32 },
 };
 function hodlSeedConfig(words = 12) {
@@ -78,13 +80,20 @@ test("card transcript input normalizes its limited character set", () => {
   assert.equal(hodlCardTypedCharactersAllowed("B"), false);
 });
 
-test("25 unique cards reach 12-word bits; 24 unique do not", () => {
+test("unique-card counts cover every BIP39 entropy length", () => {
   assert.ok(hodlCardWithoutReplacementBits(24) < 128);
   assert.ok(hodlCardWithoutReplacementBits(25) >= 128);
+  assert.ok(hodlCardWithoutReplacementBits(30) < 160);
+  assert.ok(hodlCardWithoutReplacementBits(31) >= 160);
+  assert.ok(hodlCardWithoutReplacementBits(38) < 192);
   assert.ok(hodlCardWithoutReplacementBits(39) >= 192);
+  assert.ok(hodlCardWithoutReplacementBits(49) < 224);
+  assert.ok(hodlCardWithoutReplacementBits(50) >= 224);
   assert.ok(hodlCardWithoutReplacementBits(52) < 256);
   assert.equal(hodlCardNeeded(12).first, 25);
+  assert.equal(hodlCardNeeded(15).first, 31);
   assert.equal(hodlCardNeeded(18).first, 39);
+  assert.equal(hodlCardNeeded(21).first, 50);
   assert.deepEqual(hodlCardNeeded(24), { first: 52, extra: 6 });
 });
 

--- a/test/dice-hashed.test.mjs
+++ b/test/dice-hashed.test.mjs
@@ -1,0 +1,79 @@
+// Hashed dice (COLDCARD/Keystone): recommended roll counts and entropy sizes.
+// Run with: npm test
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { entropyToMnemonic as _n } from "@scure/bip39";
+import { wordlist as Ae } from "@scure/bip39/wordlists/english.js";
+
+const root = dirname(fileURLToPath(import.meta.url));
+const app = readFileSync(join(root, "..", "src/js/app.js"), "utf8");
+
+function loadSlice(name) {
+  const start = app.indexOf(`function ${name}(`);
+  assert.ok(start >= 0, name);
+  let depth = 0;
+  let end = -1;
+  for (let i = app.indexOf("{", start); i < app.length; i++) {
+    if (app[i] === "{") depth++;
+    else if (app[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        end = i + 1;
+        break;
+      }
+    }
+  }
+  assert.ok(end > start, name);
+  return app.slice(start, end);
+}
+function loadVariable(name, nextName) {
+  const start = app.search(new RegExp(`var\\s+${name}\\s*=`));
+  const end = app.search(new RegExp(`var\\s+${nextName}\\s*=`));
+  assert.ok(start >= 0 && end > start, name);
+  return app.slice(start, end);
+}
+
+const Z = (input) => new Uint8Array(createHash("sha256").update(input).digest());
+const M = { encode: (bytes) => Buffer.from(bytes).toString("hex") };
+const api = new Function(
+  "_n",
+  "Ae",
+  "Z",
+  "M",
+  `
+  var Pt = 24;
+  ${loadVariable("hodlSeedLengths", "hodlEntropyFormats")}
+  ${["hodlSeedConfig", "kr", "hodlDiceEntropy", "hodlIanColemanDiceString", "Br" ].map(loadSlice).join("\n")}
+  return { hodlDiceEntropy, hodlSeedConfig, kr };
+  `,
+)(_n, Ae, Z, M);
+
+const SIZES = [12, 15, 18, 21, 24];
+const METHODS = ["coldcard", "coleman"];
+
+test("hashed-dice recommendation exactly reaches the entropy bits", () => {
+  const expected = { 12: 50, 15: 62, 18: 75, 21: 87, 24: 99 };
+  for (const words of SIZES) {
+    const config = api.hodlSeedConfig(words);
+    assert.equal(config.hashRolls, expected[words], `${words}: recommendation off`);
+    assert.ok(api.kr(config.hashRolls - 1) < config.bits, `${words}: shorter input still reaches ${config.bits} bits`);
+  }
+});
+
+test("hashed dice derive a full mnemonic for every target size and method", () => {
+  for (const words of SIZES) {
+    for (const method of METHODS) {
+      const config = api.hodlSeedConfig(words);
+      const rolls = "1".repeat(config.hashRolls);
+      const entropy = api.hodlDiceEntropy(rolls, method, words);
+      assert.equal(entropy.ok, true, `${words}, ${method}: not ok`);
+      assert.equal(entropy.bytes.length, config.bytes, `${words}, ${method}`);
+      const mnemonic = _n(entropy.bytes, Ae);
+      assert.equal(mnemonic.split(" ").length, words, `${words}, ${method}: ${mnemonic}`);
+    }
+  }
+});

--- a/test/dplus.test.mjs
+++ b/test/dplus.test.mjs
@@ -1,0 +1,139 @@
+// D++/Direct word selection final-roll parsing for every target word size.
+// Run with: npm test
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { wordlist as Ae } from "@scure/bip39/wordlists/english.js";
+import { validateMnemonic as Pn } from "@scure/bip39";
+
+const root = dirname(fileURLToPath(import.meta.url));
+const app = readFileSync(join(root, "..", "src/js/app.js"), "utf8");
+
+function loadSlice(name) {
+  const start = app.indexOf(`function ${name}(`);
+  assert.ok(start >= 0, name);
+  let depth = 0;
+  let end = -1;
+  for (let i = app.indexOf("{", start); i < app.length; i++) {
+    if (app[i] === "{") depth++;
+    else if (app[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        end = i + 1;
+        break;
+      }
+    }
+  }
+  assert.ok(end > start, name);
+  return app.slice(start, end);
+}
+function loadVariable(name, nextName) {
+  const start = app.search(new RegExp(`var\\s+${name}\\s*=`));
+  const end = app.search(new RegExp(`var\\s+${nextName}\\s*=`));
+  assert.ok(start >= 0 && end > start, name);
+  return app.slice(start, end);
+}
+function loadVariableBeforeFunction(name, terminator) {
+  const start = app.search(new RegExp(`var\\s+${name}\\s*=`));
+  const end = app.indexOf(`function ${terminator}(`, start);
+  assert.ok(start >= 0 && end > start, name);
+  return app.slice(start, end);
+}
+
+const Z = (input) => new Uint8Array(createHash("sha256").update(input).digest());
+const api = new Function(
+  "Ae",
+  "Pn",
+  "Z",
+  `
+  var Pt = 24;
+  ${loadVariable("hodlSeedLengths", "hodlEntropyFormats")}
+  ${loadVariableBeforeFunction("hodlDPlusFinalSpecs", "hodlDPlusStepBits")}
+  ${["hodlSeedConfig", "hodlDPlusStepBits", "hodlDPlusStepLabel", "hodlDPlusStepValue", "hodlDPlusFinalSteps", "hodlDPlusFinalDescription", "hodlDPlusFinalHelp", "hodlDPlusStepChecksumLabel", "hodlDPlusD16Value", "hodlDPlusTokens", "Rn", "Mt", "hodlTargetLastWords", "hodlComputeTargetLastWords", "mi", "hodlDPlusRolls", "hodlValidateTargetMnemonic", "hodlSeedCountStatus"].map(loadSlice).join("\n")}
+  var hodlLastWordCache = new Map();
+  var hodlBip39WordSet = new Set(Ae);
+  var hodlBip39WordIndex = new Map(Ae.map((word, index) => [word, index]));
+  return { hodlDPlusRolls, hodlDPlusFinalSteps, hodlDPlusFinalDescription, hodlDPlusFinalHelp, hodlValidateTargetMnemonic, hodlSeedConfig };
+  `,
+)(Ae, Pn, Z);
+
+const SIZES = [12, 15, 18, 21, 24];
+
+test("D++ final-roll specs cover exactly log2(candidates) bits per size", () => {
+  for (const words of SIZES) {
+    const config = api.hodlSeedConfig(words);
+    const steps = api.hodlDPlusFinalSteps(words);
+    const bits = steps.reduce((acc, step) => acc + (step === "d8" ? 3 : step === "d16" ? 4 : 1), 0);
+    assert.equal(bits, Math.log2(config.candidates), `${words}-word spec`);
+  }
+});
+
+test("D++ parses and completes a valid transcript for every target size", () => {
+  for (const words of SIZES) {
+    const config = api.hodlSeedConfig(words);
+    const group = "10E"; // valid D8 (1) + D16 (0) + D16 (E)
+    const steps = api.hodlDPlusFinalSteps(words);
+    const validFaces = steps.map((step) => (step === "d8" || step === "coin" ? "5" : "0"));
+    const value = group.repeat(config.partialWords) + validFaces.join("");
+    const parsed = api.hodlDPlusRolls(value, words, false);
+    assert.equal(parsed.waiting, "complete", `${words}: waiting=${parsed.waiting}`);
+    assert.equal(parsed.complete, true, `${words}: not complete`);
+    assert.equal(parsed.allRolledValid, true, `${words}: not all valid`);
+    if (!parsed.finalWord) assert.ok(false, `${words}: no final word`);
+    const phrase = [...parsed.wordSlots, parsed.finalWord].join(" ");
+    const bad = parsed.wordSlots.filter((w) => !w);
+    assert.equal(bad.length, 0, `${words}: empty slots`);
+    assert.equal(api.hodlValidateTargetMnemonic(phrase, words).ok, true, `${words}: ${phrase}`);
+  }
+});
+
+test("D++ reports the next required roll through every phase", () => {
+  const value12 = "10E".repeat(11);
+  let parsed = api.hodlDPlusRolls(value12, 12, false);
+  assert.equal(parsed.waiting, "checksum-d8");
+  parsed = api.hodlDPlusRolls(value12 + "4", 12, false);
+  assert.equal(parsed.waiting, "checksum-d16");
+  parsed = api.hodlDPlusRolls("10E".repeat(2), 12, false);
+  assert.equal(parsed.waiting, "d8");
+  parsed = api.hodlDPlusRolls("10E1", 12, false);
+  assert.equal(parsed.waiting, "d16-first");
+  parsed = api.hodlDPlusRolls("10E1A", 12, false);
+  assert.equal(parsed.waiting, "d16-second");
+  parsed = api.hodlDPlusRolls("10E".repeat(11) + "G", 12, false);
+  assert.equal(parsed.waiting, "correction");
+  assert.equal(parsed.firstInvalid.final, true);
+});
+
+test("D++ picks a candidate with the same index the spec maps to", () => {
+  const words = 15;
+  const config = api.hodlSeedConfig(words);
+  const parsed = api.hodlDPlusRolls("10E".repeat(config.partialWords) + "12", words, false);
+  assert.equal(parsed.waiting, "complete");
+  // (d8 - 1) * 8 + (d8 - 1) = 0 * 8 + 1 = 1
+  assert.equal(parsed.finalWord, parsed.candidates[1]);
+  const words21 = 21;
+  const config21 = api.hodlSeedConfig(words21);
+  const parsed21 = api.hodlDPlusRolls("10E".repeat(config21.partialWords) + "A", words21, false);
+  assert.equal(parsed21.finalWord, parsed21.candidates[0xA]);
+  const words18 = 18;
+  const config18 = api.hodlSeedConfig(words18);
+  const parsed18 = api.hodlDPlusRolls("10E".repeat(config18.partialWords) + "A5", words18, false);
+  // (d16) * 2 + (coin >= 5 ? 1 : 0) = 10 * 2 + 1 = 21
+  assert.equal(parsed18.finalWord, parsed18.candidates[21]);
+  const words12 = 12;
+  const config12 = api.hodlSeedConfig(words12);
+  const parsed12 = api.hodlDPlusRolls("10E".repeat(config12.partialWords) + "3A", words12, false);
+  // (d8 - 1) * 16 + (d16) = 2 * 16 + 10 = 42
+  assert.equal(parsed12.finalWord, parsed12.candidates[42]);
+  assert.equal(api.hodlValidateTargetMnemonic([...parsed12.wordSlots, parsed12.finalWord].join(" "), 12).ok, true);
+});
+
+test("D++, BitBox wording and help strings render for every size", () => {
+  for (const words of SIZES) {
+    assert.ok(api.hodlDPlusFinalDescription(words).length > 0, words);
+    assert.ok(api.hodlDPlusFinalHelp(words).length > 0, words);
+  }
+});

--- a/test/number-bases.test.mjs
+++ b/test/number-bases.test.mjs
@@ -68,8 +68,16 @@ test("number-base character counts preserve exact BIP39 entropy lengths", () => 
     [128, 64, 43, 32, 28, 23],
   );
   assert.deepEqual(
+    ["bin", "base4", "base8", "hex", "base32", "base64"].map((format) => api.hodlEntropyFormatConfig(format, 15).digits),
+    [160, 80, 54, 40, 32, 30],
+  );
+  assert.deepEqual(
     ["bin", "base4", "base8", "hex", "base32", "base64"].map((format) => api.hodlEntropyFormatConfig(format, 18).digits),
     [192, 96, 64, 48, 40, 32],
+  );
+  assert.deepEqual(
+    ["bin", "base4", "base8", "hex", "base32", "base64"].map((format) => api.hodlEntropyFormatConfig(format, 21).digits),
+    [224, 112, 75, 56, 48, 39],
   );
   assert.deepEqual(
     ["bin", "base4", "base8", "hex", "base32", "base64"].map((format) => api.hodlEntropyFormatConfig(format, 24).digits),
@@ -80,7 +88,9 @@ test("number-base character counts preserve exact BIP39 entropy lengths", () => 
 test("all six formats decode to the same entropy bytes", () => {
   const vectors = [
     [12, "000102030405060708090a0b0c0d0e0f"],
+    [15, "000102030405060708090a0b0c0d0e0f10111213"],
     [18, "000102030405060708090a0b0c0d0e0f1011121314151617"],
+    [21, "000102030405060708090a0b0c0d0e0f101112131415161718191a1b"],
     [24, "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"],
   ];
   for (const [words, hex] of vectors) {
@@ -117,12 +127,13 @@ test("Base 8 uses a mixed-radix final character and Base32 switches to coin flip
 });
 
 test("complete entropy can be synchronized into every number base", () => {
-  const hex = "000102030405060708090a0b0c0d0e0f";
-  const bytes = Uint8Array.from(Buffer.from(hex, "hex"));
-  for (const format of ["bin", "base4", "base8", "hex", "base32", "base64"]) {
-    const value = api.hodlNumberBaseValueFromBytes(bytes, format, 12);
-    assert.equal(value.replace(/\s/g, ""), encodeInFormat(hex, format, 12), format);
-    assert.equal(api.hodlNumberBaseEntropy(value, format, 12).hex, hex, format);
+  for (const [words, hex] of [[12, "000102030405060708090a0b0c0d0e0f"], [15, "000102030405060708090a0b0c0d0e0f10111213"], [21, "000102030405060708090a0b0c0d0e0f101112131415161718191a1b"]]) {
+    const bytes = Uint8Array.from(Buffer.from(hex, "hex"));
+    for (const format of ["bin", "base4", "base8", "hex", "base32", "base64"]) {
+      const value = api.hodlNumberBaseValueFromBytes(bytes, format, words);
+      assert.equal(value.replace(/\s/g, ""), encodeInFormat(hex, format, words), `${words} words, ${format}`);
+      assert.equal(api.hodlNumberBaseEntropy(value, format, words).hex, hex, `${words} words, ${format}`);
+    }
   }
 });
 

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -675,6 +675,7 @@ test("PSBT amounts and fees are labeled as unverified claims", () => {
 
 test("seed-length selector offers all five BIP39 sizes", () => {
   for (const words of [12, 15, 18, 21, 24]) {
-    assert.match(template, new RegExp(`data-seed-words="${words}"`), `${words} missing`);
+    assert.match(template, new RegExp(`data-seed-words="${words}"`), `${words} missing from src/index.html`);
+    assert.match(app, new RegExp(`data-seed-words="${words}"`), `${words} missing from runtime markup in src/js/app.js`);
   }
 });

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -672,3 +672,9 @@ test("PSBT amounts and fees are labeled as unverified claims", () => {
   assert.match(app, /Input amounts and any fee are unverified PSBT claims/);
   assert.doesNotMatch(app, /Fee \(from PSBT fields\)/);
 });
+
+test("seed-length selector offers all five BIP39 sizes", () => {
+  for (const words of [12, 15, 18, 21, 24]) {
+    assert.match(template, new RegExp(`data-seed-words="${words}"`), `${words} missing`);
+  }
+});


### PR DESCRIPTION
## Summary

The seed-length selector and every entropy entry method previously carried full support only for 12-, 18-, and 24-word seeds. This series extends 12, 15, 18, 21, and 24 words across all entropy types, each mode landings as its own commit.

## What changed, per commit

- **Word lengths: presets and selectors** — `hodlSeedLengths` gains exact 15-word (160 bits/20 bytes/40 hex, 62 hashed rolls, 14 partial words, 64 candidates) and 21-word (224/28/56, 87 rolls, 20 partial, 16 candidates) entries, and `src/index.html` gains the two selector buttons.
- **D++ word picks** — the hardcoded 12/18/24 checksum-final logic becomes a fixed roll spec per size: 12 → D8+D16, 15 → D8 twice, 18 → D16+coin, 21 → D16, 24 → D8. UI copy, correction guidance, error messages, and keypad behavior derive from the spec. `test/dplus.test.mjs` proves each spec's bits exactly cover `log2(candidates)` and the picked word is BIP39 checksum-valid.
- **BitBox diceware** — already table-driven; `test/bitbox.test.mjs` verifies all five sizes produce checksum-valid candidates and skip reroll faces (5/6) correctly.
- **Number bases** — fully generic through `hodlEntropyFormatConfig`; extended `test/number-bases.test.mjs` asserts exact digit counts for 15/21 in all six formats with byte round trips.
- **Cards** — thresholds were coarse (`≤192 → 39`, else `52+6`); now exact minimal counts: 25 (128), 31 (160), 39 (192), 50 (224), 52+6 (256), with cumulative-entropy tests.
- **Hashed dice (COLDCARD/Keystone)** — `test/dice-hashed.test.mjs` asserts the documented roll guidance (50/62/75/87/99) and full-mnemonic derivation for every size in both methods.
- **UI defaults** — `test/ui-defaults.test.mjs` asserts all five selector buttons render.
- **Selection wording/index fallback** — pre-JS fallback markup and D++ error strings stop claiming 23-word/8-candidate specifics.
- **Docs** — README notes support for all five phrase lengths.

## Verification

- `npm run build` → clean; `entropylab.html` regenerates byte-identically from sources.
- All **229 non-browser tests pass** (was 220 at the base), including the three new suites (`dplus`, `bitbox`, `dice-hashed`) and extended `number-bases`/`cards`/`ui-defaults` suites.
- `test/browser.test.mjs` (headless Firefox) failed **identically at the base commit** in my environment — Firefox never starts the suite (`RenderCompositorSWGL failed mapping default framebuffer`), so the report file is never written. Not caused by this change; would appreciate a CI/local confirmation.