### PR TITLE
Attest the wallet HTML and publish a SHA-256 manifest (#58)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -24,6 +24,11 @@ jobs:
     name: Build · compile site + Pages artifact
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      # Keyless Sigstore attestation of the exact wallet HTML (issue #58).
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -34,6 +39,19 @@ jobs:
         run: npm ci --ignore-scripts
       - name: Build static site
         run: npm run build
+      - name: Generate the SHA-256 checksum manifest
+        run: sha256sum entropylab.html > SHA256SUMS.txt
+      - name: Attest the wallet artifact
+        if: github.ref == 'refs/heads/rock' && github.event_name == 'push'
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: entropylab.html
+      - name: Upload the checksum manifest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: entropylab-sha256sums
+          path: SHA256SUMS.txt
+          retention-days: 7
       - name: Prepare static site
         run: |
           mkdir _site
@@ -232,11 +250,13 @@ jobs:
         run: npm run build:wasm
       - name: Build static site
         run: npm run build
+      - name: Generate the SHA-256 checksum manifest
+        run: sha256sum entropylab.html > SHA256SUMS.txt
       - name: Commit the generated artifact
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -f entropylab.html src/js/secp256k1-wasm-b64.js
+          git add -f entropylab.html src/js/secp256k1-wasm-b64.js SHA256SUMS.txt
           if git diff --cached --quiet; then
             echo "Build output is unchanged; nothing to commit."
             exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 
 # Build output: compiled by CI and committed back after merges to main.
 /entropylab.html
+/SHA256SUMS.txt
 /versions.json
 
 # Rust build output (the wasm artifact is committed as src/js/secp256k1-wasm-b64.js)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,24 @@ wallet or signing device before receiving funds.
 
 To build the HTML file yourself, see [Building from source](#building-from-source).
 
+### Verifying the download
+
+Every merge to `rock` publishes a `SHA256SUMS.txt` checksum manifest for
+`entropylab.html` (committed next to it in this repository) and a
+[GitHub artifact attestation](https://github.com/w-s-bitcoin/entropylab/attestations)
+for the exact bytes built by CI. After downloading, verify both:
+
+```sh
+sha256sum -c SHA256SUMS.txt
+gh attestation verify entropylab.html -R w-s-bitcoin/entropylab
+```
+
+The attestation is keyless (Sigstore) and bound to this repository's release
+workflow, so it authenticates the artifact independently of the hosting
+account. The checksum manifest alone only detects accidental corruption —
+always pair it with the attestation or with your own rebuild from source,
+which is byte-for-byte reproducible.
+
 An online version is available at [entropylab.online](https://entropylab.online)
 for convenient access. Do not enter seed phrases, private keys, or other secret
 wallet material into an internet-connected device; use the downloaded HTML on

--- a/test/validate.test.mjs
+++ b/test/validate.test.mjs
@@ -150,6 +150,20 @@ test("the WASM boot chain has a failure path that kills the page", () => {
   assert.match(app, /<tr><td>secp256k1 WebAssembly module<\/td><td>Failed<\/td><\/tr>/);
 });
 
+test("the release build attests the wallet artifact and ships a checksum manifest (issue #58)", () => {
+  const workflow = read(".github/workflows/ci-cd.yml");
+  const build = workflow.match(/^  build:\n(?:.|\n)*?(?=^  [a-z-]+:)/m)?.[0] ?? "";
+  assert.match(build, /sha256sum entropylab\.html > SHA256SUMS\.txt/, "build must generate SHA256SUMS.txt");
+  assert.match(build, /actions\/attest-build-provenance@[0-9a-f]{40}/, "build must attest entropylab.html");
+  assert.match(build, /subject-path: entropylab\.html/, "the attestation subject is the wallet HTML");
+  assert.match(build, /attestations: write/, "attestation requires the attestations permission");
+  // Only merges to the default branch produce release attestations.
+  assert.match(build, /if: github\.ref == 'refs\/heads\/rock' && github\.event_name == 'push'\n\s*uses: actions\/attest-build-provenance/);
+  const artifact = workflow.match(/^  artifact:\n(?:.|\n)*?(?=^  [a-z-]+:)/m)?.[0] ?? "";
+  assert.match(artifact, /SHA256SUMS\.txt/, "the committed artifact includes the checksum manifest");
+  assert.match(read("README.md"), /gh attestation verify entropylab\.html -R w-s-bitcoin\/entropylab/);
+});
+
 test("third-party actions are immutable and deployment is test-gated", () => {
   const workflow = read(".github/workflows/ci-cd.yml");
   assert.doesNotMatch(workflow, /^\s*uses:\s*[^\s]+@(?![0-9a-f]{40}(?:\s|$))/m);


### PR DESCRIPTION
## Problem

EntropyLab distributes a self-contained wallet HTML through GitHub and GitHub Pages with no signed checksum manifest, detached signature, or verifiable build attestation — users downloading the prebuilt artifact had no project-provided integrity path.

## Fix

- **`build` job** now generates `SHA256SUMS.txt` for `entropylab.html`, uploads it as a workflow artifact, and — on pushes to `rock` only — creates a **keyless Sigstore build-provenance attestation** for the exact wallet bytes via `actions/attest-build-provenance` (pinned by SHA, with job-scoped `id-token`/`attestations` permissions).
- **`artifact` job** commits `SHA256SUMS.txt` next to `entropylab.html` so the manifest travels with the repository download (the file is gitignored for contributors and force-added by CI, same as the HTML).
- **README** gains a "Verifying the download" section:

  ```sh
  sha256sum -c SHA256SUMS.txt
  gh attestation verify entropylab.html -R w-s-bitcoin/entropylab
  ```

Per the issue's scope note, the attestation (Sigstore transparency log, bound to this repository's release workflow) is the authentication path; the README states explicitly that the checksum manifest alone only detects accidental corruption, and the reproducible source build remains the independent verification path.

New `validate.test.mjs` coverage pins the control: manifest generation, the pinned attestation action, its subject and permissions, the default-branch-only condition, the committed manifest, and the README instructions.

## Interaction with #114

This PR attests the artifact produced by the existing `build` job. #114 makes every test and publication path consume that exact object with digest checks, so once both land, the attested bytes are also the tested bytes. Either can merge first; the other will need a trivial rebase over the build job.

## Verification

- `npm run build`
- `npm run test:ci` (302 pass)

Note: the attestation itself can only be exercised by CI on a real push to `rock`; the workflow syntax and permission wiring are validated locally and pinned by the new invariant test.

Closes #58.