### PR TITLE
Deduplicate @scure/base and reject crypto-dependency drift in CI (#100)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "esbuild": "0.28.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -596,15 +596,6 @@
       "engines": {
         "node": ">= 20.19.0"
       },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/micro-packed/node_modules/@scure/base": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.3.0.tgz",
-      "integrity": "sha512-NsG6Y03tY6R5BUis4FdVtHVkur0U6FOzskgs9ZXNl78CUc9fkZ78HmENUle1nSOkCasDmbubmWD9qwB7mm4PZA==",
-      "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }

--- a/package.json
+++ b/package.json
@@ -54,5 +54,8 @@
   },
   "devDependencies": {
     "esbuild": "0.28.2"
+  },
+  "overrides": {
+    "@scure/base": "2.4.0"
   }
 }

--- a/test/validate.test.mjs
+++ b/test/validate.test.mjs
@@ -92,6 +92,25 @@ test("dependencies and build tooling are exactly locked", () => {
   assert.equal(existsSync(join(root, "src/js/vendor.js")), false, "opaque vendor bundle must not return");
 });
 
+test("security-sensitive crypto libraries resolve to a single locked version", () => {
+  // Duplicated @scure/@noble copies multiply the audit surface of key and
+  // address encoding code and can drift apart unnoticed on lockfile
+  // regeneration (issue #100). package.json pins one reviewed version with an
+  // npm override; this test rejects any second copy anywhere in the tree.
+  const lock = JSON.parse(read("package-lock.json"));
+  const versions = new Map();
+  for (const [path, entry] of Object.entries(lock.packages)) {
+    const name = path.match(/(?:^|\/)node_modules\/(@(?:scure|noble)\/[^/]+)$/)?.[1];
+    if (!name) continue;
+    if (!versions.has(name)) versions.set(name, new Set());
+    versions.get(name).add(entry.version);
+  }
+  assert.ok(versions.size > 0, "no @scure/@noble packages found in the lockfile");
+  for (const [name, found] of versions) {
+    assert.equal(found.size, 1, `${name} resolves to multiple locked versions: ${[...found].join(", ")}`);
+  }
+});
+
 test("Node scripts and test files parse", () => {
   const nodeFiles = [
     "scripts/build.mjs",


### PR DESCRIPTION
## Problem

The locked dependency tree carried two versions of `@scure/base` on the wallet key/address encoding paths: 2.4.0 as a direct dependency and a nested 2.3.0 via `micro-packed` (through `@scure/btc-signer`). Duplicated crypto-encoding code increases review surface, and a lockfile regeneration could silently drift the nested 2.3.x copy.

## Fix

- `package.json` gains `"overrides": { "@scure/base": "2.4.0" }`, pinning the single reviewed version across the tree. The nested copy disappears from `package-lock.json` (`npm ls @scure/base` shows 2.4.0 everywhere).
- `test/validate.test.mjs` now rejects any `@scure/*` or `@noble/*` package that resolves to more than one locked version anywhere in the tree, so an unexpected duplicate fails CI.

## Compatibility validation (per the issue's caveat)

micro-packed declares `@scure/base ~2.3.0`; before pinning 2.4.0 across it, the complete suite was run against the deduped tree:

- `npm ci --ignore-scripts` from a clean `node_modules` — installs the override tree
- `npm run build`
- `npm run test:ci` — 306 pass, including the descriptor, wallet-export reference vectors (Bitcoin Core ground truth), PSBT, and address tests that exercise micro-packed through btc-signer

The lockfile diff also refreshes the root `engines` entry to mirror the manifest's `node >=20.19` (the committed lockfile predated that manifest change).

Closes #100.