### PR TITLE
Add explicit local symbol-font fallbacks for card suit glyphs (#104)

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -32,8 +32,13 @@
   --site-header-pad: 16px; /* the bar's side padding; the status tag aligns to it */
   --site-min-width: 320px; /* the narrowest layout we lay out for: below this the page scrolls */
   --display: "Iowan Old Style", Palatino, Georgia, serif;
-  --sans: "Segoe UI", system-ui, sans-serif;
-  --mono: ui-monospace, "Cascadia Code", Menlo, Consolas, monospace;
+  /* The card-suit glyphs (♠ ♥ ♦ ♣, U+2660–U+2666) are not covered by every
+     default UI font (notably SF Mono on macOS); the named symbol fonts
+     between the preferred families and the generic fallback carry them on
+     Windows, macOS, and Linux. All are locally installed system fonts —
+     nothing is ever downloaded (the no-network-egress rule). */
+  --sans: "Segoe UI", system-ui, "Segoe UI Symbol", "Apple Symbols", "Noto Sans Symbols", "DejaVu Sans", sans-serif;
+  --mono: ui-monospace, "Cascadia Code", Menlo, Consolas, "Segoe UI Symbol", "Apple Symbols", "Noto Sans Symbols", "DejaVu Sans Mono", "DejaVu Sans", monospace;
 }
 :root[data-theme="light"] {
   color-scheme: light;

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -837,3 +837,20 @@ test("dice rolls hide Pearson chi-squared fairness behind a text expand button",
   assert.match(template, /dicefairness\.johnellmore\.com/);
   assert.match(template, /How can I test whether a die is fair/);
 });
+
+test("card suit glyphs have explicit local symbol-font fallbacks (issue #104)", () => {
+  // ♠ ♥ ♦ ♣ (U+2660–U+2666) appear wherever cards are entered or displayed,
+  // but not every default UI font covers them (notably SF Mono on macOS).
+  // Both stacks must name local symbol fonts before the generic fallback so
+  // the suits render on Windows, macOS, and Linux.
+  for (const property of ["--sans", "--mono"]) {
+    const stack = css.match(new RegExp(`${property}: ([^;]+);`))?.[1] ?? "";
+    for (const family of ['"Segoe UI Symbol"', '"Apple Symbols"', '"Noto Sans Symbols"']) {
+      assert.ok(stack.includes(family), `${property} is missing the ${family} fallback`);
+    }
+    assert.ok(/, (sans-serif|monospace)$/.test(stack.trim()), `${property} must keep its generic fallback last`);
+  }
+  // Fonts are local system fonts only: no webfont may ever be downloaded.
+  assert.doesNotMatch(css, /@font-face|\.woff2?|fonts\.googleapis|fonts\.gstatic/);
+  assert.doesNotMatch(template, /@font-face|\.woff2?|fonts\.googleapis|fonts\.gstatic/);
+});


### PR DESCRIPTION
## Problem / verification result

The card suits (♠ ♥ ♦ ♣, U+2660–U+2666) are rendered through the shared font stacks:

- `--sans: "Segoe UI", system-ui, sans-serif`
- `--mono: ui-monospace, "Cascadia Code", Menlo, Consolas, monospace`

Checking coverage per major OS: Segoe UI (Windows), Cascadia Code, Menlo, Consolas, and DejaVu Sans Mono (common Linux `ui-monospace`) cover the suits, but **SF Mono (macOS `ui-monospace`) does not**, and SF's coverage via `system-ui` is version-dependent. With the old stacks, a missing glyph fell straight through to the browser's generic fallback — nondeterministic, and a poor outcome for a suit picker whose four buttons must be unmistakably distinct.

## Fix

Both stacks now name the common **locally installed** symbol fonts between the preferred families and the generic fallback:

- Windows: Segoe UI Symbol
- macOS: Apple Symbols
- Linux: Noto Sans Symbols, DejaVu Sans / DejaVu Sans Mono

Glyphs present in the preferred fonts are unaffected (fallback is per-character), and everything stays a local system font — no webfont is ever downloaded, keeping the no-network-egress rule intact.

## Tests

New `ui-defaults.test.mjs` case pins both stacks' symbol fallbacks and generic-last ordering, and asserts no `@font-face`/webfont URL can appear in the CSS or template.

## Verification

- `npm run build`
- `npm run test:ci` (302 pass)
- `npm run test:ui`

Closes #104.