### PR TITLE
Reserve compact LifeHash fingerprint frames

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -699,13 +699,16 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
   border-radius: 10px; background: var(--surface-2);
   transition: background-color .16s ease, border-color .16s ease;
 }
-/* The LifeHash sits beside the fingerprint: a deterministic visual twin of the
-   hex, so two fingerprints can be compared at a glance. Crisp pixels, no
-   interpolation, per the LifeHash presentation guidance. */
-.master-fingerprint-lifehash {
-  float: right; width: 48px; height: 48px; margin: 0 0 4px 8px; border-radius: 4px;
-  image-rendering: pixelated; background: #fff;
+/* The fixed-size frame stays present while the fingerprint is unavailable, so
+   resolving a LifeHash never changes the card height or shifts nearby fields. */
+.master-fingerprint-lifehash-frame {
+  float: right; display: block; width: 40px; height: 40px; margin-left: 8px;
+  border: 1px solid var(--border); border-radius: 4px; overflow: hidden; background: transparent;
 }
+.master-fingerprint-lifehash {
+  display: block; width: 100%; height: 100%; image-rendering: pixelated; background: #fff;
+}
+.master-fingerprint-lifehash[hidden] { display: none; }
 .master-fingerprint-label {
   display: block; color: var(--muted); font-size: 12px; line-height: 1.35;
   transition: color .16s ease, opacity .16s ease;

--- a/src/index.html
+++ b/src/index.html
@@ -99,11 +99,13 @@ words, pick one of the checksum words.</span></span>
       <div class="master-fingerprint-preview" id="master-fingerprint-preview" role="status" aria-live="polite" aria-atomic="true">
         <p class="label master-fingerprint-heading">Master fingerprint</p>
         <div class="master-fingerprint-card is-disabled" id="base-master-fingerprint-card" role="group" data-state="unavailable" aria-label="Base seed master fingerprint unavailable">
+          <span class="master-fingerprint-lifehash-frame" aria-hidden="true"><img class="master-fingerprint-lifehash" id="base-master-fingerprint-lifehash" alt="" width="96" height="96" hidden></span>
           <span class="master-fingerprint-label">Base seed</span>
           <code class="master-fingerprint-value" id="base-master-fingerprint"></code>
         </div>
         <span class="master-fingerprint-arrow is-disabled" id="master-fingerprint-arrow" aria-hidden="true">→</span>
         <div class="master-fingerprint-card master-fingerprint-derived is-disabled" id="passphrase-master-fingerprint-card" role="group" data-state="unavailable" aria-label="With passphrase master fingerprint unavailable">
+          <span class="master-fingerprint-lifehash-frame" aria-hidden="true"><img class="master-fingerprint-lifehash" id="passphrase-master-fingerprint-lifehash" alt="" width="96" height="96" hidden></span>
           <span class="master-fingerprint-label">With passphrase</span>
           <code class="master-fingerprint-value" id="passphrase-master-fingerprint"></code>
         </div>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -426,13 +426,13 @@ ec.innerHTML = `
       <div class="master-fingerprint-preview" id="master-fingerprint-preview" role="status" aria-live="polite" aria-atomic="true">
         <p class="label master-fingerprint-heading">Master fingerprint</p>
         <div class="master-fingerprint-card is-disabled" id="base-master-fingerprint-card" role="group" data-state="unavailable" aria-label="Base seed master fingerprint unavailable">
-          <img class="master-fingerprint-lifehash" id="base-master-fingerprint-lifehash" alt="" width="96" height="96" hidden />
+          <span class="master-fingerprint-lifehash-frame" aria-hidden="true"><img class="master-fingerprint-lifehash" id="base-master-fingerprint-lifehash" alt="" width="96" height="96" hidden /></span>
           <span class="master-fingerprint-label">Base seed</span>
           <code class="master-fingerprint-value" id="base-master-fingerprint"></code>
         </div>
         <span class="master-fingerprint-arrow is-disabled" id="master-fingerprint-arrow" aria-hidden="true">\u2192</span>
         <div class="master-fingerprint-card master-fingerprint-derived is-disabled" id="passphrase-master-fingerprint-card" role="group" data-state="unavailable" aria-label="With passphrase master fingerprint unavailable">
-          <img class="master-fingerprint-lifehash" id="passphrase-master-fingerprint-lifehash" alt="" width="96" height="96" hidden />
+          <span class="master-fingerprint-lifehash-frame" aria-hidden="true"><img class="master-fingerprint-lifehash" id="passphrase-master-fingerprint-lifehash" alt="" width="96" height="96" hidden /></span>
           <span class="master-fingerprint-label">With passphrase</span>
           <code class="master-fingerprint-value" id="passphrase-master-fingerprint"></code>
         </div>
@@ -4646,14 +4646,16 @@ function hodlSetMasterFingerprintCard(card, valueNode, value, imageNode) {
   let available = typeof value === "string" && value.length > 0, label = `${card.querySelector(".master-fingerprint-label")?.textContent.trim() || ""} master fingerprint`.trim();
   valueNode.textContent = available ? value : "";
   if (imageNode) {
-    imageNode.hidden = !available;
+    imageNode.hidden = true;
+    imageNode.removeAttribute("src");
     if (available) {
       // LifeHash is deterministic per fingerprint; show it only once resolved.
       hodlLifeHash.fromFingerprint(value).then((url) => {
-        if (valueNode.textContent === value) imageNode.src = url;
+        if (valueNode.textContent === value) {
+          imageNode.src = url;
+          imageNode.hidden = false;
+        }
       }).catch(() => { imageNode.hidden = true; });
-    } else {
-      imageNode.removeAttribute("src");
     }
   }
   card.classList.toggle("is-disabled", !available);

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -421,13 +421,16 @@ test("Legacy multisig defaults to BIP45 and offers BIP87 accounts only for Legac
   assert.match(app, /legacyScriptConflict=standards\.includes\("bip87"\)&&summary\.kinds\.some\(kind=>kind!=="p2sh"\)/);
 });
 
-test("the master fingerprint cards carry a LifeHash image next to the hex", () => {
-  // Both cards get a LifeHash img beside the fingerprint value.
-  assert.match(app, /id="base-master-fingerprint-card"[\s\S]*?id="base-master-fingerprint-lifehash"/);
-  assert.match(app, /id="passphrase-master-fingerprint-card"[\s\S]*?id="passphrase-master-fingerprint-lifehash"/);
+test("the master fingerprint cards reserve a compact empty square for each LifeHash", () => {
+  // Both cards keep a frame beside the value, while the image itself starts hidden.
+  assert.match(app, /id="base-master-fingerprint-card"[\s\S]*?class="master-fingerprint-lifehash-frame"[\s\S]*?id="base-master-fingerprint-lifehash"[^>]*hidden/);
+  assert.match(app, /id="passphrase-master-fingerprint-card"[\s\S]*?class="master-fingerprint-lifehash-frame"[\s\S]*?id="passphrase-master-fingerprint-lifehash"[^>]*hidden/);
   // The card setter renders the deterministic icon for the shown fingerprint.
   assert.match(app, /function hodlSetMasterFingerprintCard\(card,valueNode,value,imageNode\)/);
   assert.match(app, /hodlLifeHash\.fromFingerprint\(value\)/);
+  assert.match(appSource, /imageNode\.hidden = true;\s*imageNode\.removeAttribute\("src"\);/);
+  assert.match(appSource, /imageNode\.src = url;\s*imageNode\.hidden = false;/);
+  assert.match(css, /\.master-fingerprint-lifehash-frame \{[^}]*width: 40px; height: 40px;/);
   // Crisp pixels per the LifeHash presentation guidance.
   assert.match(css, /\.master-fingerprint-lifehash \{[^}]*image-rendering: pixelated;/);
 });


### PR DESCRIPTION
## Summary
- keep a compact 40px square reserved in each master-fingerprint card
- show an empty square until the corresponding fingerprint is available
- reveal a LifeHash only after its asynchronous render resolves and avoid stale icons
- align the frame with even top and bottom card spacing

## Validation
- npm run ci