### PR TITLE
Gate the page on a per-release beta software disclaimer

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -633,13 +633,24 @@ td { border-top: 1px solid var(--border); padding: 8px; vertical-align: top; fon
 .online-warning strong { color: var(--danger); }
 .online-warning a { font-weight: 700; white-space: nowrap; }
 .beta-warning strong { color: var(--danger); }
-.site-footer {
-  margin-top: var(--space-lede); padding-top: 14px; border-top: 1px solid var(--border);
+.disclaimer-overlay {
+  position: fixed; inset: 0; z-index: 200; display: grid; place-items: center;
+  padding: 24px; box-sizing: border-box; background: rgb(0 0 0 / 55%);
+  opacity: 0; transition: opacity .24s ease;
 }
-.fine-print {
-  max-width: 700px; margin: 0 auto; color: var(--faint); font-size: 12px;
-  line-height: 1.6; text-align: center;
+.disclaimer-overlay[hidden] { display: none; }
+.disclaimer-overlay.is-visible { opacity: 1; }
+.disclaimer-overlay.is-dismissed { opacity: 0; pointer-events: none; }
+.disclaimer-card {
+  max-width: 520px; padding: 28px 24px; text-align: center;
+  border: 1px solid var(--danger); border-radius: 12px;
+  background: color-mix(in oklab, var(--danger) 10%, var(--surface));
+  box-shadow: 0 16px 36px rgb(0 0 0 / 55%);
 }
+.disclaimer-icon { width: 48px; height: 48px; color: var(--danger); }
+.disclaimer-title { margin: 12px 0 6px; font-size: 22px; color: var(--fg); }
+.disclaimer-text { margin: 0 0 18px; color: var(--fg); line-height: 1.5; }
+@media (prefers-reduced-motion: reduce) { .disclaimer-overlay { transition: none; } }
 .sanity-failure {
   min-height: 100dvh; display: grid; place-items: center; padding: 24px; box-sizing: border-box;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -15,6 +15,9 @@
     </div>
   </div>
   <div class="wrap">
+    <aside class="beta-warning no-print" role="alert">
+      <strong>Beta software:</strong> EntropyLab is experimental and should be used only for testing. Do not rely on it to secure real bitcoin, and never test with funds you cannot afford to lose.
+    </aside>
     <noscript>
       <aside class="beta-warning no-print" role="alert">
         <strong>JavaScript is required:</strong> EntropyLab performs wallet calculations locally inside your browser. With JavaScript disabled the calculator cannot derive keys or addresses. Enable JavaScript, then run this file offline on an air-gapped computer.
@@ -262,11 +265,16 @@ words, pick one of the checksum words.</span></span>
       <p>Die Distribution / Fairness Analysis (Pearson’s χ²): <a href="https://rpg.stackexchange.com/questions/70802/how-can-i-test-whether-a-die-is-fair" target="_blank" rel="noopener noreferrer">How can I test whether a die is fair?</a> — live check while entering rolls, following the <a href="https://dicefairness.johnellmore.com/" target="_blank" rel="noopener noreferrer">Dice Fairness Tester</a> thresholds.</p>
       <p>Jade anti-exfil (sign-to-contract): <a href="https://blog.blockstream.com/anti-exfil-stopping-key-exfiltration/" target="_blank" rel="noopener noreferrer">Anti-Exfil: Stopping Key Exfiltration</a> — secp256k1-zkp <code>ecdsa_s2c</code> / <code>anti_exfil_host_verify</code>.</p>
     </section>
-    <footer class="site-footer no-print">
-      <p class="fine-print">EntropyLab is designed to be used by advanced bitcoin users, and is otherwise for testing and educational purposes only.<br>It is your responsibility to keep your private key and seed material air-gapped and offline.</p>
-    </footer>
   </div>
-</div><!--/$--><script>/*@@JS_BROWSER_CHECK@@*/</script><script id="btc-calc-script">/*@@JS_MAIN@@*/</script>
+</div><!--/$--><div class="disclaimer-overlay no-print" id="beta-disclaimer" role="alertdialog" aria-modal="true" aria-labelledby="beta-disclaimer-title" aria-describedby="beta-disclaimer-text" hidden>
+  <div class="disclaimer-card">
+    <svg class="disclaimer-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3 2.5 20h19L12 3z"/><path d="M12 10v4M12 17.5h.01"/></svg>
+    <p class="disclaimer-title" id="beta-disclaimer-title">Beta software</p>
+    <p class="disclaimer-text" id="beta-disclaimer-text">EntropyLab is experimental and can be dangerous: a bug could produce wrong keys or addresses, and funds sent to them could be lost. Do not use it in production, and never with funds you cannot afford to lose.</p>
+    <button class="btn primary" id="beta-disclaimer-accept" type="button">I understand</button>
+  </div>
+</div>
+<script>/*@@JS_BROWSER_CHECK@@*/</script><script id="btc-calc-script">/*@@JS_MAIN@@*/</script>
 <script>/*@@JS_SQLITE_WRITER@@*/</script>
 <script>/*@@JS_WALLET_EXPORT@@*/</script>
 <script>/*@@JS_ONLINE@@*/</script>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -379,6 +379,9 @@ ec.innerHTML = `
     </div>
   </div>
   <div class="wrap">
+    <aside class="beta-warning no-print" role="alert">
+      <strong>Beta software:</strong> EntropyLab is experimental and should be used only for testing. Do not rely on it to secure real bitcoin, and never test with funds you cannot afford to lose.
+    </aside>
     <aside class="online-warning no-print" id="online-warning" role="alert" hidden>
       <strong>Online version:</strong> Do not enter seed phrases, private keys, or other wallet secrets on an internet-connected device. <a href="entropylab.html" download="entropylab.html">Download EntropyLab</a> and run the HTML file offline on a trusted, air-gapped computer.
     </aside>
@@ -588,9 +591,6 @@ ec.innerHTML = `
       <p>D++ D8 &amp; D16 method: <a href="https://thesimplestbitcoinbook.net/wp-content/uploads/2023/09/Roll-Your-Own-Seed-Phrase-PDF.pdf" target="_blank" rel="noopener noreferrer">Roll Your Own Bitcoin Seed Phrase</a> \u2014 the published 24-word workflow uses one D8 labeled 1\u20138 and two hexadecimal D16 dice labeled 0\u2013F per word, then a final D8.</p>
       <p>Jade anti-exfil (sign-to-contract): <a href="https://blog.blockstream.com/anti-exfil-stopping-key-exfiltration/" target="_blank" rel="noopener noreferrer">Anti-Exfil: Stopping Key Exfiltration</a> \u2014 secp256k1-zkp <code>ecdsa_s2c</code> / <code>anti_exfil_host_verify</code>.</p>
     </section>
-    <footer class="site-footer no-print">
-      <p class="fine-print">EntropyLab is designed to be used by advanced bitcoin users, and is otherwise for testing and educational purposes only.<br>It is your responsibility to keep your private key and seed material air-gapped and offline.</p>
-    </footer>
   </div>
 `;
 if (/^(www\.)?entropylab\.online$/i.test(location.hostname)) document.getElementById("online-warning")?.removeAttribute("hidden");

--- a/src/js/browser-check.js
+++ b/src/js/browser-check.js
@@ -10,7 +10,9 @@
 // entire page is killed and replaced with a centered failure report listing
 // the failed checks, because wallet output from a broken host cannot be
 // trusted. This script runs before the application scripts so a host broken
-// enough to crash them still gets the failure screen.
+// enough to crash them still gets the failure screen. A second,
+// independent unit at the bottom of this file gates the page on the beta
+// disclaimer.
 (() => {
   // Each check returns true when the browser behaves and throws or returns
   // false when it does not. Keep every check free of BigInt literal syntax
@@ -104,4 +106,45 @@
     <p class="sanity-failure-advice">Open this file in a current, mainstream browser such as Firefox on a trusted, air-gapped computer.</p>
   </div>
 </main>`;
+})();
+
+// Beta disclaimer: a modal gate the user must explicitly accept. The markup
+// ships in the static template outside #btc-calc so application boot (which
+// replaces that node's contents) cannot wipe it, and it starts hidden so a
+// host without JavaScript never sees an overlay it cannot dismiss — this
+// script is what reveals it (fade in), and acceptance fades it back out and
+// removes it from the document. Acceptance is remembered in localStorage,
+// the same site-settings store as the theme, keyed to this build's version:
+// every new release asks again. When storage is unavailable (file://
+// origins, private modes) the disclaimer simply shows on every load, which
+// is the safe direction for a wallet tool. When the sanity barrage above
+// has killed the page, the overlay is gone with it and this unit no-ops.
+(() => {
+  const overlay = document.getElementById("beta-disclaimer");
+  const accept = document.getElementById("beta-disclaimer-accept");
+  if (!overlay || !accept) return;
+  const KEY = "entropylab-beta-accepted";
+  const VERSION = "{{VERSION}}";
+  let accepted = false;
+  try {
+    accepted = localStorage.getItem(KEY) === VERSION;
+  } catch (e) {}
+  if (accepted) {
+    overlay.remove();
+    return;
+  }
+  overlay.hidden = false;
+  // Two frames: let the overlay paint once at opacity 0 so the is-visible
+  // class below actually runs the fade-in transition.
+  requestAnimationFrame(() => requestAnimationFrame(() => {
+    overlay.classList.add("is-visible");
+    accept.focus();
+  }));
+  accept.addEventListener("click", () => {
+    try {
+      localStorage.setItem(KEY, VERSION);
+    } catch (e) {}
+    overlay.classList.add("is-dismissed");
+    setTimeout(() => overlay.remove(), 400);
+  });
 })();

--- a/test/browser-check.test.mjs
+++ b/test/browser-check.test.mjs
@@ -37,6 +37,44 @@ const workingCrypto = () => {
   };
 };
 
+// A minimal in-memory localStorage stand-in for the disclaimer gate tests.
+const memoryStorage = (initial = {}) => ({
+  getItem: (key) => (key in initial ? initial[key] : null),
+  setItem: (key, value) => {
+    initial[key] = String(value);
+  },
+  dump: () => initial,
+});
+
+// A fake disclaimer overlay and accept button recording what the gate did.
+const disclaimerDom = () => {
+  const calls = { shown: false, focused: false, dismissed: false, removed: 0, onClick: null };
+  const overlay = {
+    hidden: true,
+    classList: {
+      add: (name) => {
+        if (name === "is-visible") calls.shown = true;
+        if (name === "is-dismissed") calls.dismissed = true;
+      },
+    },
+    remove: () => {
+      calls.removed += 1;
+    },
+  };
+  const accept = {
+    focus: () => {
+      calls.focused = true;
+    },
+    addEventListener: (type, fn) => {
+      if (type === "click") calls.onClick = fn;
+    },
+  };
+  return {
+    calls,
+    elements: { "beta-disclaimer": overlay, "beta-disclaimer-accept": accept },
+  };
+};
+
 const loadModule = (overrides = {}) => {
   const options = {
     secure: true,
@@ -46,6 +84,8 @@ const loadModule = (overrides = {}) => {
     textDecoderImpl: TextDecoder,
     hasBody: true,
     normalizeImpl: undefined, // when present in overrides, replaces String.prototype.normalize
+    elements: {}, // DOM elements the disclaimer gate can find, by id
+    storage: memoryStorage(),
     ...overrides,
   };
   const body = { innerHTML: PAGE };
@@ -54,6 +94,7 @@ const loadModule = (overrides = {}) => {
     window: { isSecureContext: options.secure },
     document: {
       documentElement,
+      getElementById: (id) => options.elements[id] ?? null,
       ...(options.hasBody ? { body } : {}),
     },
     crypto: options.cryptoImpl,
@@ -61,6 +102,10 @@ const loadModule = (overrides = {}) => {
     TextEncoder: options.textEncoderImpl,
     TextDecoder: options.textDecoderImpl,
     Uint8Array,
+    localStorage: options.storage,
+    // Run callbacks synchronously so assertions see the post-fade state.
+    requestAnimationFrame: (fn) => fn(),
+    setTimeout: (fn) => fn(),
   };
   const originalNormalize = String.prototype.normalize;
   if ("normalizeImpl" in overrides) String.prototype.normalize = overrides.normalizeImpl;
@@ -232,4 +277,65 @@ test("the compiled application ships the inlined barrage", () => {
   assert.match(compiled, /Host failed basic sanity checks/);
   assert.match(compiled, /data-browser-checks|dataset\.browserChecks/);
   assert.doesNotMatch(compiled, /\/\*@@JS_BROWSER_CHECK@@\*\//);
+});
+
+// The source token {{VERSION}} stands in for the running release here; the
+// build substitutes the package version into the compiled artifact (asserted
+// below), so acceptance recorded under one release never silences the next.
+test("the beta disclaimer shows on first boot and acceptance is stored for the running version", () => {
+  const { calls, elements } = disclaimerDom();
+  const storage = memoryStorage();
+  loadModule({ elements, storage });
+  assert.equal(elements["beta-disclaimer"].hidden, false, "the overlay was not revealed");
+  assert.ok(calls.shown, "the fade-in class was not applied");
+  assert.ok(calls.focused, "the accept button was not focused");
+  assert.equal(typeof calls.onClick, "function", "no accept handler was registered");
+  calls.onClick();
+  assert.equal(storage.dump()["entropylab-beta-accepted"], "{{VERSION}}");
+  assert.ok(calls.dismissed, "the fade-out class was not applied");
+  assert.equal(calls.removed, 1, "the overlay was not removed after the fade");
+});
+
+test("a stored acceptance for the running version skips the beta disclaimer", () => {
+  const { calls, elements } = disclaimerDom();
+  loadModule({ elements, storage: memoryStorage({ "entropylab-beta-accepted": "{{VERSION}}" }) });
+  assert.equal(elements["beta-disclaimer"].hidden, true, "the overlay was revealed");
+  assert.equal(calls.shown, false);
+  assert.equal(calls.removed, 1, "the accepted overlay was not removed outright");
+});
+
+test("an acceptance stored under another version re-asks", () => {
+  const { calls, elements } = disclaimerDom();
+  loadModule({ elements, storage: memoryStorage({ "entropylab-beta-accepted": "0.0.0" }) });
+  assert.equal(elements["beta-disclaimer"].hidden, false, "the overlay stayed hidden");
+  assert.ok(calls.shown, "the disclaimer did not re-ask");
+});
+
+test("unavailable storage fails open: the disclaimer still shows and dismissal still works", () => {
+  const { calls, elements } = disclaimerDom();
+  const throwingStorage = {
+    getItem() {
+      throw new Error("denied");
+    },
+    setItem() {
+      throw new Error("denied");
+    },
+  };
+  loadModule({ elements, storage: throwingStorage });
+  assert.equal(elements["beta-disclaimer"].hidden, false, "the overlay stayed hidden");
+  assert.ok(calls.shown, "the disclaimer did not show");
+  calls.onClick();
+  assert.ok(calls.dismissed, "the fade-out class was not applied");
+  assert.equal(calls.removed, 1, "the overlay was not removed after the fade");
+});
+
+test("the compiled disclaimer acceptance is keyed to the package version", () => {
+  ensureBuild();
+  const compiled = read("entropylab.html");
+  const { version } = JSON.parse(read("package.json"));
+  assert.match(compiled, /const KEY = "entropylab-beta-accepted";/);
+  assert.ok(
+    compiled.includes(`const VERSION = "${version}";`),
+    "the compiled gate does not embed the package version",
+  );
 });

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -559,8 +559,8 @@ test("private alternate account exports are visible without an accordion", () =>
 });
 
 test("top banners share one consistent gap", () => {
-  // The network banner left the group for the header status tag; the no-JS
-  // notice and the hosted-site warning still share the gap.
+  // The network banner left the group for the header status tag; the beta
+  // banner, the no-JS notice, and the hosted-site warning still share the gap.
   assert.match(
     css,
     /\.beta-warning, \.online-warning\s*\{[^}]*margin: 0 0 12px;/s,
@@ -570,24 +570,57 @@ test("top banners share one consistent gap", () => {
   assert.match(css, /\.card \{[^}]*margin: 16px 0; \}/);
 });
 
-test("the beta notice sits in the footer as fine print, not a banner", () => {
+test("the beta notice sits at the top of the page as a banner", () => {
   for (const markup of [template, app]) {
     const wrapper = markup.indexOf('<div class="wrap">');
     const live = markup.slice(wrapper).replace(/<!--[\s\S]*?-->/g, "");
-    // It reads as a closing disclaimer now, so it trails the sources card and
-    // drops the alert role the banner needed to announce itself on load.
-    const footer = live.match(/<footer class="site-footer no-print">[\s\S]*?<\/footer>/)?.[0];
-    assert.ok(footer, "the footer fine print is missing");
-    assert.match(footer, /<p class="fine-print">EntropyLab is designed to be used by advanced bitcoin users, and is otherwise for testing and educational purposes only\.<br>It is your responsibility to keep your private key and seed material air-gapped and offline\.<\/p>/);
-    assert.doesNotMatch(footer, /role="alert"|<strong>/);
-    assert.ok(live.indexOf("sources") < live.indexOf("site-footer"), "the footer must follow the sources card");
-    // The only .beta-warning left is the no-JS notice in the static template.
-    assert.doesNotMatch(live, /class="beta-warning[^"]*"[^>]*>\s*<strong>Beta software/);
+    // It is a load-time warning again, so it keeps the alert role and leads
+    // the wrap, ahead of the hosted-site warning and the pitch card.
+    assert.match(live, /<aside class="beta-warning no-print" role="alert">\s*<strong>Beta software:<\/strong> EntropyLab is experimental and should be used only for testing\. Do not rely on it to secure real bitcoin, and never test with funds you cannot afford to lose\.\s*<\/aside>/);
+    assert.ok(
+      live.indexOf("<strong>Beta software:") < live.indexOf('id="online-warning"'),
+      "the beta banner must precede the online warning",
+    );
+    assert.ok(
+      live.indexOf("<strong>Beta software:") < live.indexOf('class="kicker"'),
+      "the beta banner must precede the pitch card",
+    );
+    // The closing footer disclaimer is gone; the only other .beta-warning is
+    // the no-JS notice in the static template.
+    assert.doesNotMatch(live, /site-footer|fine-print/);
   }
-  assert.match(css, /\.site-footer \{\s*margin-top: var\(--space-lede\);[^}]*border-top: 1px solid var\(--border\);/s);
-  assert.match(css, /\.fine-print \{[^}]*color: var\(--faint\); font-size: 12px;/s);
-  assert.match(css, /\.fine-print \{\s*max-width: 700px; margin: 0 auto;/s);
-  assert.doesNotMatch(css, /\.fine-print strong/);
+  assert.doesNotMatch(css, /\.site-footer|\.fine-print/);
+});
+
+test("the beta disclaimer gates the page as a modal until accepted", () => {
+  // The overlay sits in the static template after the #btc-calc root: the
+  // application boot replaces that root's contents, so the gate must live
+  // outside it — and outside the runtime template — to survive boot.
+  const marker = template.indexOf("<!--/$-->");
+  const overlayAt = template.indexOf('<div class="disclaimer-overlay');
+  assert.ok(marker >= 0 && overlayAt > marker, "the disclaimer overlay must follow the #btc-calc root");
+  assert.ok(overlayAt < template.indexOf("/*@@JS_BROWSER_CHECK@@*/"), "the disclaimer overlay must ship before the scripts");
+  assert.doesNotMatch(appSource, /beta-disclaimer/, "the runtime template must not carry the disclaimer");
+  // It starts hidden: the reveal is scripted, so a no-JavaScript host never
+  // sees an overlay it cannot dismiss.
+  assert.match(
+    template,
+    /<div class="disclaimer-overlay no-print" id="beta-disclaimer" role="alertdialog" aria-modal="true" aria-labelledby="beta-disclaimer-title" aria-describedby="beta-disclaimer-text" hidden>/,
+  );
+  assert.match(template, /<p class="disclaimer-title" id="beta-disclaimer-title">Beta software<\/p>/);
+  assert.match(
+    template,
+    /<p class="disclaimer-text" id="beta-disclaimer-text">EntropyLab is experimental and can be dangerous:.*Do not use it in production, and never with funds you cannot afford to lose\.<\/p>/,
+  );
+  assert.match(template, /<button class="btn primary" id="beta-disclaimer-accept" type="button">I understand<\/button>/);
+  // The fade: transparent until .is-visible, faded out and inert once
+  // .is-dismissed, and motion-free when the user prefers reduced motion.
+  assert.match(css, /\.disclaimer-overlay \{\s*position: fixed; inset: 0;[^}]*opacity: 0; transition: opacity \.24s ease;/s);
+  assert.match(css, /\.disclaimer-overlay\[hidden\] \{ display: none; \}/);
+  assert.match(css, /\.disclaimer-overlay\.is-visible \{ opacity: 1; \}/);
+  assert.match(css, /\.disclaimer-overlay\.is-dismissed \{ opacity: 0; pointer-events: none; \}/);
+  assert.match(css, /@media \(prefers-reduced-motion: reduce\) \{ \.disclaimer-overlay \{ transition: none; \} \}/);
+  assert.match(css, /\.disclaimer-card \{[^}]*border: 1px solid var\(--danger\);/s);
 });
 
 test("the lockup steps down again below 400px", () => {
@@ -644,10 +677,10 @@ test("the site header is fixed, carries the logo, and holds the version, downloa
     // The in-flow title block folded into the marketing card, so the wrapper
     // opens on that card and carries no second header of its own.
     const live = markup.slice(wrapper).replace(/<!--[\s\S]*?-->/g, "");
-    // The static template opens with a no-JS notice; the runtime one has no
-    // need of it. Both then carry the conditional warnings, which start hidden,
-    // so the card is the first thing either page actually renders.
-    assert.match(live, /<div class="wrap">\s*(?:<noscript>[\s\S]*?<\/noscript>\s*)?(?:<aside[^>]*online-warning[\s\S]*?<\/aside>\s*)*<section class="card">/);
+    // The wrapper opens on the beta banner; the static template follows with
+    // a no-JS notice the runtime page has no need of. Both then carry the
+    // conditional warnings, which start hidden.
+    assert.match(live, /<div class="wrap">\s*<aside class="beta-warning no-print" role="alert">[\s\S]*?<\/aside>\s*(?:<noscript>[\s\S]*?<\/noscript>\s*)?(?:<aside[^>]*online-warning[\s\S]*?<\/aside>\s*)*<section class="card">/);
     assert.doesNotMatch(markup.slice(wrapper), /<header>|download-controls/);
   }
   assert.doesNotMatch(css, /^header (\{|h1)/m);


### PR DESCRIPTION
## What

Restores the beta warning to a prominent position and requires explicit acceptance:

- The **Beta software** warning is a load-time banner at the top of the page again (first element inside `.wrap`, ahead of the online warning), replacing the footer fine print; the footer markup and its now-unused CSS are removed.
- A modal disclaimer (`role=alertdialog`, site-styled danger card) fades in over a dimmed page on boot: *"EntropyLab is experimental and can be dangerous … Do not use it in production, and never with funds you cannot afford to lose."* Accepting with **I understand** fades it out and removes it from the document.
- Acceptance is persisted in `localStorage` under `entropylab-beta-accepted` — the same site-settings store as the theme — keyed to the build's `{{VERSION}}`, so **every new release re-asks**. If storage is unavailable (file:// origins, private windows) it fails open: the disclaimer shows on every load.

## Safety details

- The overlay lives outside `#btc-calc`, so application boot (which replaces that node's contents) cannot wipe it.
- It ships `hidden`; only the script reveals it, so a no-JavaScript host never sees an overlay it cannot dismiss (the no-JS notice still shows).
- When the startup sanity barrage kills the page, the overlay dies with it — the failure report wins.
- Focus lands on the accept button; `prefers-reduced-motion` disables the fade; the overlay is `no-print`.
- No network egress, no new dependencies; output stays a single self-contained `entropylab.html` (rebuilt, not committed — CI commits the artifact post-merge as usual).

## Tests

- New behavioral tests in `test/browser-check.test.mjs`: first-boot show + persist, same-version skip, other-version re-ask, storage-failure fail-open, and the compiled artifact embedding the package version in the acceptance key.
- New markup/CSS invariants in `test/ui-defaults.test.mjs`; the footer-notice test now asserts the banner's top position, and the header-structure test expects the banner first.

## Commands run

- `npm run build`
- `npm run verify` (byte-reproducible artifact confirmed)
- `npm test` — 291/292 pass. `headless Firefox runs the hosted and offline suites` fails in this local environment and fails identically on unmodified `rock` (headless Firefox cannot initialize rendering here), so it is unrelated to this change.