### PR TITLE
Name wallet.dat exports after the wallet master fingerprint (#77)

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1447,7 +1447,7 @@ function hodlDownloadWalletDat() {
   if (!re || !hodlWalletExport.hasDescriptors(re)) return;
   let bytes = hodlWalletExport.buildWalletDat(re, Ge, hodlWalletDatDeps()), blob = new Blob([bytes], { type: "application/octet-stream" }), url = URL.createObjectURL(blob), link = document.createElement("a");
   link.href = url;
-  link.download = hodlWalletExport.walletDatFilename(Ge);
+  link.download = hodlWalletExport.walletDatFilename(re, Ge);
   link.click();
   setTimeout(() => URL.revokeObjectURL(url), 1e3);
 }

--- a/src/js/wallet-export.js
+++ b/src/js/wallet-export.js
@@ -239,8 +239,17 @@ var hodlWalletExport = (() => {
     });
   };
 
-  const walletDatFilename = (includePrivate = false) =>
-    includePrivate ? "private-wallet-secrets.dat" : "watch-only-wallet.dat";
+  // Name the file after the wallet's master fingerprint (XFP) so exports are
+  // unique and identifiable when a user keeps wallets for several seeds; the
+  // reveal state suffix still says which variant the file contains. Falls
+  // back to the plain name when the wallet has no fingerprint.
+  const walletDatFilename = (wallet, includePrivate = false) => {
+    const base = includePrivate ? "private-wallet-secrets" : "watch-only-wallet";
+    const fingerprint = typeof wallet?.masterFingerprint === "string" && /^[0-9a-fA-F]{8}$/.test(wallet.masterFingerprint)
+      ? wallet.masterFingerprint.toLowerCase()
+      : null;
+    return fingerprint ? `entropylab-${fingerprint}-${base}.dat` : `${base}.dat`;
+  };
 
   const walletDatButtonLabel = (includePrivate = false) =>
     includePrivate ? "Download wallet.dat with secrets (xprvs)" : "Download watch-only wallet.dat";

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -898,7 +898,7 @@
     state.downloadName = "";
     datButton.click();
     const dat = await (await until(() => state.lastBlob, "watch-only wallet.dat")).text();
-    assert(state.downloadName === "watch-only-wallet.dat", "Unexpected wallet.dat filename");
+    assert(state.downloadName === "entropylab-73c5da0a-watch-only-wallet.dat", "Unexpected wallet.dat filename");
     assert(dat.startsWith("SQLite format 3"), "wallet.dat is not a SQLite database");
     assert(dat.includes("walletdescriptor") && dat.includes("wpkh([") && dat.includes("tr(["), "wallet.dat is missing descriptor records");
     assert(dat.includes("activeexternalspk") && dat.includes("activeinternalspk"), "wallet.dat is missing active script records");
@@ -923,7 +923,7 @@
     state.downloadName = "";
     datButton.click();
     const dat = await (await until(() => state.lastBlob, "private wallet.dat")).text();
-    assert(state.downloadName === "private-wallet-secrets.dat", "Unexpected private wallet.dat filename");
+    assert(state.downloadName === "entropylab-73c5da0a-private-wallet-secrets.dat", "Unexpected private wallet.dat filename");
     assert(dat.startsWith("SQLite format 3"), "private wallet.dat is not a SQLite database");
     assert(dat.includes("walletdescriptorkey"), "Private wallet.dat is missing spending key records");
   });

--- a/test/wallet-export.test.mjs
+++ b/test/wallet-export.test.mjs
@@ -368,10 +368,16 @@ test("button gating: only HD wallets with descriptors", () => {
   assert.equal(hasDescriptors(WATCH_ONLY_WALLET), true);
 });
 
-test("filename announces watch-only vs secrets", () => {
+test("filename announces the wallet fingerprint and watch-only vs secrets", () => {
   const { walletDatFilename } = loadModule();
-  assert.equal(walletDatFilename(false), "watch-only-wallet.dat");
-  assert.equal(walletDatFilename(true), "private-wallet-secrets.dat");
+  const wallet = { masterFingerprint: "73C5DA0A" };
+  // Unique, identifiable files: the master XFP names the wallet (issue #77).
+  assert.equal(walletDatFilename(wallet, false), "entropylab-73c5da0a-watch-only-wallet.dat");
+  assert.equal(walletDatFilename(wallet, true), "entropylab-73c5da0a-private-wallet-secrets.dat");
+  assert.equal(walletDatFilename(wallet), "entropylab-73c5da0a-watch-only-wallet.dat");
+  // Without a usable fingerprint the names fall back to the plain forms.
+  assert.equal(walletDatFilename(null, false), "watch-only-wallet.dat");
+  assert.equal(walletDatFilename({ masterFingerprint: "not-an-xfp" }, true), "private-wallet-secrets.dat");
   assert.equal(walletDatFilename(), "watch-only-wallet.dat");
 });
 
@@ -398,7 +404,7 @@ test("template, build script, and app wiring ship the export", () => {
   assert.match(app, /id="download-wallet-dat"[^>]*>\$\{hodlWalletExport\.walletDatButtonLabel\(includePrivate\)\}/);
   assert.match(app, /hodlWalletExport\.hasDescriptors\(re\)/);
   assert.match(app, /hodlWalletExport\.buildWalletDat\(\s*re\s*,\s*Ge\s*,\s*hodlWalletDatDeps\(\s*\)\s*\)/);
-  assert.match(app, /hodlWalletExport\.walletDatFilename\(Ge\)/);
+  assert.match(app, /hodlWalletExport\.walletDatFilename\(re, Ge\)/);
   assert.match(app, /document\.getElementById\("download-wallet-dat"\)/);
   assert.match(css, /\.save-wallet-dat/);
 });


### PR DESCRIPTION
## What

The Bitcoin Core `wallet.dat` download used one static pair of file names (`watch-only-wallet.dat` / `private-wallet-secrets.dat`), so exports for different seeds were indistinguishable and easy to overwrite or mix up.

`walletDatFilename` now takes the wallet and prefixes the file name with the lowercase master XFP, e.g.:

- `entropylab-73c5da0a-watch-only-wallet.dat`
- `entropylab-73c5da0a-private-wallet-secrets.dat`

Falls back to the previous plain names when the wallet has no usable fingerprint (defensive; the export button only renders for HD wallets, which always have one).

Closes #77.

## Notes

- Only the singlesig HD flow produces a `wallet.dat`; multisig is watch-only descriptor text, so there is exactly one XFP to name.
- The reveal-state suffix still says which variant the file contains, so the safety signal in the file name is unchanged.

## Verification

- `npm run build`
- `npm run test:wallet-export` (15 pass)
- `npm run test:ci` (301 pass)
- Updated the filename unit tests, the app-wiring assertion, and the browser-suite expectations (BIP39 vector `abandon…about` → XFP `73c5da0a`).