### PR TITLE
PSBT inspection: decode and block unsafe sighash policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Official website: [entropylab.online](https://entropylab.online)
   for repeated ECDSA nonces from the same public key, verifies optional Jade
   anti-exfil (sign-to-contract) transcripts without a key, and can compare supported
   SegWit v0 SIGHASH_ALL signatures with RFC 6979, including Bitcoin Core-style low-r grinding, in a temporary session.
+  Every input's declared sighash policy and each signature's appended sighash
+  byte are decoded without a key; anything other than exact SIGHASH_ALL is a
+  blocking warning.
 - Runs a quick barrage of startup sanity checks on the host browser (secure
   context, CSPRNG, BigInt, UTF-8 encoding, and NFKD normalization). If any
   check fails, the page is replaced with a failure report listing the failed

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "node scripts/build.mjs",
     "clean": "node scripts/build.mjs --clean",
     "test": "node --test test/*.test.mjs",
-    "test:ci": "node --test test/network-check.test.mjs test/browser-check.test.mjs test/ui-defaults.test.mjs test/validate.test.mjs test/descriptor.test.mjs test/seedqr.test.mjs test/cards.test.mjs test/copy-seed.test.mjs test/number-bases.test.mjs test/dice-fairness.test.mjs test/seed-numbers.test.mjs test/dplus.test.mjs test/psbt-low-r.test.mjs test/psbt-metadata.test.mjs test/secret-clear.test.mjs test/sqlite-writer.test.mjs test/wallet-export.test.mjs test/psbt-anti-exfil.test.mjs test/address-match.test.mjs test/psbt-nonce-reuse.test.mjs test/lifehash.test.mjs",
+    "test:ci": "node --test test/network-check.test.mjs test/browser-check.test.mjs test/ui-defaults.test.mjs test/validate.test.mjs test/descriptor.test.mjs test/seedqr.test.mjs test/cards.test.mjs test/copy-seed.test.mjs test/number-bases.test.mjs test/dice-fairness.test.mjs test/seed-numbers.test.mjs test/dplus.test.mjs test/psbt-low-r.test.mjs test/psbt-metadata.test.mjs test/psbt-sighash.test.mjs test/secret-clear.test.mjs test/sqlite-writer.test.mjs test/wallet-export.test.mjs test/psbt-anti-exfil.test.mjs test/address-match.test.mjs test/psbt-nonce-reuse.test.mjs test/lifehash.test.mjs",
     "test:dice-fairness": "node --test test/dice-fairness.test.mjs",
     "test:network": "node --test test/network-check.test.mjs",
     "test:browser-check": "node --test test/browser-check.test.mjs",

--- a/src/index.html
+++ b/src/index.html
@@ -221,7 +221,7 @@ words, pick one of the checksum words.</span></span>
     <section class="card no-print" id="psbt-card" role="tabpanel" hidden>
       <div class="kicker">Inspect first. Sign elsewhere.</div>
       <h2>Read a PSBT. Check its ECDSA nonces.</h2>
-      <p class="muted psbt-intro">Inspecting a PSBT v0 does not require a private key. EntropyLab can show outputs, PSBT-provided input amounts and fees, signatures, and repeated ECDSA nonce values. Optional Jade anti-exfil transcripts (host nonce ρ and signer opening R) are checked without a key. Loading a matching key additionally checks whether supported signatures match plain RFC 6979 or Bitcoin Core-style low-r grinding; a mismatch alone is not evidence of a compromised signer.</p>
+      <p class="muted psbt-intro">Inspecting a PSBT v0 does not require a private key. EntropyLab can show outputs, PSBT-provided input amounts and fees, signatures, and repeated ECDSA nonce values. Optional Jade anti-exfil transcripts (host nonce ρ and signer opening R) are checked without a key. Every input's declared sighash policy and each signature's appended sighash byte are also decoded without a key; anything other than exact SIGHASH_ALL is a blocking warning. Loading a matching key additionally checks whether supported signatures match plain RFC 6979 or Bitcoin Core-style low-r grinding; a mismatch alone is not evidence of a compromised signer.</p>
       <label class="field">PSBT v0 (base64 or hex)
         <textarea id="psbt-text" placeholder="cHNidP8B..." spellcheck="false" autocomplete="off" autocapitalize="off"></textarea>
       </label>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -6322,6 +6322,30 @@ function hodlPartialSigs(entries) {
 function hodlTapSigs(entries) {
   return hodlFind(entries, 19).concat(hodlFind(entries, 20));
 }
+// PSBT_IN_SIGHASH_TYPE (input type 0x03): empty keydata, four-byte
+// little-endian policy. It must be decoded before signing, and shown even
+// without a session key.
+function hodlSighashPolicy(entries) {
+  let declarations = hodlFind(entries, 3).filter((entry) => entry.keydata.length === 0);
+  if (!declarations.length) return null;
+  if (declarations[0].val.length !== 4) throw new Error("A sighash policy field is malformed.");
+  return new DataView(declarations[0].val.buffer, declarations[0].val.byteOffset, 4).getUint32(0, true);
+}
+// The base type occupies the low seven bits; bit 0x80 marks ANYONECANPAY.
+function hodlSighashLabel(policy) {
+  let base = policy & 0x7f, baseName = base === 1 ? "SIGHASH_ALL" : base === 2 ? "SIGHASH_NONE" : base === 3 ? "SIGHASH_SINGLE" : "unknown 0x" + base.toString(16);
+  return baseName + ((policy & 0x80) ? " | ANYONECANPAY" : "") + " (0x" + policy.toString(16) + ")";
+}
+// Exact SIGHASH_ALL is the only policy that commits to every displayed
+// output. Anything else, or a disagreement between the PSBT field and a
+// signature's appended byte, is blocking — no session key required.
+function hodlSighashProblems(declared, suffix) {
+  let problems = [];
+  if (declared !== null && declared !== 1) problems.push("The PSBT requests " + hodlSighashLabel(declared) + ", which does not commit to all shown outputs.");
+  if (suffix !== null && suffix !== 1) problems.push("This signature uses " + hodlSighashLabel(suffix) + ", which does not commit to all shown outputs.");
+  if (declared !== null && suffix !== null && declared !== suffix) problems.push("The PSBT-declared policy and the signature's appended sighash byte disagree.");
+  return problems;
+}
 function hodlFinalized(entries) {
   return entries.some((entry) => entry.type === 7 || entry.type === 8);
 }
@@ -6682,9 +6706,18 @@ function hodlRenderPsbt(psbt) {
       inputSum += witnessUtxo.amount;
       knownInputs++;
     }
+    let declaredSighash = null, declaredSighashError = "";
+    try {
+      declaredSighash = hodlSighashPolicy(entries);
+    } catch (exception) {
+      declaredSighashError = exception.message || String(exception);
+    }
+    let declaredLabel = declaredSighashError ? "" : declaredSighash === null ? "SIGHASH_ALL (default)" : hodlSighashLabel(declaredSighash);
     let previous = tx.inputs[index], destination = witnessUtxo ? hodlAddr(witnessUtxo.script, network) : "(previous output details unavailable)", signatures = hodlPartialSigs(entries), tapSignatures = hodlTapSigs(entries), finalized = hodlFinalized(entries);
     tapSignatureCount += tapSignatures.length;
-    html.push("<p class='psbt-kv'><strong>Input " + index + "</strong> \xB7 " + hodlHexRev(previous.txid) + " : " + previous.vout + (witnessUtxo ? " \xB7 " + hodlSats(witnessUtxo.amount) + " BTC claimed" : "") + "<br>" + $t(destination) + "<br>" + (signatures.length + tapSignatures.length ? signatures.length + tapSignatures.length + " signature(s) present" : finalized ? "Finalized input data present" : "Not signed yet") + "</p>");
+    html.push("<p class='psbt-kv'><strong>Input " + index + "</strong> \xB7 " + hodlHexRev(previous.txid) + " : " + previous.vout + (witnessUtxo ? " \xB7 " + hodlSats(witnessUtxo.amount) + " BTC claimed" : "") + "<br>" + $t(destination) + "<br>" + (signatures.length + tapSignatures.length ? signatures.length + tapSignatures.length + " signature(s) present" : finalized ? "Finalized input data present" : "Not signed yet") + (declaredSighashError ? "<br>Declared sighash policy unreadable: " + $t(declaredSighashError) : "<br>Signature policy: " + $t(declaredLabel)) + "</p>");
+    if (declaredSighashError) html.push("<p class='psbt-bad'><strong>Policy problem:</strong> input " + index + " declares a malformed sighash policy. Do not sign until its policy is known.</p>");
+    else if (declaredSighash !== null && declaredSighash !== 1) html.push("<p class='psbt-bad'><strong>Policy problem:</strong> input " + index + " requests " + $t(declaredLabel) + "; that policy does not commit to all shown outputs. Do not accept the displayed outputs as what a signature will authorize.</p>");
     signatures.forEach(signature => {
       let parts = hodlSigParts(signature.der),
         looseR = parts ? parts.r : hodlDerRLoose(signature.der),
@@ -6698,10 +6731,16 @@ function hodlRenderPsbt(psbt) {
         privateKey = hodlPrivForPub(signature.pubkey) || hodlPrivFromPath(entries, signature.pubkey),
         message = "Need the matching key in this session to check RFC 6979 and low-r grind.",
         className = "muted";
+      let suffixForPolicy = signature.raw.length >= 2 ? signature.sighash : null,
+        sighashProblems = hodlSighashProblems(declaredSighash, suffixForPolicy);
       if (!parts && !looseR) {
         uninspected += 1;
         message = "Signature is not DER and its nonce cannot be inspected.";
-        className = "psbt-warn"
+        className = "psbt-warn";
+        if (sighashProblems.length) {
+          message = "Signature policy problem: " + sighashProblems.join(" ");
+          className = "psbt-bad";
+        }
       } else {
         rValues.push({
           input: index,
@@ -6711,7 +6750,11 @@ function hodlRenderPsbt(psbt) {
           sighash,
           valid: parts ? signatureValid : null
         });
-        if (!parts) {
+        if (sighashProblems.length) {
+          // An unsafe or conflicting sighash policy blocks every other check.
+          message = "Signature policy problem: " + sighashProblems.join(" ");
+          className = "psbt-bad";
+        } else if (!parts) {
           message = "Signature is not strict DER. Its r value is still compared for nonce reuse.";
           className = "psbt-warn"
         } else if (signatureValid === !1) {
@@ -6751,10 +6794,7 @@ function hodlRenderPsbt(psbt) {
           message = "Could not recompute this signature: " + (exception.message || String(exception));
           className = "psbt-warn";
         }
-        else if (privateKey && signature.sighash !== 1) {
-          message = "Matching key found, but this check currently supports SIGHASH_ALL without ANYONECANPAY only.";
-          className = "psbt-warn";
-        } else if (privateKey && !scriptCode) {
+        else if (privateKey && !scriptCode) {
           message = "Matching key found, but this input script is not yet supported for RFC 6979 comparison.";
           className = "psbt-warn";
         }

--- a/test/psbt-sighash.test.mjs
+++ b/test/psbt-sighash.test.mjs
@@ -1,0 +1,87 @@
+// PSBT_IN_SIGHASH_TYPE and signature suffix policy must be decoded and be
+// blocking without a session key. Regression coverage for each base type and
+// ANYONECANPAY combination.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const app = readFileSync(join(root, "src/js/app.js"), "utf8");
+
+function loadSlice(name) {
+  const start = app.indexOf(`function ${name}(`);
+  assert.ok(start >= 0, name);
+  let depth = 0;
+  for (let index = app.indexOf("{", start); index < app.length; index++) {
+    if (app[index] === "{") depth++;
+    else if (app[index] === "}" && --depth === 0) return app.slice(start, index + 1);
+  }
+  throw new Error(`Could not extract ${name}`);
+}
+
+const hodlFind = (entries, type) => entries.filter((entry) => entry.type === type);
+const { hodlSighashPolicy, hodlSighashLabel, hodlSighashProblems } = new Function(
+  "hodlFind",
+  `${["hodlSighashPolicy", "hodlSighashLabel", "hodlSighashProblems"].map(loadSlice).join("\n")}; return { hodlSighashPolicy, hodlSighashLabel, hodlSighashProblems };`,
+)(hodlFind);
+
+const entry = (type, value, keydata = new Uint8Array(0)) => ({ type, keydata, val: value });
+const u32 = (value) => Uint8Array.of(value & 255, (value >>> 8) & 255, (value >>> 16) & 255, (value >>> 24) & 255);
+
+const BASES = [
+  [1, "SIGHASH_ALL"],
+  [2, "SIGHASH_NONE"],
+  [3, "SIGHASH_SINGLE"],
+];
+
+test("the declared policy is parsed as an empty-keydata little-endian u32", () => {
+  assert.equal(hodlSighashPolicy([entry(3, u32(1))]), 1);
+  assert.equal(hodlSighashPolicy([entry(3, u32(0x82))]), 0x82);
+  // a non-empty keydata declaration is not a policy
+  assert.equal(hodlSighashPolicy([entry(3, u32(0x82), Uint8Array.of(1))]), null);
+  // malformed length is rejected, not silently ignored
+  assert.throws(() => hodlSighashPolicy([entry(3, Uint8Array.of(1))]), /malformed/);
+});
+
+test("every base type and its ANYONECANPAY form is labeled", () => {
+  for (const [value, name] of BASES) {
+    assert.ok(hodlSighashLabel(value).includes(name) && !hodlSighashLabel(value).includes("ANYONECANPAY"), name);
+    assert.ok(hodlSighashLabel(value | 0x80).includes("ANYONECANPAY"), name);
+  }
+});
+
+test("exact SIGHASH_ALL declared and signed produces no problem", () => {
+  assert.deepEqual(hodlSighashProblems(1, 1), []);
+  assert.deepEqual(hodlSighashProblems(null, 1), []);
+});
+
+test("non-ALL declarations are blocking even with an ALL suffix, in inspection mode", () => {
+  for (const [value, name] of BASES.slice(1)) {
+    for (const variant of [value, value | 0x80]) {
+      const problems = hodlSighashProblems(variant, 1);
+      assert.ok(problems.length >= 1 && problems[0].includes(name), `${name}: ${problems.join(" ")}`);
+    }
+  }
+});
+
+test("a non-ALL suffix is blocking even without a declared policy", () => {
+  for (const [value, name] of BASES.slice(1)) {
+    for (const variant of [value, value | 0x80]) {
+      const problems = hodlSighashProblems(null, variant);
+      assert.ok(problems.length === 1 && problems[0].includes(name), name);
+    }
+  }
+});
+
+test("a declared/signature mismatch is reported", () => {
+  const problems = hodlSighashProblems(1, 0x82);
+  assert.ok(problems.some((problem) => problem.includes("disagree")));
+});
+
+test("an agreed non-ALL policy still flags both sides of the request", () => {
+  const problems = hodlSighashProblems(0x83, 0x83);
+  assert.equal(problems.length, 2);
+  assert.ok(problems.every((problem) => problem.includes("SIGHASH_SINGLE")), problems.join(" "));
+});


### PR DESCRIPTION
## Summary

Fixes the PSBT-inspector finding: previously, `PSBT_IN_SIGHASH_TYPE` (input type 0x03) was retained as an unrendered generic entry, so a pre-signing PSBT could request `SIGHASH_NONE`, `SIGHASH_SINGLE`, or `ANYONECANPAY` while the inspector displayed outputs as if they were committed. Existing partial signatures had their appended sighash byte extracted, but a non-ALL warning only rendered when the matching session key was loaded.

This branch parses the declared policy as an empty-keydata, four-byte little-endian input field, renders every input's declared policy, and raises a blocking `psbt-bad` warning for any policy other than exact `SIGHASH_ALL` — without a session key. The appended sighash byte is decoded and checked in inspect-only mode, and a `Policy problem` warning is raised on mismatch between the PSBT field and the signature suffix.

The trailed key-only check (`try again after loading the matching key` branch) is removed; the same condition now flips directly to `psbt-bad` without needing the profile.

## Verification

- `npm run build` — deterministic `entropylab.html` from `src/`.
- `npm test` — 236/237 pass; the one failure is the pre-existing headless-Firefox framebuffer mapping error in this environment (same on `rock`).
- `node --test test/psbt-sighash.test.mjs` — 7/7 pass: decodes the field, labels all base/ANYONECANPAY combinations, exercises ALL/NONE/SINGLE declarations and suffixes, mismatch, and malformed length.

## Intentionally excluded

The build artifact `entropylab.html` is CI-rebuilt from `src/` and intentionally not included, matching the repo convention. All existing PSBT tests were re-run unchanged.