### PR TITLE
Identify multisig co-signers by derivation authority, not xpub text (#92)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:wasm": "node scripts/build-wasm.mjs",
     "clean": "node scripts/build.mjs --clean",
     "test": "node --test test/*.test.mjs",
-    "test:ci": "node --test test/network-check.test.mjs test/browser-check.test.mjs test/ui-defaults.test.mjs test/validate.test.mjs test/descriptor.test.mjs test/seedqr.test.mjs test/cards.test.mjs test/copy-seed.test.mjs test/number-bases.test.mjs test/dice-fairness.test.mjs test/seed-numbers.test.mjs test/dplus.test.mjs test/psbt-low-r.test.mjs test/psbt-metadata.test.mjs test/psbt-sighash.test.mjs test/secret-clear.test.mjs test/sqlite-writer.test.mjs test/wallet-export.test.mjs test/psbt-anti-exfil.test.mjs test/address-match.test.mjs test/psbt-nonce-reuse.test.mjs test/lifehash.test.mjs test/secp256k1-wasm.test.mjs",
+    "test:ci": "node --test test/network-check.test.mjs test/browser-check.test.mjs test/ui-defaults.test.mjs test/validate.test.mjs test/descriptor.test.mjs test/seedqr.test.mjs test/cards.test.mjs test/copy-seed.test.mjs test/number-bases.test.mjs test/dice-fairness.test.mjs test/seed-numbers.test.mjs test/dplus.test.mjs test/psbt-low-r.test.mjs test/psbt-metadata.test.mjs test/psbt-sighash.test.mjs test/secret-clear.test.mjs test/sqlite-writer.test.mjs test/wallet-export.test.mjs test/psbt-anti-exfil.test.mjs test/address-match.test.mjs test/psbt-nonce-reuse.test.mjs test/lifehash.test.mjs test/secp256k1-wasm.test.mjs test/msig-cosigner-identity.test.mjs",
     "test:dice-fairness": "node --test test/dice-fairness.test.mjs",
     "test:network": "node --test test/network-check.test.mjs",
     "test:browser-check": "node --test test/browser-check.test.mjs",

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -5811,7 +5811,11 @@ function hodlMultisigAccountKeyError(parsed, kind, legacyStandard = "bip45") {
   return "";
 }
 function hodlCanonicalMultisigKey(parsed) {
-  return hodlSerializeExtendedKey(parsed.node.publicExtendedKey, parsed.network, "x", false);
+  // Co-signer identity is the derivation authority: the compressed account
+  // public key plus chain code. Version bytes and the unauthenticated parent
+  // fingerprint in the extended-key serialization are metadata; mutating only
+  // those bytes must not let one key pass as two distinct co-signers.
+  return M.encode(parsed.node.publicKey) + ":" + M.encode(parsed.node.chainCode);
 }
 function hodlDuplicateMultisigKey(ta, parsed) {
   let canonical = hodlCanonicalMultisigKey(parsed);
@@ -6026,6 +6030,9 @@ function hodlBuildMsig() {
         if (!key) throw new Error("Could not derive a public key");
         return key;
       });
+      // Final defense behind the co-signer identity check: never emit a
+      // script whose public keys repeat, whatever the supplied encodings were.
+      if (new Set(receivePublicKeys.concat(changePublicKeys).map(M.encode)).size !== receivePublicKeys.length + changePublicKeys.length) throw new Error("Two co-signers derive the same public key. Every co-signer must use a distinct extended public key.");
       receive.push(Object.assign({
         index,
         path: receivePath.slice(1) + index

--- a/test/msig-cosigner-identity.test.mjs
+++ b/test/msig-cosigner-identity.test.mjs
@@ -1,0 +1,126 @@
+// Multisig co-signer identity (issue #92): an extended public key's parent
+// fingerprint and version bytes are unauthenticated serialization metadata.
+// Mutating only those bytes must not let one account key pass as two
+// distinct co-signers, and no generated script may contain a repeated public
+// key.
+// Run with: npm test
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { HDKey } from "@scure/bip32";
+import { mnemonicToSeedSync } from "@scure/bip39";
+import { createBase58check } from "@scure/base";
+import { sha256 } from "@noble/hashes/sha2.js";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const app = readFileSync(join(root, "src/js/app.js"), "utf8");
+
+// Extract the app's real identity function and run it against real HDKey
+// nodes, so the test exercises the shipped comparison rather than a copy.
+function loadIdentityFn() {
+  const start = app.indexOf("function hodlCanonicalMultisigKey(");
+  assert.ok(start >= 0, "hodlCanonicalMultisigKey");
+  let depth = 0;
+  let end = -1;
+  for (let i = app.indexOf("{", start); i < app.length; i++) {
+    if (app[i] === "{") depth++;
+    else if (app[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        end = i + 1;
+        break;
+      }
+    }
+  }
+  assert.ok(end > start, "hodlCanonicalMultisigKey end");
+  const path = join(root, "test", `.msig-identity-${Math.random().toString(16).slice(2)}.mjs`);
+  writeFileSync(
+    path,
+    `import { hex as M } from "@scure/base";\n${app.slice(start, end)}\nexport { hodlCanonicalMultisigKey };\n`,
+  );
+  return path;
+}
+
+const slicePath = loadIdentityFn();
+const { hodlCanonicalMultisigKey } = await import(pathToFileURL(slicePath).href);
+unlinkSync(slicePath);
+
+const base58check = createBase58check(sha256);
+const seed = mnemonicToSeedSync(
+  "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+);
+// One account node per standard the multisig flow accepts.
+const ACCOUNT_PATHS = {
+  "Legacy BIP45": "m/45'",
+  "Legacy BIP87": "m/87'/0'/0'",
+  "Nested SegWit BIP48": "m/48'/0'/0'/1'",
+  "Native SegWit BIP48": "m/48'/0'/0'/2'",
+  "Taproot BIP86": "m/86'/0'/0'",
+};
+
+const identityOf = (node) => hodlCanonicalMultisigKey({ node });
+
+// Re-encode an extended key with only metadata bytes changed, then parse it
+// back the way the app does before deriving an HDKey.
+const remetadata = (xpub, mutate) => {
+  const payload = base58check.decode(xpub);
+  mutate(payload);
+  return HDKey.fromExtendedKey(base58check.encode(payload));
+};
+
+test("xpubs differing only in parent-fingerprint bytes are one co-signer", () => {
+  for (const [label, path] of Object.entries(ACCOUNT_PATHS)) {
+    const node = HDKey.fromMasterSeed(seed).derive(path);
+    const mutated = remetadata(node.publicExtendedKey, (payload) => {
+      payload[5] ^= 0xff; // parent fingerprint bytes 5..8
+      payload[6] ^= 0xff;
+      payload[7] ^= 0xff;
+      payload[8] ^= 0xff;
+    });
+    assert.notEqual(mutated.publicExtendedKey, node.publicExtendedKey, label);
+    assert.notEqual(mutated.parentFingerprint, node.parentFingerprint, label);
+    assert.equal(identityOf(mutated), identityOf(node), label);
+  }
+});
+
+test("xpubs differing only in version bytes are one co-signer", () => {
+  const node = HDKey.fromMasterSeed(seed).derive("m/48'/0'/0'/2'");
+  // Same payload, reserialized under the mainnet Zpub version (0x02aa7ed3).
+  const zpubPayload = base58check.decode(node.publicExtendedKey);
+  zpubPayload.set([0x02, 0xaa, 0x7e, 0xd3], 0);
+  const zpub = base58check.encode(zpubPayload);
+  assert.notEqual(zpub, node.publicExtendedKey);
+  // The app normalizes version bytes before parsing; do the same here.
+  const reparsed = remetadata(zpub, (payload) => {
+    payload.set([0x04, 0x88, 0xb2, 0x1e], 0);
+  });
+  assert.equal(identityOf(reparsed), identityOf(node));
+});
+
+test("legitimately distinct account keys stay distinct", () => {
+  const first = HDKey.fromMasterSeed(seed).derive("m/48'/0'/0'/2'");
+  const otherSeed = mnemonicToSeedSync(
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
+  );
+  const second = HDKey.fromMasterSeed(otherSeed).derive("m/48'/0'/0'/2'");
+  assert.notEqual(identityOf(first), identityOf(second));
+  // A different hardened account of the same seed is also a distinct signer.
+  assert.notEqual(identityOf(first), identityOf(HDKey.fromMasterSeed(seed).derive("m/48'/0'/1'/2'")));
+});
+
+test("both duplicate checks and the final script guard use derivation identity", () => {
+  // Field-level and final validation compare hodlCanonicalMultisigKey output.
+  assert.match(app, /function hodlDuplicateMultisigKey\(ta, parsed\) \{\s*let canonical = hodlCanonicalMultisigKey\(parsed\)/);
+  assert.match(app, /canonical = hodlCanonicalMultisigKey\(parsed\);\s*if \(xpubs\.includes\(canonical\)\) throw new Error\(`Co-signer \$\{index \+ 1\} duplicates an earlier co-signer/);
+  // Final defense: a generated script never contains a repeated public key.
+  assert.match(app, /new Set\(receivePublicKeys\.concat\(changePublicKeys\)\.map\(M\.encode\)\)\.size !== receivePublicKeys\.length \+ changePublicKeys\.length/);
+  // Identity ignores the reserialized extended key (which carries metadata).
+  const start = app.indexOf("function hodlCanonicalMultisigKey(");
+  const end = app.indexOf("function hodlDuplicateMultisigKey", start);
+  const body = app.slice(start, end);
+  assert.match(body, /node\.publicKey/);
+  assert.match(body, /node\.chainCode/);
+  assert.doesNotMatch(body, /publicExtendedKey/);
+});


### PR DESCRIPTION
## Problem

EntropyLab checked whether multisig co-signers are distinct by comparing complete reserialized account xpubs. A BIP32 serialization includes four parent-fingerprint bytes that are metadata and do not participate in child derivation. Changing only those bytes and recomputing the checksum produced a different accepted xpub string with the same public key and chain code — both entries then derived the same public key at every index, but the duplicate check treated them as separate co-signers. In an m-of-n policy, one participant could silently fill multiple nominal signer slots.

## Fix

- `hodlCanonicalMultisigKey` now identifies a co-signer by **derivation authority**: the compressed account public key plus chain code (hex), ignoring version bytes and the unauthenticated parent fingerprint. Both the field-level check (`hodlDuplicateMultisigKey`) and the final validation in `hodlValidatedMsigInputs` use it.
- Final defense: script construction rejects any receive/change index whose derived public keys repeat, whatever the supplied encodings were.

## Tests (`test/msig-cosigner-identity.test.mjs`)

The app's real identity function is slice-loaded and exercised against real HDKey nodes:

- Xpubs differing only in parent-fingerprint bytes 5–8 are one co-signer — regression fixtures for Legacy BIP45, Legacy BIP87, Nested SegWit BIP48, Native SegWit BIP48, and Taproot BIP86 account paths.
- Same payload reserialized under different version bytes (xpub vs Zpub) is one co-signer.
- Legitimately distinct account keys (different seed, different hardened account) stay distinct.
- Source assertions pin both duplicate checks and the final derived-key guard.

## Verification

- `npm run build`
- `npm run test:ci` (305 pass, includes the 4 new tests)
- `node --test test/msig-cosigner-identity.test.mjs`

Closes #92.