### PR TITLE
Default wallet.dat exports to a genesis descriptor birthday (#95)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,12 @@ Official website: [entropylab.online](https://entropylab.online)
   script type, active and ready for address generation. The default download
   is watch-only; while private recovery material is shown on screen, the
   export becomes the spending variant (account xprvs as descriptor keys) and
-  the button says so. Generated database files match Bitcoin Core's own
-  record layout byte-for-byte (verified against Bitcoin Core v28.3.0).
+  the button says so. The descriptor birthday defaults to genesis so
+  recovered keys are discovered by Bitcoin Core's initial scan; choose the
+  "New keys" birthday only for entropy created at that moment. If a loaded
+  wallet looks empty, repair it with `rescanblockchain 0` in Bitcoin Core.
+  Generated database files match Bitcoin Core's own record layout
+  byte-for-byte (verified against Bitcoin Core v28.3.0).
 
 ## Usage
 

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1083,6 +1083,10 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .recovery-download-disclosure {
   flex: 1 1 100%; margin: 0; color: var(--muted); font-size: 12px; line-height: 1.5;
 }
+.wallet-dat-birthday { display: inline-flex; align-items: center; gap: 8px; color: var(--muted); font-size: 13px; }
+.wallet-dat-birthday select { width: auto; margin: 0; }
+.wallet-dat-birthday-help { flex: 1 1 100%; margin: 0; font-size: 12px; }
+.wallet-dat-birthday-help code { font-family: var(--mono); }
 .recovery-download-disclosure strong { color: var(--fg); }
 .wallet-result-messages {
   margin-top: 18px; padding: 14px 16px; border: 1px solid color-mix(in oklab, var(--warn) 42%, var(--border));

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -597,7 +597,7 @@ ec.innerHTML = `
   </div>
 `;
 if (/^(www\.)?entropylab\.online$/i.test(location.hostname)) document.getElementById("online-warning")?.removeAttribute("hidden");
-var hodlKeyModes = ["dice", "cards", "hex", "seed", "key"], hodlCardRanks = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "T", "J", "Q", "K"], hodlDirectCardRanks = ["A", "2", "3", "4", "5", "6", "7", "8"], hodlCardSuits = [{ code: "S", symbol: "\u2660", label: "Spades", red: false }, { code: "H", symbol: "\u2665", label: "Hearts", red: true }, { code: "C", symbol: "\u2663", label: "Clubs", red: false }, { code: "D", symbol: "\u2666", label: "Diamonds", red: true }], hodlCardSuit = "", hodlCardRank = "", hodlCardMethod = "hashed", hodlSeedMethod = "words", hodlSeedZeroIndexed = false, hodlCardColemanSymbols = false, Ne = "dice", ge = "coldcard", Pt = 24, hodlEntropyFormat = "hex", hodlDiceCoinPositions = [], ft = "", re = null, Ge = false, Zs = W("#modes"), at = W("#form"), dr = W("#out");
+var hodlKeyModes = ["dice", "cards", "hex", "seed", "key"], hodlCardRanks = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "T", "J", "Q", "K"], hodlDirectCardRanks = ["A", "2", "3", "4", "5", "6", "7", "8"], hodlCardSuits = [{ code: "S", symbol: "\u2660", label: "Spades", red: false }, { code: "H", symbol: "\u2665", label: "Hearts", red: true }, { code: "C", symbol: "\u2663", label: "Clubs", red: false }, { code: "D", symbol: "\u2666", label: "Diamonds", red: true }], hodlCardSuit = "", hodlCardRank = "", hodlCardMethod = "hashed", hodlSeedMethod = "words", hodlSeedZeroIndexed = false, hodlCardColemanSymbols = false, Ne = "dice", ge = "coldcard", Pt = 24, hodlEntropyFormat = "hex", hodlDiceCoinPositions = [], ft = "", re = null, Ge = false, hodlWalletDatBirthday = "genesis", Zs = W("#modes"), at = W("#form"), dr = W("#out");
 hodlKeyModes.forEach((e) => {
   let t = document.createElement("button"), active = e === Ne;
   t.type = "button";
@@ -1315,7 +1315,13 @@ function hodlPrivateDataControls(descriptionId, scope = "wallet") {
 }
 function hodlWalletDatControl(includePrivate) {
   if (!hodlWalletExport.hasDescriptors(re)) return "";
-  return `<button class="btn secondary save-wallet-dat" id="download-wallet-dat" type="button" aria-describedby="recovery-sheet-disclosure">${hodlWalletExport.walletDatButtonLabel(includePrivate)}</button>`;
+  // Bitcoin Core starts its automatic scan at the wallet birthday stored in
+  // the descriptor records. Recovery needs genesis (creation time 0) so
+  // transactions predating this export are found; "now" is only safe for
+  // keys created at this moment and skips past history (faster, and reveals
+  // no older activity to anyone who later sees the file). If a loaded wallet
+  // looks empty, repair it with Bitcoin Core's `rescanblockchain 0`.
+  return `<label class="wallet-dat-birthday">Wallet birthday <select data-wallet-dat-birthday aria-describedby="wallet-dat-birthday-help"><option value="genesis"${hodlWalletDatBirthday === "genesis" ? " selected" : ""}>Recovering keys \xB7 scan from genesis</option><option value="now"${hodlWalletDatBirthday === "now" ? " selected" : ""}>New keys \xB7 created today</option></select></label><button class="btn secondary save-wallet-dat" id="download-wallet-dat" type="button" aria-describedby="recovery-sheet-disclosure wallet-dat-birthday-help">${hodlWalletExport.walletDatButtonLabel(includePrivate)}</button><p class="muted wallet-dat-birthday-help" id="wallet-dat-birthday-help">Bitcoin Core only auto-scans history back to the birthday. Choose \u201CNew keys\u201D only for entropy created right now; recovering older keys with today's birthday can look empty until you run <code>rescanblockchain 0</code> in Bitcoin Core.</p>`;
 }
 function hodlSaveRecoveryControl() {
   return `<div class="wallet-data-actions no-print"><button class="btn secondary save-recovery-sheet" id="save" type="button">Save watch-only sheet</button>${hodlWalletDatControl(false)}</div>`;
@@ -1445,7 +1451,11 @@ function hodlWalletDatDeps() {
 }
 function hodlDownloadWalletDat() {
   if (!re || !hodlWalletExport.hasDescriptors(re)) return;
-  let bytes = hodlWalletExport.buildWalletDat(re, Ge, hodlWalletDatDeps()), blob = new Blob([bytes], { type: "application/octet-stream" }), url = URL.createObjectURL(blob), link = document.createElement("a");
+  // Recovery default is a genesis birthday so Core scans from the start;
+  // "now" is written only when the user confirms the keys are new (issue
+  // #95).
+  let creationTime = hodlWalletDatBirthday === "now" ? Math.floor(Date.now() / 1000) : 0;
+  let bytes = hodlWalletExport.buildWalletDat(re, Ge, hodlWalletDatDeps(), creationTime), blob = new Blob([bytes], { type: "application/octet-stream" }), url = URL.createObjectURL(blob), link = document.createElement("a");
   link.href = url;
   link.download = hodlWalletExport.walletDatFilename(re, Ge);
   link.click();
@@ -1470,6 +1480,12 @@ function hodlBindWalletResultActions() {
     walletDat.replaceWith(clean);
     clean.addEventListener("click", hodlDownloadWalletDat);
   }
+  document.querySelectorAll("[data-wallet-dat-birthday]").forEach((select) => {
+    select.value = hodlWalletDatBirthday;
+    select.onchange = () => {
+      hodlWalletDatBirthday = select.value === "now" ? "now" : "genesis";
+    };
+  });
   hodlBindAddressMatch();
 }
 function hodlFocusWalletResult() {
@@ -5006,6 +5022,10 @@ function hodlInitMasterFingerprintPreview() {
 }
 function hodlCalculateKey() {
   W("#error").textContent = "";
+  // A fresh derivation restores the safe wallet.dat birthday default (scan
+  // from genesis) so a previous "new keys" choice cannot leak into a
+  // recovery export.
+  hodlWalletDatBirthday = "genesis";
   try {
     let network = hodlSelectedNetwork(document.getElementById("network")), count = Number(document.getElementById("count").value), passphrase = document.getElementById("pass").value, scriptType = hodlSelectedScriptType(), account = Ne === "key" ? 0 : hodlReadAccount();
     if (Ne !== "key" && hodlPassphraseBip39Enabled() && passphrase) {

--- a/test/wallet-export.test.mjs
+++ b/test/wallet-export.test.mjs
@@ -403,7 +403,7 @@ test("template, build script, and app wiring ship the export", () => {
   assert.match(app, /hodlSaveRecoveryControl\s*\(\s*\)\s*\{\s*return\s*`<div class="wallet-data-actions no-print">[^`]*\$\{hodlWalletDatControl\(\s*(?:false|!1)\s*\)\}/);
   assert.match(app, /id="download-wallet-dat"[^>]*>\$\{hodlWalletExport\.walletDatButtonLabel\(includePrivate\)\}/);
   assert.match(app, /hodlWalletExport\.hasDescriptors\(re\)/);
-  assert.match(app, /hodlWalletExport\.buildWalletDat\(\s*re\s*,\s*Ge\s*,\s*hodlWalletDatDeps\(\s*\)\s*\)/);
+  assert.match(app, /hodlWalletExport\.buildWalletDat\(\s*re\s*,\s*Ge\s*,\s*hodlWalletDatDeps\(\s*\)\s*,\s*creationTime\s*\)/);
   assert.match(app, /hodlWalletExport\.walletDatFilename\(re, Ge\)/);
   assert.match(app, /document\.getElementById\("download-wallet-dat"\)/);
   assert.match(css, /\.save-wallet-dat/);
@@ -457,8 +457,9 @@ class Blob {
 const document = {
   createElement: () => ({ click() { captured.name = this.download; } }),
   getElementById: (id) => elements.get(id) ?? null,
+  querySelectorAll: (selector) => [...elements.values()].filter((element) => element.matches?.(selector)),
 };
-let re = null, Ge = false;
+let re = null, Ge = false, hodlWalletDatBirthday = "genesis";
 const tr = (bytes) => sha256(bytes);
 const Cs = descriptorChecksum;
 const sr = { decode: b58checkDecode };
@@ -476,7 +477,8 @@ ${extract("function hodlWalletDatDeps", "function hodlFocusWalletResult")}
 ${sqliteSrc}
 ${walletSrc}
 const setResult = (value, flag) => { re = value; Ge = flag; };
-export { captured, elements, hodlPrivateDataControls, hodlSaveRecoveryControl, hodlDownloadWalletDat, hodlBindWalletResultActions, setResult };
+const setWalletDatBirthday = (value) => { hodlWalletDatBirthday = value; };
+export { captured, elements, hodlPrivateDataControls, hodlSaveRecoveryControl, hodlDownloadWalletDat, hodlBindWalletResultActions, setResult, setWalletDatBirthday };
 `;
 
 // Keep the transient harness out of test/ so parallel suites that list the
@@ -523,6 +525,49 @@ test("download handler emits a real wallet.dat through the app code path", { ski
       .map(([key, val]) => [bytesToHex(key), bytesToHex(val)]),
   );
   assert.deepEqual(asMap(report.rows), expected);
+});
+
+// Issue #95: a recovered wallet exported with the export time as its
+// descriptor birthday is not rescanned back to its real history by Bitcoin
+// Core. The download defaults to a genesis birthday (creation time 0) so
+// recovery discovers older transactions; "now" is written only on request.
+const readBackCreationTime = (bytes) => {
+  const report = sqliteReadBack(bytes);
+  const descriptorRow = report.rows.find(([key]) => key.startsWith("10" + "77616c6c657464657363726970746f72"));
+  const value = Buffer.from(descriptorRow[1], "hex");
+  return Number(value.readBigUInt64LE(1 + value[0]));
+};
+
+test("wallet.dat download defaults to a genesis birthday for recovery", { skip: !PYTHON_SQLITE }, () => {
+  ui.setResult(WATCH_ONLY_WALLET, false);
+  ui.setWalletDatBirthday("genesis");
+  ui.hodlDownloadWalletDat();
+  assert.equal(readBackCreationTime(new Uint8Array(ui.captured.blob.parts[0])), 0);
+});
+
+test("wallet.dat download writes the current time only for keys confirmed new", { skip: !PYTHON_SQLITE }, () => {
+  ui.setResult(PRIVATE_WALLET, true);
+  ui.setWalletDatBirthday("now");
+  const before = Math.floor(Date.now() / 1000) - 1;
+  ui.hodlDownloadWalletDat();
+  const after = Math.floor(Date.now() / 1000) + 1;
+  const creationTime = readBackCreationTime(new Uint8Array(ui.captured.blob.parts[0]));
+  assert.ok(creationTime >= before && creationTime <= after, `creation time ${creationTime} is not the export time`);
+  ui.setWalletDatBirthday("genesis");
+});
+
+test("the wallet.dat control offers the birthday choice with genesis as the safe default", () => {
+  ui.setResult(WATCH_ONLY_WALLET, false);
+  const html = ui.hodlSaveRecoveryControl();
+  assert.match(html, /data-wallet-dat-birthday/);
+  assert.match(html, /<option value="genesis" selected>Recovering keys/);
+  assert.match(html, /<option value="now">New keys/);
+  // The tradeoff and the manual repair path are explained next to the button.
+  assert.match(html, /wallet-dat-birthday-help/);
+  assert.match(html, /rescanblockchain 0/);
+  // The app reset keeps a stale "new keys" choice out of later derivations.
+  assert.match(app, /function hodlCalculateKey\(\) \{\s*W\("#error"\)\.textContent = "";\s*\n?[^}]*hodlWalletDatBirthday = "genesis";/);
+  assert.match(app, /hodlWalletDatBirthday === "now" \? Math\.floor\(Date\.now\(\) \/ 1000\) : 0/);
 });
 
 test("binding attaches the download to #download-wallet-dat and tolerates missing elements", () => {


### PR DESCRIPTION
## Problem

Every generated `wallet.dat` serialized the export time as every descriptor's creation time. Bitcoin Core uses descriptor creation times to establish the wallet birth time, and its automatic scan starts at approximately that time — so a recovered seed whose history predates the export appeared empty or incomplete until the user ran an explicit early rescan.

## Fix

The wallet.dat control now offers an explicit **wallet birthday** next to the download button:

- **Recovering keys · scan from genesis** (default) — writes creation time `0` to every descriptor record, so Core scans from genesis and discovers transactions predating the export.
- **New keys · created today** — keeps the current-time birthday, only for entropy created at that moment.

Supporting behavior:

- The choice resets to the safe genesis default on every derivation, so a stale "new keys" selection cannot leak into a later recovery export.
- The control explains the scan-time/privacy tradeoff and documents the manual repair path (`rescanblockchain 0`).
- README documents the default and the repair command.

## Tests

New coverage in `test/wallet-export.test.mjs` (watch-only and private variants):

- Default download writes descriptor creation time `0` (verified by reading the emitted SQLite database with the real SQLite library).
- "New keys" writes the current export time.
- The control markup exposes both choices with genesis preselected and explains the tradeoff and `rescanblockchain 0`.
- Source assertions pin the derivation-time reset and the creation-time selection.

The existing Bitcoin Core v28.3.0 ground-truth record tests are unchanged and pass.

## Verification

- `npm run build`
- `npm run test:ci` (304 pass)
- `npm run test:wallet-export` (18 pass)

Closes #95.