### PR TITLE
Standardize enabled button press feedback

### DIFF
--- a/entropylab.html
+++ b/entropylab.html
@@ -78,6 +78,15 @@ h2 { font-size: 1.5rem; margin: 8px 0; }
 a { color: var(--accent); }
 button, select, textarea, input { font: inherit; }
 button { cursor: pointer; }
+/* Every enabled button uses the same momentary press feedback. The disabled
+   state is intentionally excluded so controls that become unavailable after
+   their click transition directly from orange to their disabled treatment. */
+button:not(:disabled):active {
+  background: var(--selection-accent) !important;
+  color: var(--selection-fg) !important;
+  border-color: var(--selection-accent) !important;
+}
+button:not(:disabled):active * { color: inherit !important; }
 .wrap { max-width: 1000px; margin: 0 auto; padding: calc(var(--site-header-height) + 20px) 16px 64px; }
 .kicker { font-size: 12px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--accent); font-weight: 600; }
 .card { background: var(--surface); border: 1px solid var(--border); border-radius: 20px; padding: 20px; margin: 16px 0; }

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -76,6 +76,15 @@ h2 { font-size: 1.5rem; margin: 8px 0; }
 a { color: var(--accent); }
 button, select, textarea, input { font: inherit; }
 button { cursor: pointer; }
+/* Every enabled button uses the same momentary press feedback. The disabled
+   state is intentionally excluded so controls that become unavailable after
+   their click transition directly from orange to their disabled treatment. */
+button:not(:disabled):active {
+  background: var(--selection-accent) !important;
+  color: var(--selection-fg) !important;
+  border-color: var(--selection-accent) !important;
+}
+button:not(:disabled):active * { color: inherit !important; }
 .wrap { max-width: 1000px; margin: 0 auto; padding: calc(var(--site-header-height) + 20px) 16px 64px; }
 .kicker { font-size: 12px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--accent); font-weight: 600; }
 .card { background: var(--surface); border: 1px solid var(--border); border-radius: 20px; padding: 20px; margin: 16px 0; }

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -31,6 +31,13 @@ test("top status banner omits the entropy RNG message", () => {
   assert.match(template, /<div class="kicker">Run Offline · Bring your own entropy<\/div>/);
 });
 
+test("every enabled button uses orange and black momentary press feedback", () => {
+  assert.match(css, /button:not\(:disabled\):active \{[\s\S]*?background: var\(--selection-accent\) !important;[\s\S]*?color: var\(--selection-fg\) !important;[\s\S]*?border-color: var\(--selection-accent\) !important;/);
+  assert.match(css, /button:not\(:disabled\):active \* \{ color: inherit !important; \}/);
+  assert.equal(/--selection-accent: #ff9900;/.test(css), true);
+  assert.equal(/--selection-fg: #000000;/.test(css), true);
+});
+
 test("all wallet network selectors enable and default to mainnet", () => {
   for (const id of ["network", "msig-network", "psbt-network"]) {
     const selectedMainnet = new RegExp(


### PR DESCRIPTION
Applies one consistent momentary pressed state to every enabled button.\n\n- Uses the existing orange selection accent and black foreground.\n- Excludes disabled controls so buttons that become unavailable transition directly to their disabled state.\n- Adds a UI invariant test and rebuilds the standalone artifact.\n\nValidation: npm run test:ci (245 passing), npm run verify, and git diff --check.