### PR TITLE
Fix #86: tokenise D++ decimal D16 by delimiter, not by character

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1881,10 +1881,30 @@ function hodlDPlusD16Value(face) {
 }
 // Single tokenizer shared by the parser and the input sanitiser so the two can
 // never disagree about where one roll ends and the next begins.
-function hodlDPlusTokens(value) {
+function hodlDPlusTokens(value, numberedD16 = false) {
   let text = String(value ?? ""),
     entries = [],
     index = 0;
+  if (numberedD16) {
+    // Decimal D16: each non-separator chunk is one roll. Normalise 1-9 to
+    // themselves, 10-15 to A-F, 16 to 0. Out-of-range or non-numeric chunks
+    // keep their original face but are flagged invalid so the downstream
+    // pipeline surfaces them via invalidRanges.
+    for (const match of text.matchAll(/[^\s,;|]+/g)) {
+      let start = match.index,
+        chunk = match[0],
+        end = start + chunk.length,
+        parsed = Number.parseInt(chunk, 10),
+        face,
+        invalid = false;
+      if (Number.isFinite(parsed) && parsed >= 1 && parsed <= 9) face = String(parsed);
+      else if (Number.isFinite(parsed) && parsed >= 10 && parsed <= 15) face = "ABCDEF"[parsed - 10];
+      else if (Number.isFinite(parsed) && parsed === 16) face = "0";
+      else { face = chunk.toUpperCase(); invalid = true; }
+      entries.push({ face, start, end, invalid });
+    }
+    return entries;
+  }
   while (index < text.length) {
     let character = String.fromCodePoint(text.codePointAt(index));
     if (/[\s,;|]/.test(character)) {
@@ -1908,7 +1928,7 @@ function hodlDPlusRolls(value, targetWords = Pt, numberedD16 = hodlDPlusNumbered
     rejectedD8 = 0,
     rejectedD16 = 0,
     acceptedCharacters = [];
-  entries = hodlDPlusTokens(value);
+  entries = hodlDPlusTokens(value, numberedD16);
   let rolledEntries = entries.slice(0, rolledCharacterTarget),
     wordSlots = Array(rolledTarget).fill(""),
     groups = [],
@@ -1918,7 +1938,7 @@ function hodlDPlusRolls(value, targetWords = Pt, numberedD16 = hodlDPlusNumbered
   for (let groupIndex = 0; groupIndex < rolledTarget; groupIndex++) {
     let tokens = rolledEntries.slice(groupIndex * 3, groupIndex * 3 + 3);
     if (!tokens.length) break;
-    let validity = tokens.map((token, position) => position === 0 ? /^[1-8]$/.test(token.face) : hodlDPlusD16Value(token.face) !== null);
+    let validity = tokens.map((token, position) => token.invalid ? false : (position === 0 ? /^[1-8]$/.test(token.face) : hodlDPlusD16Value(token.face) !== null));
     tokens.forEach((token, position) => {
       if (validity[position]) {
         acceptedCharacters.push(token.face);

--- a/test/dplus-decimal.test.mjs
+++ b/test/dplus-decimal.test.mjs
@@ -1,0 +1,168 @@
+// D++ decimal (numbered) D16 input parsing.
+//
+// Lock-down coverage for issue #86: when numberedD16 is enabled the tokenizer
+// must consume multi-digit values 10-16 as a single roll rather than splitting
+// them into single hex digits. Every value here is synthetic and the derived
+// mnemonics are not used to hold real funds.
+//
+// Run with: npm test
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { wordlist as Ae } from "@scure/bip39/wordlists/english.js";
+import { validateMnemonic as Pn } from "@scure/bip39";
+
+const root = dirname(fileURLToPath(import.meta.url));
+const app = readFileSync(join(root, "..", "src/js/app.js"), "utf8");
+
+function loadSlice(name) {
+  const start = app.indexOf(`function ${name}(`);
+  assert.ok(start >= 0, name);
+  let depth = 0;
+  let end = -1;
+  for (let i = app.indexOf("{", start); i < app.length; i++) {
+    if (app[i] === "{") depth++;
+    else if (app[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        end = i + 1;
+        break;
+      }
+    }
+  }
+  assert.ok(end > start, name);
+  return app.slice(start, end);
+}
+function loadVariable(name, nextName) {
+  const start = app.search(new RegExp(`var\\s+${name}\\s*=`));
+  const end = app.search(new RegExp(`var\\s+${nextName}\\s*=`));
+  assert.ok(start >= 0 && end > start, name);
+  return app.slice(start, end);
+}
+function loadVariableBeforeFunction(name, terminator) {
+  const start = app.search(new RegExp(`var\\s+${name}\\s*=`));
+  const end = app.indexOf(`function ${terminator}(`, start);
+  assert.ok(start >= 0 && end > start, name);
+  return app.slice(start, end);
+}
+
+const Z = (input) => new Uint8Array(createHash("sha256").update(input).digest());
+const api = new Function(
+  "Ae",
+  "Pn",
+  "Z",
+  `
+  var Pt = 24;
+  ${loadVariable("hodlSeedLengths", "hodlEntropyFormats")}
+  ${loadVariableBeforeFunction("hodlDPlusFinalSpecs", "hodlDPlusStepBits")}
+  ${["hodlSeedConfig", "hodlDPlusStepBits", "hodlDPlusStepLabel", "hodlDPlusStepValue", "hodlDPlusFinalSteps", "hodlDPlusFinalDescription", "hodlDPlusFinalHelp", "hodlDPlusStepChecksumLabel", "hodlDPlusD16Value", "hodlDPlusTokens", "Rn", "Mt", "hodlTargetLastWords", "hodlComputeTargetLastWords", "mi", "hodlDPlusRolls", "hodlValidateTargetMnemonic", "hodlSeedCountStatus"].map(loadSlice).join("\n")}
+  var hodlLastWordCache = new Map();
+  var hodlBip39WordSet = new Set(Ae);
+  var hodlBip39WordIndex = new Map(Ae.map((word, index) => [word, index]));
+  return { hodlDPlusRolls, hodlDPlusTokens, hodlDPlusD16Value, hodlDPlusFinalSteps, hodlValidateTargetMnemonic, hodlSeedConfig };
+  `,
+)(Ae, Pn, Z);
+
+// Synthetic hex group used as a baseline. D8=1 (face "1"), D16=0 (face "0"),
+// D16=14 (face "E"). Decimal equivalent is "1 16 14" (hex E = decimal 14,
+// hex 0 = decimal 16).
+const HEX_GROUP = "10E";
+const DECIMAL_GROUP = "1 16 14";
+const SIZES = [12, 15, 18, 21, 24];
+
+// Map a hex final-step face to its decimal notation equivalent.
+function decimalFinalFace(step, hexFace) {
+  if (step === "d8" || step === "coin") return hexFace;
+  // D16: "0" → "16" (decimal zero = 16), otherwise the face is unchanged.
+  return hexFace === "0" ? "16" : hexFace;
+}
+
+function buildTranscript(words, group, numberedD16) {
+  const config = api.hodlSeedConfig(words);
+  const steps = api.hodlDPlusFinalSteps(words);
+  const tokenise = (g) => numberedD16 ? g.split(/\s+/).filter(Boolean) : g.split("");
+  const headTokens = tokenise(group);
+  const headValue = numberedD16 ? headTokens.join(" ") : headTokens.join("");
+  const finalValue = steps
+    .map((step) => {
+      const hex = step === "d8" || step === "coin" ? "5" : "0";
+      return numberedD16 ? decimalFinalFace(step, hex) : hex;
+    })
+    .join(numberedD16 ? " " : "");
+  // Pad each repetition with separators in decimal mode so concatenated groups
+  // do not glue together (e.g. "14" + "1" → "141" would be one chunk).
+  const headChunk = numberedD16 ? `${headValue} ` : headValue;
+  const finalChunk = numberedD16 ? ` ${finalValue}` : finalValue;
+  return headChunk.repeat(config.partialWords) + finalChunk;
+}
+
+test("issue #86 repro: decimal D++ group '1 16 16' selects BIP39 index 0 (abandon)", () => {
+  // Group: D8=1 (face 1), D16=16 (decimal zero), D16=16 (decimal zero).
+  // WordIndex = (1-1) * 256 + 0 * 16 + 0 = 0.
+  const parsed = api.hodlDPlusRolls("1 16 16", 12, true);
+  assert.equal(parsed.groups[0].word, Ae[0], `first group word should be 'abandon' but was '${parsed.groups[0].word}'`);
+  assert.equal(parsed.groups[0].valid, true, `first group must be valid (faces=${parsed.groups[0].faces.join("|")})`);
+});
+
+test("decimal and hex transcripts of the same rolls select identical complete mnemonics", () => {
+  for (const words of SIZES) {
+    const hexValue = buildTranscript(words, HEX_GROUP, false);
+    const decValue = buildTranscript(words, DECIMAL_GROUP, true);
+    const hexParsed = api.hodlDPlusRolls(hexValue, words, false);
+    const decParsed = api.hodlDPlusRolls(decValue, words, true);
+    assert.equal(hexParsed.complete, true, `${words}: hex transcript did not complete`);
+    assert.equal(decParsed.complete, true, `${words}: decimal transcript did not complete`);
+    const hexPhrase = [...hexParsed.wordSlots, hexParsed.finalWord].join(" ");
+    const decPhrase = [...decParsed.wordSlots, decParsed.finalWord].join(" ");
+    assert.equal(decPhrase, hexPhrase, `${words}: phrases differ (hex='${hexPhrase}' dec='${decPhrase}')`);
+    assert.equal(api.hodlValidateTargetMnemonic(decPhrase, words).ok, true, `${words}: decimal phrase failed BIP39 validation`);
+  }
+});
+
+test("decimal D++ tokeniser treats values 10-16 as a single roll", () => {
+  // 'acceptedCharacters' is the flattened list of faces the parser kept. In
+  // decimal mode each value 10-16 must contribute one entry, not the digits
+  // of the decimal number.
+  for (const value of ["10", "11", "12", "13", "14", "15", "16"]) {
+    const parsed = api.hodlDPlusRolls(value, 12, true);
+    // Three groups worth of head rolls would be 33 entries; we want at most 1
+    // head entry for a single decimal value, so the very first group can have
+    // at most 1 face and the others must be empty.
+    const firstGroupFaces = parsed.groups[0].faces.length;
+    assert.ok(firstGroupFaces <= 1, `'${value}' produced ${firstGroupFaces} faces in group 0 (${parsed.groups[0].faces.join("|")})`);
+  }
+});
+
+test("decimal D++ invalid values are rejected unambiguously", () => {
+  // Each case fills a complete D++ group (D8 + D16 + D16) with a single
+  // invalid token placed in a D16 slot. In hex mode these would currently
+  // be tokenised differently, so we test decimal mode specifically.
+  const cases = [
+    { value: "1 0 5", reason: "decimal 0 is out of range (faces read 1-16)" },
+    { value: "1 17 5", reason: "decimal 17 is out of range" },
+    { value: "1 5 0", reason: "decimal 0 at the final D16 position" },
+    { value: "1 A 5", reason: "hex letter A is not valid in decimal mode" },
+    { value: "1 F 5", reason: "hex letter F is not valid in decimal mode" },
+  ];
+  for (const { value, reason } of cases) {
+    const parsed = api.hodlDPlusRolls(value, 12, true);
+    assert.equal(parsed.groups[0].valid, false, `${reason} (input='${value}', faces=${parsed.groups[0].faces.join("|")})`);
+    // The invalid token must also be reported via the parser's invalid ranges
+    // so the UI can highlight it for the user.
+    assert.ok(parsed.invalidRanges.length > 0, `${reason}: invalid input must be surfaced in invalidRanges`);
+  }
+});
+
+test("decimal D++ roll count tracks physical rolls, not decimal digits", () => {
+  // '1 16 16' is three physical rolls. Current tokenizer produces five
+  // entries and that should NOT happen after the fix.
+  const parsed = api.hodlDPlusRolls("1 16 16", 12, true);
+  // The acceptedCharacters array is what the parser keeps. Three physical
+  // rolls should yield exactly three accepted faces (or fewer if any are
+  // invalid in the first slot, which the D8 position would catch — but
+  // each value here is a valid D8 or D16).
+  assert.equal(parsed.acceptedCharacters.length, 3, `'1 16 16' produced ${parsed.acceptedCharacters.length} accepted faces, expected 3`);
+});


### PR DESCRIPTION
## Summary

Fixes #86. The D++ tokenizer split every non-separator character into a single token, which meant decimal values 10-16 (multi-character) were broken into separate rolls. `"1 16 16"` became `[1,1,6,1,6]` and selected "actress" (BIP39 index 22) instead of "abandon" (index 0). An honest user could fund a wallet whose mnemonic could not be reconstructed from the recorded physical rolls.

## What changes

- `hodlDPlusTokens` now takes a `numberedD16` parameter and, when set, splits on whitespace and the existing separator set, then normalises each chunk: 1-9 → themselves, 10-15 → A-F, 16 → 0.
- Out-of-range or non-numeric chunks keep their face so the UI can show what the user typed, plus an `invalid: true` flag so the existing pipeline surfaces them via `invalidRanges`.
- Decimal mode requires D++'s documented decimal notation. Hex transcripts continue to tokenise exactly as before, character-by-character.

## Tests

Adds `test/dplus-decimal.test.mjs` with 5 tests covering the issue's synthetic repro and all four acceptance criteria (decimal/hex equivalence for every target size, single-roll accounting for values 10-16, unambiguous rejection of out-of-range and hex-letter input in decimal mode).

```
npm run test:ci   # 248/248 pass
npm run build     # deterministic from src/
```

The single failure in `npm test` is the headless-Firefox suite timing out in this environment (`RenderCompositorSWGL failed mapping default framebuffer`); it was failing before this change and is unrelated to the parser.

## Intentionally excluded

- `entropylab.html` (build artifact; CI rebuilds and commits it after merge per the README workflow — keeping it out of PRs avoids merge conflicts and matches the repo's existing convention).
- `hodlSanitizeDPlusInput` — needs `numberedD16` threaded through so the sanitiser respects decimal mode. Split into a follow-up so this PR stays focused on the parser, per CONTRIBUTING.md's "small and focused, one change each".
