### PR TITLE
Fail closed on below-threshold card transcripts (#85)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,14 +38,16 @@ material. Its security posture rests on the following model:
 - Wallet security depends on the quality and secrecy of the entropy, seed
   phrase, passphrase, or private key supplied by the user, and on the
   integrity of the machine it runs on.
-- Low-entropy dice and card transcripts are accepted intentionally so the
-  calculator can be used for deterministic tests, demonstrations, and
-  recovery experiments. EntropyLab does not claim that hashing a short input
-  makes it secure. When the entered transcript is below the recommended
-  entropy target, the result displays a prominent warning with the estimated
-  supplied entropy and says to use it only for testing. Users who intend to
-  secure funds must meet the displayed roll/card recommendation and verify
-  their procedure independently.
+- Low-entropy dice transcripts are accepted intentionally so the calculator
+  can be used for deterministic tests, demonstrations, and recovery
+  experiments; the result displays a prominent warning with the estimated
+  supplied entropy and says to use it only for testing. Hashed card
+  transcripts instead fail closed: below the card count required for the
+  selected phrase length, derivation, seed copying, and wallet export stay
+  disabled, because a short card transcript is trivially enumerable and
+  hashing a short input does not make it secure. Users who intend to secure
+  funds must meet the displayed roll/card requirement and verify their
+  procedure independently.
 - The single-file design inlines all scripts (`script-src 'unsafe-inline'`),
   and the secp256k1 WebAssembly module adds `wasm-unsafe-eval` to the
   content security policy: Chromium and WebKit engines refuse to compile a

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2672,12 +2672,14 @@ function hodlBinaryEntropy(value, targetWords = Pt) {
   return hodlNumberBaseEntropy(value, "bin", targetWords);
 }
 function hodlCardNeeded(targetWords = Pt) {
+  // Derived from the selected BIP39 entropy target, not policy constants:
+  // the smallest without-replacement deal whose entropy reaches the target.
+  // One deck tops out at ~225.6 bits, so a 256-bit seed finishes with extra
+  // cards from a second shuffled deck.
   let bits = hodlSeedConfig(targetWords).bits;
-  if (bits <= 128) return { first: 25, extra: 0 };
-  if (bits <= 160) return { first: 31, extra: 0 };
-  if (bits <= 192) return { first: 39, extra: 0 };
-  if (bits <= 224) return { first: 50, extra: 0 };
-  return { first: 52, extra: 6 };
+  for (let first = 1; first <= 52; first++) if (hodlCardWithoutReplacementBits(first) >= bits) return { first, extra: 0 };
+  for (let extra = 1; extra <= 52; extra++) if (hodlCardWithoutReplacementBits(52) + hodlCardWithoutReplacementBits(extra) >= bits) return { first: 52, extra };
+  return { first: 52, extra: 52 };
 }
 function hodlCardWithoutReplacementBits(count) {
   let bits = 0, n = Math.min(Math.max(0, Number(count) || 0), 52);
@@ -2758,10 +2760,13 @@ function hodlCardsEntropy(value, targetWords = Pt, coleman = false) {
   if (parsed.invalid.length) return { ok: false, error: `Cards use rank then suit, like AS, 10H, or TD. Ignored: ${parsed.invalid.slice(0, 8).join(" ")}`, notes, warnings, parsed };
   if (parsed.duplicates.length) return { ok: false, error: `Do not repeat a card in the same shuffle. Repeated: ${parsed.duplicates[0]}.`, notes, warnings, parsed };
   if (!parsed.cards.length) return { ok: false, error: "Deal at least one card from a shuffled deck.", notes, warnings, parsed };
-  let required = parsed.needed.first + parsed.needed.extra, hashInput = hodlCardsHashInput(parsed.cards, coleman);
+  let required = parsed.needed.first + parsed.needed.extra;
   notes.push(`${parsed.cards.length} card${parsed.cards.length === 1 ? "" : "s"} \u2248 ${parsed.bits.toFixed(1)} bits.`);
   notes.push(coleman ? "SHA-256 hashes Ian Coleman's suit-symbol transcript (A\u2660 2\u2663 T\u2666), then the first " + config.bits + " bits become the selected " + config.words + "-word seed. One shuffled deck is about 225.6 bits." : "SHA-256 hashes the ASCII transcript (AS 2C TD), then the first " + config.bits + " bits become the selected " + config.words + "-word seed. One shuffled deck is about 225.6 bits.");
-  if (parsed.cards.length < required) warnings.push(`Only ${parsed.cards.length} of ${required} recommended cards were entered. The ${config.words}-word phrase is deterministic, but its security cannot exceed the approximately ${parsed.bits.toFixed(1)} bits supplied. Use only for testing until the recommendation is met.`);
+  // Fail closed below the entropy target: hashing a short transcript cannot
+  // add entropy, and an enumerable transcript must never produce a wallet.
+  if (parsed.cards.length < required) return { ok: false, error: `Only ${parsed.cards.length} of ${required} required cards were entered. The transcript holds about ${parsed.bits.toFixed(1)} bits, but a ${config.words}-word seed needs ${config.bits}; hashing cannot add entropy, so a short transcript is trivially enumerable. Deal ${required - parsed.cards.length} more card${required - parsed.cards.length === 1 ? "" : "s"} before deriving a wallet.`, notes, warnings, parsed };
+  let hashInput = hodlCardsHashInput(parsed.cards, coleman);
   if (parsed.cards.length > required) notes.push(`All ${parsed.cards.length} cards, including extras, are included in the hash.`);
   let digest = Z(new TextEncoder().encode(hashInput)), bytes = digest.slice(0, config.bytes);
   return { ok: true, bytes, hex: M.encode(bytes), bits: config.bits, sourceBits: parsed.bits, method: coleman ? "ian-coleman-cards-sha256" : "cards-sha256", notes, warnings, parsed, hashInput };
@@ -2955,8 +2960,10 @@ function hodlUpdateCards() {
     if (parsed.cards.length && !parsed.invalid.length && !parsed.duplicates.length && !parsed.pending) preview = _n(Z(new TextEncoder().encode(hodlCardsHashInput(parsed.cards, hodlCardColemanSymbols))).slice(0, config.bytes)).split(" ");
   } catch {
   }
-  hodlRenderDiceWordGrid(wordsBox, preview, config.words, parsed.cards.length < required);
-  let meta = W("#cards-meta"), missing = Math.max(0, required - parsed.cards.length), extra = Math.max(0, parsed.cards.length - required), status = !parsed.cards.length ? `0 of ${required} recommended cards \xB7 0.0 bits estimated \xB7 Hashed card transcript` : missing ? `${parsed.cards.length} of ${required} recommended cards \xB7 ${parsed.bits.toFixed(1)} bits estimated \xB7 seed available for testing \xB7 ${missing} more recommended` : `${parsed.cards.length} card${parsed.cards.length === 1 ? "" : "s"} \xB7 ${parsed.bits.toFixed(1)} bits estimated \xB7 ready to derive${extra ? ` \xB7 all ${extra} extra card${extra === 1 ? " is" : "s are"} included` : ""}`;
+  // Below the entropy target the preview is display-only: not copyable, and
+  // derivation stays disabled through the entropy result (issue #85).
+  hodlRenderDiceWordGrid(wordsBox, preview, config.words, parsed.cards.length < required, parsed.cards.length >= required);
+  let meta = W("#cards-meta"), missing = Math.max(0, required - parsed.cards.length), extra = Math.max(0, parsed.cards.length - required), status = !parsed.cards.length ? `0 of ${required} required cards \xB7 0.0 bits estimated \xB7 Hashed card transcript` : missing ? `${parsed.cards.length} of ${required} required cards \xB7 ${parsed.bits.toFixed(1)} bits estimated \xB7 ${missing} more required before deriving` : `${parsed.cards.length} card${parsed.cards.length === 1 ? "" : "s"} \xB7 ${parsed.bits.toFixed(1)} bits estimated \xB7 ready to derive${extra ? ` \xB7 all ${extra} extra card${extra === 1 ? " is" : "s are"} included` : ""}`;
   if (config.words === 24 && parsed.cards.length >= 52 && missing) status += parsed.cards.length === 52 ? ` \xB7 shuffle again, then deal 6 more` : ` \xB7 second shuffle ${parsed.cards.length - 52} of 6`;
   if (parsed.pending) status += ` \xB7 finish ${parsed.pending.token} with a suit`;
   if (parsed.invalidEntries.length - (parsed.pending ? 1 : 0) > 0) {
@@ -3944,7 +3951,7 @@ function hodlCopySeedPhraseButton(button) {
   if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") navigator.clipboard.writeText(phrase).then(done).catch(fallback);
   else fallback();
 }
-function hodlRenderDiceWordGrid(container, words, targetWords = Pt, provisional = false) {
+function hodlRenderDiceWordGrid(container, words, targetWords = Pt, provisional = false, copyable = true) {
   if (!container) return;
   let config = hodlSeedConfig(targetWords), values = Array.isArray(words) ? words : [], fragment = document.createDocumentFragment();
   container.innerHTML = "";
@@ -3965,7 +3972,7 @@ function hodlRenderDiceWordGrid(container, words, targetWords = Pt, provisional 
     fragment.appendChild(slot);
   }
   container.appendChild(fragment);
-  let copy = container.closest("#form")?.querySelector("[data-copy-seed-phrase]"), phrase = hodlSeedPhraseCopyText(values, config.words);
+  let copy = container.closest("#form")?.querySelector("[data-copy-seed-phrase]"), phrase = copyable ? hodlSeedPhraseCopyText(values, config.words) : "";
   if (copy) {
     copy.disabled = !phrase;
     copy.dataset.phrase = phrase;
@@ -4204,7 +4211,7 @@ function hodlRenderKeyForm() {
     if (!direct) hodlCardSuit = hodlCardRank = "";
     let suitPad = hodlCardSuits.map((suit) => `<button type="button" class="card-suit${suit.red ? " is-red" : ""}" data-card-suit="${suit.code}" aria-label="${suit.label}" aria-pressed="false">${suit.symbol}</button>`).join("");
     let rankPad = direct ? hodlDirectCardRanks.map((rank) => `<button type="button" data-direct-card-rank="${rank}" aria-label="Enter rank ${rank}">${rank}</button>`).join("") : hodlCardRanks.map((rank) => `<button type="button" data-card-rank="${rank}" aria-label="${rank === "T" ? "10" : rank}">${rank === "T" ? "10" : rank}</button>`).join("");
-    let inputId = direct ? "direct-cards" : "cards", inputLabel = direct ? "Rank-only draw transcript" : "Card transcript", inputHelp = direct ? `For each of the first ${config.partialWords} words, shuffle and draw from A\u20138 three times, then A\u20134 once. Each four-character group selects one word; spaces separate the groups. The shorter final group supplies the remaining entropy bits, and EntropyLab calculates the BIP39 checksum bits.` : `Each valid card updates a deterministic test seed. For real security, ${config.words === 24 ? "deal all 52 unique cards, shuffle again, then deal 6 more" : `deal ${needed.first} unique cards without putting them back`}. SHA-256 hashes the ASCII transcript (AS 2C TD).`, placeholder = direct ? "A284 37A2 \u2026" : hodlCardColemanSymbols ? "A\u2660 2\u2663 10\u2665 T\u2666\u2026" : "AS 2C 10H TD\u2026";
+    let inputId = direct ? "direct-cards" : "cards", inputLabel = direct ? "Rank-only draw transcript" : "Card transcript", inputHelp = direct ? `For each of the first ${config.partialWords} words, shuffle and draw from A\u20138 three times, then A\u20134 once. Each four-character group selects one word; spaces separate the groups. The shorter final group supplies the remaining entropy bits, and EntropyLab calculates the BIP39 checksum bits.` : `Each valid card updates the provisional seed preview. Derivation unlocks once the entropy target is met: ${config.words === 24 ? "deal all 52 unique cards, shuffle again, then deal 6 more" : `deal ${needed.first} unique cards without putting them back`}. SHA-256 hashes the ASCII transcript (AS 2C TD).`, placeholder = direct ? "A284 37A2 \u2026" : hodlCardColemanSymbols ? "A\u2660 2\u2663 10\u2665 T\u2666\u2026" : "AS 2C 10H TD\u2026";
     at.innerHTML = `
       <p class="label">How to turn cards into a ${config.words}-word seed</p>
       <div class="choice-grid">

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -355,7 +355,7 @@
     assert(!document.querySelector('img[src="x"]') && window.__browserTestInjected !== true, "Input executed markup");
   });
 
-  await test("cards hide dealt values by default and one valid card enables a testing seed", async () => {
+  await test("cards hide dealt values by default and below-threshold transcripts cannot derive", async () => {
     await chooseMode("Cards");
     const cards = await until(() => document.getElementById("cards"), "card transcript input");
     const dealt = document.getElementById("dealt-cards");
@@ -378,11 +378,12 @@
     input(cards, "as");
     await wait(0);
     equal(cards.value, "AS");
-    assert(!document.getElementById("go").disabled, "One valid card did not enable derivation");
-    assert(document.getElementById("cards-meta").textContent.includes("seed available for testing"), "One-card warning is missing");
+    assert(document.getElementById("go").disabled, "One card below the entropy threshold enabled derivation");
+    const oneCardMeta = document.getElementById("cards-meta").textContent;
+    assert(oneCardMeta.includes("1 of 58 required cards") && oneCardMeta.includes("more required before deriving"), "One-card blocking status is missing");
     equal([...document.querySelectorAll("#dice-words [data-word]")].filter((word) => word.textContent !== "—").length, 24);
     const cardCopy = document.querySelector('[data-copy-seed-phrase]');
-    assert(cardCopy && !cardCopy.disabled && cardCopy.dataset.phrase.split(" ").length === 24, "Testing seed preview was not copyable");
+    assert(cardCopy && cardCopy.disabled && !cardCopy.dataset.phrase, "Below-threshold seed preview was copyable");
     assert(!dealt.hidden && dealt.textContent.includes("A"), "Show cards did not reveal the dealt card");
     equal(dealt.getBoundingClientRect().height, emptyHistoryHeight);
     input(cards, "AS ZZ");
@@ -394,7 +395,7 @@
     input(cards, "as, 10♥; td");
     await wait(0);
     equal(cards.value, "AS 10H TD");
-    assert(!document.getElementById("go").disabled, "Normalized valid cards did not enable derivation");
+    assert(document.getElementById("go").disabled, "Three normalized cards below the entropy threshold enabled derivation");
     cards.focus();
     const disallowed = new InputEvent("beforeinput", { bubbles: true, cancelable: true, inputType: "insertText", data: "B" });
     assert(cards.dispatchEvent(disallowed) === false, "A character unused by card transcripts was accepted from typing");

--- a/test/cards.test.mjs
+++ b/test/cards.test.mjs
@@ -6,7 +6,7 @@ import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { mnemonicToEntropy, validateMnemonic } from "@scure/bip39";
+import { entropyToMnemonic, mnemonicToEntropy, validateMnemonic } from "@scure/bip39";
 import { wordlist as bip39English } from "@scure/bip39/wordlists/english.js";
 
 const root = dirname(fileURLToPath(import.meta.url));
@@ -45,7 +45,11 @@ const hodlSeedLengths = {
 function hodlSeedConfig(words = 12) {
   return hodlSeedLengths[words];
 }
-const hodlCardNeeded = new Function("hodlSeedConfig", `${loadSlice("hodlCardNeeded")}; return hodlCardNeeded;`)(hodlSeedConfig);
+const hodlCardNeeded = new Function(
+  "hodlSeedConfig",
+  "hodlCardWithoutReplacementBits",
+  `${loadSlice("hodlCardNeeded")}; return hodlCardNeeded;`,
+)(hodlSeedConfig, hodlCardWithoutReplacementBits);
 const hodlParseCards = new Function(
   "hodlCardNeeded",
   "hodlNormalizeCardToken",
@@ -179,26 +183,60 @@ test("hashed transcript is SHA-256 of ASCII codes", () => {
 
 test("Ian Coleman hashed cards SHA-256 the suit-symbol transcript", () => {
   assert.equal(hodlCardsHashInput(["AS", "2C", "TD"], true), "A\u2660 2\u2663 T\u2666");
-  const ascii = hodlCardsEntropy("AS 2C TD", 12, false);
-  const coleman = hodlCardsEntropy("AS 2C TD", 12, true);
+  const cards = DECK.slice(0, 25);
+  const ascii = hodlCardsEntropy(cards.join(" "), 12, false);
+  const coleman = hodlCardsEntropy(cards.join(" "), 12, true);
   assert.equal(ascii.ok, true);
   assert.equal(coleman.ok, true);
   assert.equal(ascii.method, "cards-sha256");
   assert.equal(coleman.method, "ian-coleman-cards-sha256");
   assert.notEqual(ascii.hex, coleman.hex);
-  assert.equal(coleman.hashInput, "A\u2660 2\u2663 T\u2666");
-  assert.equal(createHash("sha256").update("A\u2660 2\u2663 T\u2666", "utf8").digest("hex").slice(0, 32), coleman.hex);
+  assert.equal(coleman.hashInput, hodlCardsHashInput(cards, true));
+  assert.equal(createHash("sha256").update(coleman.hashInput, "utf8").digest("hex").slice(0, 32), coleman.hex);
 });
 
-test("one valid card produces a deterministic testing seed", () => {
-  const entropy = hodlCardsEntropy("AS", 24);
-  assert.equal(entropy.ok, true);
-  assert.equal(entropy.bytes.length, 32);
-  assert.equal(entropy.parsed.cards.length, 1);
-  assert.match(entropy.warnings.join(" "), /Only 1 of 58 recommended cards/);
-  assert.match(entropy.warnings.join(" "), /Use only for testing/);
+test("below-threshold card transcripts fail closed and never produce a seed", () => {
+  // One card: 52 enumerable candidates must not produce a wallet (issue #85).
+  const one = hodlCardsEntropy("AS", 24);
+  assert.equal(one.ok, false);
+  assert.equal(one.bytes, undefined);
+  assert.equal(one.parsed.cards.length, 1);
+  assert.match(one.error, /Only 1 of 58 required cards/);
+  assert.match(one.error, /trivially enumerable/);
   assert.equal(hodlCardsEntropy("AS AS", 24).ok, false);
   assert.equal(hodlCardsEntropy("ZZ", 24).ok, false);
+});
+
+test("entropy thresholds are enforced at the exact boundary for every phrase length", () => {
+  // Required counts come from hodlCardWithoutReplacementBits, not constants.
+  for (const [words, first, extra] of [[12, 25, 0], [15, 31, 0], [18, 39, 0], [21, 50, 0], [24, 52, 6]]) {
+    const needed = hodlCardNeeded(words);
+    assert.equal(needed.first, first);
+    assert.equal(needed.extra, extra);
+    const required = first + extra;
+    // 24 words span two shuffles: the first 52 cards come from one deck and
+    // the extra cards from a fresh one (repeats across shuffles are allowed).
+    const deal = (count) => count <= 52 ? DECK.slice(0, count).join(" ") : `${DECK.join(" ")} ${DECK.slice(0, count - 52).join(" ")}`;
+    const below = hodlCardsEntropy(deal(required - 1), words);
+    assert.equal(below.ok, false, `${words} words accepted ${required - 1} cards`);
+    assert.match(below.error, new RegExp(`Only ${required - 1} of ${required} required cards`));
+    const full = hodlCardsEntropy(deal(required), words);
+    assert.equal(full.ok, true, `${words} words rejected ${required} cards`);
+    assert.equal(full.bytes.length, words / 3 * 4);
+  }
+});
+
+test("a complete card transcript keeps deriving the expected deterministic seed", () => {
+  // 24 words: full deck plus six cards from a second shuffle.
+  const transcript = `${DECK.join(" ")} ${DECK.slice(0, 6).join(" ")}`;
+  const entropy = hodlCardsEntropy(transcript, 24);
+  assert.equal(entropy.ok, true);
+  assert.equal(entropy.bytes.length, 32);
+  const expected = createHash("sha256").update(transcript, "utf8").digest();
+  assert.deepEqual([...entropy.bytes], [...expected.subarray(0, 32)]);
+  const mnemonic = entropyToMnemonic(entropy.bytes, bip39English);
+  assert.equal(mnemonic.split(" ").length, 24);
+  assert.ok(validateMnemonic(mnemonic, bip39English));
 });
 
 test("hashed-card controls accept either suit or rank first and filter the other row", () => {

--- a/test/validate.test.mjs
+++ b/test/validate.test.mjs
@@ -164,8 +164,9 @@ test("third-party actions are immutable and deployment is test-gated", () => {
 
 test("the intentional low-entropy recovery behavior is documented", () => {
   const security = read("SECURITY.md");
-  assert.match(security, /low-entropy dice and card transcripts are accepted intentionally/i);
-  assert.match(security, /does not claim that hashing a short input\s+makes it secure/i);
+  assert.match(security, /low-entropy dice transcripts are accepted intentionally/i);
+  assert.match(security, /card\s+transcripts instead fail closed/i);
+  assert.match(security, /hashing a short input\s+does not make it secure/i);
 });
 
 const htmlFiles = [appFile];


### PR DESCRIPTION
## Problem

The hashed Cards mode accepted any non-empty valid transcript as wallet entropy; falling short of the selected BIP39 entropy target only produced a warning. A one-card transcript has 52 possible values, and SHA-256 expands the representation without adding entropy — an observer who suspects the workflow can enumerate every candidate wallet and match it against a public address or xpub.

## Fix

Fail closed until the deal reaches the required count:

- `hodlCardsEntropy` returns a blocking error while below the threshold. Since every downstream output (seed copying after derivation, xprv/private-key display, wallet export) is gated on that result, below-threshold transcripts can no longer produce or export a wallet.
- The provisional word-grid preview still renders during entry, but its seed-phrase copy control stays disabled below the threshold (`copyable` flag on `hodlRenderDiceWordGrid`; dice flows unchanged).
- Required counts are now **derived from the selected entropy target** via `hodlCardWithoutReplacementBits` rather than duplicated as policy constants. The values are unchanged (25/31/39/50 cards for 12/15/18/21 words; 52 + 6 for 24 words), which the existing boundary test pins.
- Status/help text updated: "N of R required cards · X more required before deriving" replaces "seed available for testing".

## Tests

- Below-threshold transcripts (one card, and target−1 cards for every phrase length) return no usable entropy.
- Exact boundary tests for 12/15/18/21/24-word phrases: target−1 cards fail, target cards derive.
- A complete 58-card transcript still derives the expected SHA-256 transcript digest and a valid 24-word mnemonic.
- Browser suite flipped: one card leaves the derive button disabled, shows the blocking status, and keeps the preview copy control disabled.

## Verification

- `npm run build`
- `npm run test:ci` (305 pass)
- `npm run test:cards`

Closes #85.