### PR TITLE
Inspect raw signed transactions and label session-key output ownership.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ Official website: [entropylab.online](https://entropylab.online)
   Every input's declared sighash policy and each signature's appended sighash
   byte are decoded without a key; anything other than exact SIGHASH_ALL is a
   blocking warning.
+- Accepts a fully signed raw Bitcoin transaction (hex or base64) in the same
+  inspector: outputs, extracted ECDSA nonces, and inscription-envelope hints.
+  Fee and RFC 6979 cannot be checked without previous outputs.
+- With a session seed, root xprv, WIF, or hex key, labels each output as
+  change, receive, or not in this wallet (accounts 0–2, 50 receive + 50
+  change, all four script types). A two-or-more-output transaction with no
+  matching change is a blocking warning.
 - Runs a quick barrage of startup sanity checks on the host browser (secure
   context, CSPRNG, BigInt, UTF-8 encoding, and NFKD normalization). If any
   check fails, the page is replaced with a failure report listing the failed

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@ EntropyLab is a single HTML file with no runtime dependencies. It is designed to
 - Accepts dice rolls, coin flips, playing cards, hexadecimal entropy, BIP39 seed phrases (12–24 words), extended keys, WIF keys, raw private keys, and Casascius mini keys.
 - Derives BIP39 seeds, BIP32 extended keys, master fingerprints, addresses, and Bitcoin Core-compatible descriptors for legacy, nested SegWit, native SegWit, and Taproot; mainnet and testnet.
 - Builds multisignature wallets, including watch-only multisig from extended public keys alone.
-- Inspects PSBT v0 transactions: amounts, fees, repeated ECDSA nonces, and optional anti-exfil transcript checks.
+- Inspects PSBT v0 and raw signed transactions: amounts, fees (PSBT claims), repeated ECDSA nonces, optional anti-exfil transcript checks, and session-key output ownership (change vs not yours).
 - Exports a Bitcoin Core wallet.dat (watch-only by default) with all derived descriptors imported.
 - Runs startup sanity checks on the host browser and refuses to render if they fail.
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:wasm": "node scripts/build-wasm.mjs",
     "clean": "node scripts/build.mjs --clean",
     "test": "node --test test/*.test.mjs",
-    "test:ci": "node --test test/network-check.test.mjs test/browser-check.test.mjs test/ui-defaults.test.mjs test/validate.test.mjs test/descriptor.test.mjs test/seedqr.test.mjs test/cards.test.mjs test/copy-seed.test.mjs test/number-bases.test.mjs test/dice-fairness.test.mjs test/seed-numbers.test.mjs test/dplus.test.mjs test/psbt-low-r.test.mjs test/psbt-metadata.test.mjs test/psbt-sighash.test.mjs test/secret-clear.test.mjs test/sqlite-writer.test.mjs test/wallet-export.test.mjs test/psbt-anti-exfil.test.mjs test/address-match.test.mjs test/psbt-nonce-reuse.test.mjs test/lifehash.test.mjs test/secp256k1-wasm.test.mjs test/msig-cosigner-identity.test.mjs",
+    "test:ci": "node --test test/network-check.test.mjs test/browser-check.test.mjs test/ui-defaults.test.mjs test/validate.test.mjs test/descriptor.test.mjs test/seedqr.test.mjs test/cards.test.mjs test/copy-seed.test.mjs test/number-bases.test.mjs test/dice-fairness.test.mjs test/seed-numbers.test.mjs test/dplus.test.mjs test/psbt-low-r.test.mjs test/psbt-metadata.test.mjs test/psbt-sighash.test.mjs test/secret-clear.test.mjs test/sqlite-writer.test.mjs test/wallet-export.test.mjs test/psbt-anti-exfil.test.mjs test/address-match.test.mjs test/psbt-nonce-reuse.test.mjs test/lifehash.test.mjs test/secp256k1-wasm.test.mjs test/msig-cosigner-identity.test.mjs test/tx-ownership.test.mjs",
     "test:dice-fairness": "node --test test/dice-fairness.test.mjs",
     "test:network": "node --test test/network-check.test.mjs",
     "test:browser-check": "node --test test/browser-check.test.mjs",

--- a/src/index.html
+++ b/src/index.html
@@ -241,13 +241,13 @@ words, pick one of the checksum words.</span></span>
     </section>
     <section class="card no-print" id="psbt-card" role="tabpanel" hidden>
       <div class="kicker">Inspect first. Sign elsewhere.</div>
-      <h2>Read a PSBT. Check its ECDSA nonces.</h2>
-      <p class="muted psbt-intro">Inspecting a PSBT v0 does not require a private key. EntropyLab can show outputs, PSBT-provided input amounts and fees, signatures, and repeated ECDSA nonce values. Optional Jade anti-exfil transcripts (host nonce ρ and signer opening R) are checked without a key. Every input's declared sighash policy and each signature's appended sighash byte are also decoded without a key; anything other than exact SIGHASH_ALL is a blocking warning. Loading a matching key additionally checks whether supported signatures match plain RFC 6979 or Bitcoin Core-style low-r grinding; a mismatch alone is not evidence of a compromised signer.</p>
-      <label class="field">PSBT v0 (base64 or hex)
-        <textarea id="psbt-text" placeholder="cHNidP8B..." spellcheck="false" autocomplete="off" autocapitalize="off"></textarea>
+      <h2>Read a PSBT or a signed transaction.</h2>
+      <p class="muted psbt-intro">Inspecting a PSBT v0 or a raw Bitcoin transaction does not require a private key. EntropyLab can show outputs, PSBT-provided input amounts and fees, signatures, and repeated ECDSA nonce values. Optional Jade anti-exfil transcripts (host nonce ρ and signer opening R) are checked without a key. Every input's declared sighash policy and each signature's appended sighash byte are also decoded without a key; anything other than exact SIGHASH_ALL is a blocking warning. Loading a matching key additionally labels which outputs belong to this wallet (change vs receive vs not yours) and checks whether supported signatures match plain RFC 6979 or Bitcoin Core-style low-r grinding; a mismatch alone is not evidence of a compromised signer.</p>
+      <label class="field">PSBT v0 or raw transaction (base64 or hex)
+        <textarea id="psbt-text" placeholder="cHNidP8B… or 020000000001…" spellcheck="false" autocomplete="off" autocapitalize="off"></textarea>
       </label>
       <div class="psbt-grid">
-        <label class="field">Optional session key (BIP39 seed phrase, WIF, or 64-character hex)
+        <label class="field">Optional session key (BIP39 seed phrase, root xprv/tprv, WIF, or 64-character hex)
           <textarea id="psbt-key" placeholder="Leave blank for inspect-only mode" spellcheck="false" autocomplete="off" autocapitalize="off"></textarea>
         </label>
         <div>
@@ -264,7 +264,7 @@ words, pick one of the checksum words.</span></span>
         <span class="field-note">USB Jade only (Green host nonce + opening). QR / sign_psbt does not run anti-exfil yet. BitBox anti-klepto is a different mix — do not paste it here.</span>
       </label>
       <div class="row psbt-actions">
-        <button class="btn primary" id="psbt-go" type="button">Inspect PSBT</button>
+        <button class="btn primary" id="psbt-go" type="button">Inspect</button>
         <button class="btn secondary" id="psbt-use-calc" type="button">Use active key this session</button>
         <button class="btn secondary" id="psbt-wipe" type="button">End session / clear fields</button>
       </div>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -4,11 +4,13 @@ import { ripemd160 } from "@noble/hashes/legacy.js";
 // is a drop-in for the noble/curves surface this file uses (see
 // src/js/secp256k1.js). App boot waits for the module to be ready.
 import { secp256k1 as xe, secp256k1Ready } from "./secp256k1.js";
+import { parseRawTx, extractEcdsaSignatures, inscriptionHints, isPsbtMagic } from "./tx.js";
+import { indexHdKey, indexSingleKey, matchOwnership, pathLabel } from "./ownership.js";
 import { createBase58check as fi, hex as M } from "@scure/base";
 import { HDKey as Gt } from "@scure/bip32";
 import { entropyToMnemonic as bi, mnemonicToEntropy as Er, mnemonicToSeedSync as wi, validateMnemonic as Pn } from "@scure/bip39";
 import { wordlist as bip39English } from "@scure/bip39/wordlists/english.js";
-import { NETWORK as Ie, OutScript as Oe, TEST_NETWORK as mo, p2pkh as ir, p2sh as Jr, p2tr as en, p2wpkh as Tt, utils as bitcoinUtils } from "@scure/btc-signer";
+import { NETWORK as Ie, OutScript as Oe, TEST_NETWORK as mo, p2pkh as ir, p2sh as Jr, p2tr as en, p2wpkh as Tt, Address as or, utils as bitcoinUtils } from "@scure/btc-signer";
 import { renderSVG as Xs } from "uqr";
 const Ae = Object.freeze(bip39English);
 const tr = Z;
@@ -572,13 +574,13 @@ ec.innerHTML = `
     </section>
     <section class="card no-print" id="psbt-card" role="tabpanel" hidden>
       <div class="kicker">Inspect first. Sign elsewhere.</div>
-      <h2>Read a PSBT. Check its ECDSA nonces.</h2>
-      <p class="muted psbt-intro">Inspecting a PSBT v0 does not require a private key. EntropyLab can show outputs, PSBT-provided input amounts and fees, signatures, and repeated ECDSA nonce values. Optional Jade anti-exfil transcripts (host nonce \u03C1 and signer opening R) are checked without a key. Loading a matching key additionally checks whether supported signatures match plain RFC 6979 or Bitcoin Core-style low-r grinding; a mismatch alone is not evidence of a compromised signer.</p>
-      <label class="field">PSBT v0 (base64 or hex)
-        <textarea id="psbt-text" placeholder="cHNidP8B..." spellcheck="false" autocomplete="off" autocapitalize="off"></textarea>
+      <h2>Read a PSBT or a signed transaction.</h2>
+      <p class="muted psbt-intro">Inspecting a PSBT v0 or a raw Bitcoin transaction does not require a private key. EntropyLab can show outputs, PSBT-provided input amounts and fees, signatures, and repeated ECDSA nonce values. Optional Jade anti-exfil transcripts (host nonce \u03C1 and signer opening R) are checked without a key. Loading a matching key additionally labels which outputs belong to this wallet (change vs receive vs not yours) and checks whether supported signatures match plain RFC 6979 or Bitcoin Core-style low-r grinding; a mismatch alone is not evidence of a compromised signer.</p>
+      <label class="field">PSBT v0 or raw transaction (base64 or hex)
+        <textarea id="psbt-text" placeholder="cHNidP8B\u2026 or 020000000001\u2026" spellcheck="false" autocomplete="off" autocapitalize="off"></textarea>
       </label>
       <div class="psbt-grid">
-        <label class="field">Optional session key (BIP39 seed phrase, WIF, or 64-character hex)
+        <label class="field">Optional session key (BIP39 seed phrase, root xprv/tprv, WIF, or 64-character hex)
           <textarea id="psbt-key" placeholder="Leave blank for inspect-only mode" spellcheck="false" autocomplete="off" autocapitalize="off"></textarea>
         </label>
         <div>
@@ -595,7 +597,7 @@ ec.innerHTML = `
         <span class="field-note">USB Jade only (Green host nonce + opening). QR / sign_psbt does not run anti-exfil yet. BitBox anti-klepto is a different mix \u2014 do not paste it here.</span>
       </label>
       <div class="row psbt-actions">
-        <button class="btn primary" id="psbt-go" type="button">Inspect PSBT</button>
+        <button class="btn primary" id="psbt-go" type="button">Inspect</button>
         <button class="btn secondary" id="psbt-use-calc" type="button">Use active key this session</button>
         <button class="btn secondary" id="psbt-wipe" type="button">End session / clear fields</button>
       </div>
@@ -6600,16 +6602,16 @@ function hodlB64(value) {
 }
 function hodlPsbtBytes(raw) {
   let value = raw.trim(), compact = value.replace(/\s/g, "");
-  if (!value) throw new Error("Paste a PSBT v0.");
-  if (compact.length > 7e6) throw new Error("This PSBT is too large to inspect safely.");
+  if (!value) throw new Error("Paste a PSBT v0 or a raw Bitcoin transaction.");
+  if (compact.length > 7e6) throw new Error("This file is too large to inspect safely.");
   let bytes;
   if (/^[0-9a-fA-F]+$/.test(compact) && compact.length % 2 === 0 && compact.length >= 10) bytes = M.decode(compact.toLowerCase());
   else try {
     bytes = hodlB64(compact);
   } catch {
-    throw new Error("That does not look like a PSBT in base64 or hex.");
+    throw new Error("That does not look like a PSBT or raw transaction in base64 or hex.");
   }
-  if (bytes.length > 5e6) throw new Error("This PSBT is too large to inspect safely.");
+  if (bytes.length > 5e6) throw new Error("This file is too large to inspect safely.");
   return bytes;
 }
 function hodlReadMap(bytes, offset) {
@@ -6706,7 +6708,15 @@ function hodlSats(number) {
 }
 function hodlAddr(script, network) {
   try {
-    return or(_s(network)).encode(Oe.decode(script));
+    let net = _s(network);
+    if (script instanceof Uint8Array) {
+      if (script.length === 22 && script[0] === 0 && script[1] === 20) return or(net).encode({ type: "wpkh", hash: Uint8Array.from(script.subarray(2)) });
+      if (script.length === 34 && script[0] === 0 && script[1] === 32) return or(net).encode({ type: "wsh", hash: Uint8Array.from(script.subarray(2)) });
+      if (script.length === 34 && script[0] === 0x51 && script[1] === 32) return or(net).encode({ type: "tr", pubkey: Uint8Array.from(script.subarray(2)) });
+      if (script.length === 25 && script[0] === 118 && script[1] === 169 && script[23] === 136 && script[24] === 172) return or(net).encode({ type: "pkh", hash: Uint8Array.from(script.subarray(3, 23)) });
+      if (script.length === 23 && script[0] === 169 && script[22] === 135) return or(net).encode({ type: "sh", hash: Uint8Array.from(script.subarray(2, 22)) });
+    }
+    return or(net).encode(Oe.decode(script));
   } catch {
     return "script " + M.encode(script);
   }
@@ -6916,8 +6926,18 @@ function hodlLoadPsbtKey(text, passphrase) {
     hf(hodlPsbtPriv);
     hodlPsbtNote = "Session key: 32-byte private key. Kept in page memory only.";
   } else {
+    try {
+      let parsed = uf(value);
+      if (parsed && parsed.isPrivate && parsed.node) {
+        hodlPsbtHd = parsed.node;
+        hodlPsbtNote = "Session key: " + (parsed.prefix || "xprv") + ". Kept in page memory only.";
+        hodlPsbtSource = "manual";
+        return;
+      }
+    } catch {
+    }
     let mnemonic = Mt(value);
-    if (!mnemonic.ok) throw new Error(mnemonic.error || "Enter a BIP39 seed phrase, WIF, or 64-character hex key.");
+    if (!mnemonic.ok) throw new Error(mnemonic.error || "Enter a BIP39 seed phrase, root xprv/tprv, WIF, or 64-character hex key.");
     let seed = wi(mnemonic.words.join(" "), passphrase || "");
     try {
       hodlPsbtHd = Gt.fromMasterSeed(seed);
@@ -6998,8 +7018,9 @@ function hodlRunPsbt() {
       document.getElementById("psbt-pass").value = "";
     }
     document.getElementById("psbt-session").textContent = hodlPsbtNote;
-    let psbt = hodlParsePsbt(hodlPsbtBytes(document.getElementById("psbt-text").value));
-    output.innerHTML = hodlRenderPsbt(psbt);
+    let bytes = hodlPsbtBytes(document.getElementById("psbt-text").value);
+    if (isPsbtMagic(bytes)) output.innerHTML = hodlRenderPsbt(hodlParsePsbt(bytes));
+    else output.innerHTML = hodlRenderRawTx(parseRawTx(bytes));
   } catch (exception) {
     error.textContent = exception instanceof Error ? exception.message : String(exception);
   }
@@ -7089,6 +7110,77 @@ function hodlRfc6979Compare(sighash, privateKey, r) {
   }
   return { ok: false, className: "psbt-warn", message: "Does not match plain RFC 6979 or Bitcoin Core-style low-r grind. Honest signers may add other auxiliary randomness. A mismatch alone is not evidence of compromise. Reused r on two different messages is the real alarm." };
 }
+function hodlSessionOwnership(network) {
+  if (hodlPsbtHd) return indexHdKey(hodlPsbtHd, network);
+  if (hodlPsbtPriv) return indexSingleKey(hodlPsbtPriv, network, (key, compressed) => xe.getPublicKey(key, compressed));
+  return new Map();
+}
+function hodlDeclaredOutput(entries, script, network) {
+  if (!hodlPsbtHd || !entries || !script) return null;
+  let fingerprint = Us(hodlPsbtHd.fingerprint);
+  for (let entry of hodlFind(entries, 2)) {
+    if (entry.val.length < 4 || (entry.val.length - 4) % 4) continue;
+    let fp = M.encode(entry.val.slice(0, 4));
+    let path = [];
+    for (let i = 4; i < entry.val.length; i += 4) path.push(new DataView(entry.val.buffer, entry.val.byteOffset + i, 4).getUint32(0, true));
+    let label = "m/" + pathLabel(path);
+    if (fp !== fingerprint) return { state: "other-wallet", path: label, fingerprint: fp };
+    try {
+      let node = hodlPsbtHd;
+      for (let index of path) node = node.deriveChild(index);
+      if (!node.publicKey || !hodlEq(node.publicKey, entry.keydata)) return { state: "lie", path: label };
+      let address = hodlAddr(script, network);
+      let encoded = false;
+      for (let scriptType of ["p2pkh", "p2sh-p2wpkh", "p2wpkh", "p2tr"]) {
+        try {
+          if (hodlAddressesEqual(address, pf(scriptType, node.publicKey, network))) encoded = true;
+        } catch {
+        }
+      }
+      if (!encoded) return { state: "lie", path: label };
+      let chain = path.length >= 2 ? path[path.length - 2] : null;
+      return { state: "ours", path: label, role: chain === 1 ? "change" : chain === 0 ? "receive" : "key" };
+    } catch {
+      return { state: "lie", path: label };
+    }
+  }
+  return null;
+}
+function hodlRenderOutputHtml(output, index, network, map, entries) {
+  let scan = matchOwnership(map, output.script);
+  let address = hodlAddr(output.script, network);
+  if (scan.state !== "ours") scan = matchOwnership(map, address);
+  if (scan.state === "ours" && address.startsWith("script ") && scan.address) address = scan.address;
+  let declared = null;
+  try {
+    declared = hodlDeclaredOutput(entries, output.script, network);
+  } catch {
+  }
+  let extra = "", className = "psbt-kv";
+  if (declared && declared.state === "lie") {
+    extra = "<br><strong>PSBT lies:</strong> claims " + $t(declared.path) + " but this session key does not produce this output. Do not sign.";
+    className = "psbt-bad";
+  } else if (scan.state === "ours") {
+    let label = scan.role === "change" ? "change" : scan.role === "receive" ? "receive (this wallet)" : "this session key";
+    extra = "<br>" + $t(label + " \xB7 " + scan.path);
+    className = scan.role === "change" || scan.role === "key" ? "psbt-ok" : "psbt-kv";
+  } else if (declared && declared.state === "ours") {
+    extra = "<br>" + $t((declared.role === "change" ? "change" : "this wallet") + " \xB7 " + declared.path + " (verified)");
+    className = "psbt-ok";
+  } else if (scan.state === "external") {
+    extra = "<br>not in this wallet (accounts 0\u20132, 50 receive + 50 change, four script types)";
+  } else if (scan.state === "no-session") {
+    extra = "<br><span class='muted'>Load a session key to see if this output is yours.</span>";
+  }
+  return "<p class='" + className + "'><strong>Output " + index + "</strong> \xB7 " + hodlSats(output.amount) + " BTC<br>" + $t(address) + extra + "</p>";
+}
+function hodlOwnershipWarning(outputs, network, map) {
+  if (!map || !map.size) return "";
+  let ours = outputs.some((output) => matchOwnership(map, output.script).state === "ours" || matchOwnership(map, hodlAddr(output.script, network)).state === "ours");
+  if (ours) return "<p class='muted'>Session key: outputs compared against " + map.size + " derived scripts (accounts 0\u20132, 50 receive + 50 change, four types).</p>";
+  if (outputs.length < 2) return "<p class='muted'>This output is not in the session wallet (accounts 0\u20132, 50 receive + 50 change, four script types).</p>";
+  return "<p class='psbt-bad'><strong>No output belongs to this session wallet.</strong> If you expected change, do not sign. A destination-swap can replace both the payment and the change.</p>";
+}
 function hodlRenderPsbt(psbt) {
   let network = hodlSelectedNetwork(document.getElementById("psbt-network")),
     transcript = null,
@@ -7108,9 +7200,11 @@ function hodlRenderPsbt(psbt) {
     transcriptError = exception.message || String(exception);
   }
   html.push("<p class='label'>Where this transaction sends bitcoin</p>");
+  let ownershipMap = hodlSessionOwnership(network);
   tx.outputs.forEach((output, index) => {
-    html.push("<p class='psbt-kv'><strong>Output " + index + "</strong> \xB7 " + hodlSats(output.amount) + " BTC<br>" + $t(hodlAddr(output.script, network)) + "</p>");
+    html.push(hodlRenderOutputHtml(output, index, network, ownershipMap, psbt.outputs[index]));
   });
+  html.push(hodlOwnershipWarning(tx.outputs, network, ownershipMap));
   psbt.inputs.forEach((entries, index) => {
     let witnessUtxo = hodlWitUtxo(entries);
     if (witnessUtxo) {
@@ -7235,8 +7329,54 @@ function hodlRenderPsbt(psbt) {
   if (rValues.length) html.push("<p class='psbt-kv'>r values:<br>" + rValues.map(value => $t(value.hex) + " (input " + value.input + ")").join("<br>") + "</p>");
   rows.forEach(row => html.push("<p class='" + row.className + "'><strong>Input " + row.input + "</strong> pubkey " + $t(row.pubkey.slice(0, 18)) + "\u2026 \u2014 " + $t(row.message) + "</p>"));
   if (tapSignatureCount) html.push("<p class='muted'>This PSBT also contains " + tapSignatureCount + " Taproot / Schnorr signature(s). They are counted but their BIP340 nonces are not analyzed in this version.</p>");
-  html.push("<p class='muted'>RFC 6979 comparison currently covers SegWit v0 P2WPKH and P2WSH signatures using SIGHASH_ALL, including Bitcoin Core-style low-r grinding. Jade anti-exfil is secp256k1-zkp sign-to-contract and needs the USB host nonce plus signer opening; QR / sign_psbt Jade does not run it yet. BitBox anti-klepto is a different construction. Nonce reuse detection compares r values for the same secp256k1 point, including compressed and uncompressed encodings and recoverable non-strict DER. A clean verdict is not issued when a signature cannot be inspected.</p>");
+  html.push("<p class='muted'>RFC 6979 comparison currently covers SegWit v0 P2WPKH and P2WSH signatures using SIGHASH_ALL, including Bitcoin Core-style low-r grinding. Jade anti-exfil is secp256k1-zkp sign-to-contract and needs the USB host nonce plus signer opening; QR / sign_psbt Jade does not run it yet. BitBox anti-klepto is a different construction. Nonce reuse detection compares r values for the same secp256k1 point, including compressed and uncompressed encodings and recoverable non-strict DER. A clean verdict is not issued when a signature cannot be inspected. Output ownership is derived from the session key: accounts 0\u20132, 50 receive + 50 change, all four script types. It does not talk to the chain.</p>");
   return html.join("")
+}
+function hodlRenderRawTx(tx) {
+  let network = hodlSelectedNetwork(document.getElementById("psbt-network")),
+    html = [],
+    map = hodlSessionOwnership(network),
+    signatures = extractEcdsaSignatures(tx),
+    rValues = [],
+    uninspected = 0;
+  html.push("<p class='psbt-warn'><strong>Raw Bitcoin transaction.</strong> Not a PSBT. Input amounts and fee are unknown without previous outputs. RFC 6979 cannot be checked here. This is the last look before broadcast.</p>");
+  html.push("<p class='label'>Where this transaction sends bitcoin</p>");
+  tx.outputs.forEach((output, index) => {
+    html.push(hodlRenderOutputHtml(output, index, network, map, null));
+  });
+  html.push(hodlOwnershipWarning(tx.outputs, network, map));
+  tx.inputs.forEach((input, index) => {
+    html.push("<p class='psbt-kv'><strong>Input " + index + "</strong> \xB7 " + hodlHexRev(input.txid) + " : " + input.vout + "<br>sequence " + $t("0x" + input.sequence.toString(16)) + (input.sequence < 0xfffffffe ? " \xB7 RBF-capable" : "") + "</p>");
+  });
+  inscriptionHints(tx).forEach((hint) => {
+    html.push("<p class='psbt-warn'><strong>Inscription envelope</strong> in input " + hint.input + " (" + hint.bytes + " bytes of script/witness). This transaction reveals OP_FALSE OP_IF \"ord\" data.</p>");
+  });
+  html.push("<p class='muted'>Version " + tx.version + " \xB7 locktime " + tx.locktime + (tx.segwit ? " \xB7 segwit" : "") + ". Fee unknown \u2014 previous output amounts are not in a raw transaction.</p>");
+  html.push("<p class='label'>ECDSA nonce check</p>");
+  signatures.forEach((signature) => {
+    let parts = hodlSigParts(signature.der), looseR = parts ? parts.r : hodlDerRLoose(signature.der);
+    if (!looseR || !signature.pubkey) {
+      if (signature.der) uninspected += 1;
+      return;
+    }
+    rValues.push({
+      input: signature.input,
+      r: looseR,
+      hex: M.encode(looseR),
+      pubkey: hodlPubId(signature.pubkey),
+      sighash: null,
+      valid: null
+    });
+  });
+  let { reused, possible } = hodlCompareNonces(rValues);
+  if (reused.length || possible.length) html.push("<p class='psbt-bad'><strong>Repeated nonce r for the same public key.</strong> Message digests cannot be rebuilt from a raw transaction without prevouts, so treat this as a warning and do not broadcast until the signatures are checked independently.</p>");
+  else if (uninspected) html.push("<p class='psbt-warn'><strong>Incomplete nonce coverage.</strong> Some ECDSA signatures could not be inspected.</p>");
+  else if (rValues.length >= 2) html.push("<p class='psbt-ok'>No repeated ECDSA nonce r values were found for the same public key in this transaction.</p>");
+  else if (rValues.length === 1) html.push("<p class='muted'>Only one ECDSA signature with a readable r is present. Nonce reuse cannot be judged from this file alone.</p>");
+  else html.push("<p class='muted'>No ECDSA signatures with a readable r and public key were found.</p>");
+  if (rValues.length) html.push("<p class='psbt-kv'>r values:<br>" + rValues.map((value) => $t(value.hex) + " (input " + value.input + ")").join("<br>") + "</p>");
+  html.push("<p class='muted'>Raw-transaction inspect does not reconstruct sighashes. Paste the PSBT when you still can; use this path for a fully signed hex dump from a hardware wallet or Bitcoin Core.</p>");
+  return html.join("");
 }
 var hodlAccountId = "bip84",
   hodlNextKeyId = 1,

--- a/src/js/ownership.js
+++ b/src/js/ownership.js
@@ -1,0 +1,238 @@
+// Match transaction outputs against a session key. Air-gapped: no chain.
+import { sha256 } from "@noble/hashes/sha2.js";
+import { ripemd160 } from "@noble/hashes/legacy.js";
+import { p2pkh, p2sh, p2tr, p2wpkh, NETWORK, TEST_NETWORK } from "@scure/btc-signer";
+
+export const OWNERSHIP_GAP = 50;
+export const OWNERSHIP_ACCOUNTS = 3;
+
+const SCRIPT_TYPES = [
+  { id: "bip44", script: "p2pkh", purpose: 44 },
+  { id: "bip49", script: "p2sh-p2wpkh", purpose: 49 },
+  { id: "bip84", script: "p2wpkh", purpose: 84 },
+  { id: "bip86", script: "p2tr", purpose: 86 },
+];
+
+function netOf(network) {
+  return network === "testnet" ? TEST_NETWORK : NETWORK;
+}
+
+function coinType(network) {
+  return network === "testnet" ? 1 : 0;
+}
+
+function hash160(bytes) {
+  return ripemd160(sha256(bytes));
+}
+
+function concatBytes(...parts) {
+  const out = new Uint8Array(parts.reduce((sum, part) => sum + part.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+function bytesToHex(bytes) {
+  if (!bytes) return "";
+  if (typeof bytes === "string") return bytes.replace(/^0x/i, "").toLowerCase();
+  const arr = bytes instanceof Uint8Array ? bytes : Uint8Array.from(bytes);
+  let hex = "";
+  for (let i = 0; i < arr.length; i++) hex += arr[i].toString(16).padStart(2, "0");
+  return hex;
+}
+
+function taggedTapTweak(pubkey) {
+  // p2tr script is OP_1 || 32-byte x-only output key. We still prefer scure when it works.
+  return pubkey.slice(1);
+}
+
+function scriptFor(script, pubkey, network) {
+  const compressed = pubkey.length === 33 ? pubkey : null;
+  const key = compressed || pubkey;
+  if (script === "p2pkh") {
+    const hash = hash160(key);
+    return concatBytes(Uint8Array.of(0x76, 0xa9, 0x14), hash, Uint8Array.of(0x88, 0xac));
+  }
+  if (script === "p2wpkh") {
+    if (!compressed) return null;
+    const hash = hash160(compressed);
+    return concatBytes(Uint8Array.of(0x00, 0x14), hash);
+  }
+  if (script === "p2sh-p2wpkh") {
+    if (!compressed) return null;
+    const hash = hash160(compressed);
+    const redeem = concatBytes(Uint8Array.of(0x00, 0x14), hash);
+    const redeemHash = hash160(redeem);
+    return concatBytes(Uint8Array.of(0xa9, 0x14), redeemHash, Uint8Array.of(0x87));
+  }
+  if (script === "p2tr") {
+    try {
+      const pay = p2tr(taggedTapTweak(compressed || pubkey), undefined, netOf(network));
+      return pay.script ? Uint8Array.from(pay.script) : null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function addressFor(script, pubkey, network) {
+  try {
+    if (script === "p2pkh") return p2pkh(pubkey, netOf(network)).address;
+    if (script === "p2sh-p2wpkh") return p2sh(p2wpkh(pubkey, netOf(network)), netOf(network)).address;
+    if (script === "p2wpkh") return p2wpkh(pubkey, netOf(network)).address;
+    if (script === "p2tr") return p2tr(pubkey.slice(1), undefined, netOf(network)).address;
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+export function normalizeAddress(value) {
+  const text = String(value ?? "").trim();
+  if (!text) return "";
+  if (/^(bc1|tb1|bcrt1)/i.test(text)) {
+    if (/[A-Z]/.test(text) && /[a-z]/.test(text)) return text;
+    return text.toLowerCase();
+  }
+  return text;
+}
+
+export function addressFromPubkey(script, pubkey, network) {
+  return addressFor(script, pubkey, network);
+}
+
+function remember(map, address, meta) {
+  if (address) {
+    const key = normalizeAddress(address);
+    if (key && !map.has(key)) map.set(key, meta);
+  }
+  if (meta.scriptHex && !map.has(meta.scriptHex)) map.set(meta.scriptHex, meta);
+}
+
+function record(map, definition, pubkey, network, extra) {
+  const scriptBytes = scriptFor(definition.script, pubkey, network);
+  if (!scriptBytes) return;
+  const address = addressFor(definition.script, pubkey, network);
+  remember(map, address, {
+    ...extra,
+    script: definition.script,
+    bip: definition.id,
+    scriptHex: bytesToHex(scriptBytes),
+    address: address || "",
+  });
+}
+
+export function indexSingleKey(priv, network, getPublicKey) {
+  const map = new Map();
+  if (!priv || !getPublicKey) return map;
+  const compressed = getPublicKey(priv, true);
+  const uncompressed = getPublicKey(priv, false);
+  for (const definition of SCRIPT_TYPES) record(map, definition, compressed, network, {
+    role: "key",
+    chain: "key",
+    index: null,
+    path: "session key",
+  });
+  record(map, SCRIPT_TYPES[0], uncompressed, network, {
+    role: "key",
+    chain: "key",
+    index: null,
+    path: "session key (uncompressed)",
+  });
+  return map;
+}
+
+export function indexHdKey(root, network, options = {}) {
+  const map = new Map();
+  if (!root) return map;
+  const gap = Number.isFinite(options.gap) ? options.gap : OWNERSHIP_GAP;
+  const accounts = Number.isFinite(options.accounts) ? options.accounts : OWNERSHIP_ACCOUNTS;
+  const coin = coinType(network);
+  const scanAccountNode = (node, pathPrefix, account) => {
+    for (const definition of SCRIPT_TYPES) {
+      for (const [chain, role] of [[0, "receive"], [1, "change"]]) {
+        for (let index = 0; index < gap; index++) {
+          let child;
+          try {
+            child = node.derive(`m/${chain}/${index}`);
+          } catch {
+            continue;
+          }
+          const pubkey = child.publicKey;
+          if (!pubkey) continue;
+          record(map, definition, pubkey, network, {
+            role,
+            chain: role,
+            index,
+            account,
+            path: `${pathPrefix}/${chain}/${index}`,
+          });
+        }
+      }
+    }
+  };
+  if (root.depth && root.depth !== 0) {
+    scanAccountNode(root, "m", null);
+    return map;
+  }
+  for (const definition of SCRIPT_TYPES) {
+    for (let account = 0; account < accounts; account++) {
+      let node;
+      try {
+        node = root.derive(`m/${definition.purpose}'/${coin}'/${account}'`);
+      } catch {
+        continue;
+      }
+      for (const [chain, role] of [[0, "receive"], [1, "change"]]) {
+        for (let index = 0; index < gap; index++) {
+          let child;
+          try {
+            child = node.derive(`m/${chain}/${index}`);
+          } catch {
+            continue;
+          }
+          const pubkey = child.publicKey;
+          if (!pubkey) continue;
+          record(map, definition, pubkey, network, {
+            role,
+            chain: role,
+            index,
+            account,
+            path: `m/${definition.purpose}h/${coin}h/${account}h/${chain}/${index}`,
+          });
+        }
+      }
+    }
+  }
+  return map;
+}
+
+export function matchOwnership(map, addressOrScript) {
+  if (!map || !map.size) return { state: "no-session" };
+  if (addressOrScript instanceof Uint8Array) {
+    const hit = map.get(bytesToHex(addressOrScript));
+    if (hit) return { state: "ours", ...hit };
+    return { state: "external", searched: map.size };
+  }
+  const key = normalizeAddress(addressOrScript);
+  if (!key) return { state: "empty" };
+  if (key.startsWith("script ")) {
+    const hex = key.slice(7).replace(/\s/g, "").toLowerCase();
+    const hit = map.get(hex);
+    if (hit) return { state: "ours", ...hit };
+  }
+  const hit = map.get(key);
+  if (!hit) return { state: "external", searched: map.size };
+  return { state: "ours", ...hit };
+}
+
+export function pathLabel(path) {
+  if (!Array.isArray(path)) return "";
+  return path.map((index) => (index & 0x80000000) ? `${index & 0x7fffffff}h` : String(index)).join("/");
+}
+
+export { SCRIPT_TYPES };

--- a/src/js/tx.js
+++ b/src/js/tx.js
@@ -1,0 +1,227 @@
+// Raw Bitcoin transaction parser for EntropyLab inspect.
+// Used when the paste is a signed (or unsigned) transaction, not a PSBT.
+const ORD_MAGIC = Uint8Array.of(0x00, 0x63, 0x03, 0x6f, 0x72, 0x64); // OP_FALSE OP_IF "ord"
+
+function need(bytes, offset, length, message) {
+  if (!Number.isSafeInteger(offset) || offset < 0 || offset + length > bytes.length) {
+    throw new Error(message || "Transaction ended early.");
+  }
+}
+
+function readU32(bytes, offset) {
+  need(bytes, offset, 4);
+  return new DataView(bytes.buffer, bytes.byteOffset + offset, 4).getUint32(0, true);
+}
+
+function readU64(bytes, offset) {
+  need(bytes, offset, 8, "Transaction ended inside an amount.");
+  let value = 0n;
+  for (let i = 0; i < 8; i++) value |= BigInt(bytes[offset + i]) << BigInt(8 * i);
+  return value;
+}
+
+function readVarInt(bytes, offset) {
+  need(bytes, offset, 1);
+  const first = bytes[offset];
+  if (first < 0xfd) return [first, offset + 1];
+  if (first === 0xfd) {
+    need(bytes, offset + 1, 2);
+    const value = bytes[offset + 1] | (bytes[offset + 2] << 8);
+    if (value < 0xfd) throw new Error("Non-minimal compact size.");
+    return [value, offset + 3];
+  }
+  if (first === 0xfe) {
+    need(bytes, offset + 1, 4);
+    const value = readU32(bytes, offset + 1);
+    if (value < 0x10000) throw new Error("Non-minimal compact size.");
+    return [value, offset + 5];
+  }
+  throw new Error("Compact size is too large.");
+}
+
+function readSlice(bytes, offset) {
+  const [length, start] = readVarInt(bytes, offset);
+  need(bytes, start, length, "Transaction ended inside a script.");
+  return [bytes.slice(start, start + length), start + length];
+}
+
+function containsOrdEnvelope(bytes) {
+  if (!(bytes instanceof Uint8Array) || bytes.length < ORD_MAGIC.length) return false;
+  outer: for (let i = 0; i <= bytes.length - ORD_MAGIC.length; i++) {
+    for (let j = 0; j < ORD_MAGIC.length; j++) {
+      if (bytes[i + j] !== ORD_MAGIC[j]) continue outer;
+    }
+    return true;
+  }
+  return false;
+}
+
+function looksLikeDerSig(bytes) {
+  if (!bytes || bytes.length < 9 || bytes[0] !== 0x30) return false;
+  const body = bytes[1];
+  if (body >= 0x80) return false;
+  return 2 + body + 1 === bytes.length || 2 + body === bytes.length;
+}
+
+function looksLikePubkey(bytes) {
+  if (!bytes) return false;
+  if (bytes.length === 33 && (bytes[0] === 2 || bytes[0] === 3)) return true;
+  if (bytes.length === 65 && bytes[0] === 4) return true;
+  return false;
+}
+
+export function scriptPushes(script) {
+  if (!(script instanceof Uint8Array)) return [];
+  const pushes = [];
+  let i = 0;
+  while (i < script.length) {
+    const op = script[i++];
+    if (op === 0x00) {
+      pushes.push(new Uint8Array());
+      continue;
+    }
+    if (op <= 0x4b) {
+      if (i + op > script.length) break;
+      pushes.push(script.slice(i, i + op));
+      i += op;
+      continue;
+    }
+    if (op === 0x4c) {
+      if (i >= script.length) break;
+      const length = script[i++];
+      if (i + length > script.length) break;
+      pushes.push(script.slice(i, i + length));
+      i += length;
+      continue;
+    }
+    if (op === 0x4d) {
+      if (i + 2 > script.length) break;
+      const length = script[i] | (script[i + 1] << 8);
+      i += 2;
+      if (i + length > script.length) break;
+      pushes.push(script.slice(i, i + length));
+      i += length;
+      continue;
+    }
+  }
+  return pushes;
+}
+
+function sigFromBytes(bytes, input) {
+  if (!looksLikeDerSig(bytes)) return null;
+  const hasSighash = bytes.length === 2 + bytes[1] + 1;
+  const der = hasSighash ? bytes.slice(0, -1) : bytes;
+  const sighash = hasSighash ? bytes[bytes.length - 1] : 1;
+  return { input, der, sighash, raw: bytes, pubkey: null };
+}
+
+function collectSigs(items, input, signatures) {
+  let pending = null;
+  for (const item of items) {
+    const sig = sigFromBytes(item, input);
+    if (sig) {
+      if (pending) signatures.push(pending);
+      pending = sig;
+      continue;
+    }
+    if (pending && looksLikePubkey(item)) {
+      pending.pubkey = item;
+      signatures.push(pending);
+      pending = null;
+      continue;
+    }
+  }
+  if (pending) signatures.push(pending);
+}
+
+export function parseRawTx(bytes) {
+  if (!(bytes instanceof Uint8Array)) throw new Error("Transaction must be bytes.");
+  if (bytes.length < 10) throw new Error("That is too short to be a Bitcoin transaction.");
+  if (bytes.length > 5e6) throw new Error("This transaction is too large to inspect safely.");
+  let offset = 0;
+  const version = readU32(bytes, offset);
+  offset += 4;
+  need(bytes, offset, 1, "Transaction ended before inputs.");
+  let segwit = false;
+  if (bytes[offset] === 0x00) {
+    need(bytes, offset, 2, "Transaction ended inside the witness marker.");
+    if (bytes[offset + 1] !== 0x01) throw new Error("Unknown witness flag.");
+    segwit = true;
+    offset += 2;
+  }
+  const [inputCount, inputStart] = readVarInt(bytes, offset);
+  if (inputCount > 1e5) throw new Error("Transaction has too many inputs.");
+  offset = inputStart;
+  const inputs = [];
+  for (let i = 0; i < inputCount; i++) {
+    need(bytes, offset, 36, "Transaction ended inside an input.");
+    const txid = bytes.slice(offset, offset + 32);
+    offset += 32;
+    const vout = readU32(bytes, offset);
+    offset += 4;
+    let scriptSig;
+    [scriptSig, offset] = readSlice(bytes, offset);
+    need(bytes, offset, 4, "Transaction ended inside an input sequence.");
+    const sequence = readU32(bytes, offset);
+    offset += 4;
+    inputs.push({ txid, vout, scriptSig, sequence, witness: [] });
+  }
+  const [outputCount, outputStart] = readVarInt(bytes, offset);
+  if (outputCount > 1e5) throw new Error("Transaction has too many outputs.");
+  offset = outputStart;
+  const outputs = [];
+  for (let i = 0; i < outputCount; i++) {
+    const amount = readU64(bytes, offset);
+    offset += 8;
+    let script;
+    [script, offset] = readSlice(bytes, offset);
+    outputs.push({ amount, script });
+  }
+  if (segwit) {
+    for (let i = 0; i < inputs.length; i++) {
+      const [stackCount, stackStart] = readVarInt(bytes, offset);
+      offset = stackStart;
+      const stack = [];
+      for (let j = 0; j < stackCount; j++) {
+        let item;
+        [item, offset] = readSlice(bytes, offset);
+        stack.push(item);
+      }
+      inputs[i].witness = stack;
+    }
+  }
+  need(bytes, offset, 4, "Transaction ended before locktime.");
+  const locktime = readU32(bytes, offset);
+  offset += 4;
+  if (offset !== bytes.length) throw new Error("Transaction contains trailing bytes.");
+  return { version, segwit, inputs, outputs, locktime, raw: bytes };
+}
+
+export function extractEcdsaSignatures(tx) {
+  const signatures = [];
+  (tx.inputs || []).forEach((input, index) => {
+    collectSigs(scriptPushes(input.scriptSig || new Uint8Array()), index, signatures);
+    collectSigs(input.witness || [], index, signatures);
+  });
+  return signatures;
+}
+
+export function inscriptionHints(tx) {
+  const hits = [];
+  (tx.inputs || []).forEach((input, index) => {
+    const scripts = [input.scriptSig, ...(input.witness || [])].filter(Boolean);
+    for (const script of scripts) {
+      if (containsOrdEnvelope(script)) {
+        hits.push({ input: index, bytes: script.length });
+        break;
+      }
+    }
+  });
+  return hits;
+}
+
+export function isPsbtMagic(bytes) {
+  return Boolean(bytes && bytes.length >= 5 && bytes[0] === 0x70 && bytes[1] === 0x73 && bytes[2] === 0x62 && bytes[3] === 0x74 && bytes[4] === 0xff);
+}
+
+export { containsOrdEnvelope };

--- a/test/tx-ownership.test.mjs
+++ b/test/tx-ownership.test.mjs
@@ -1,0 +1,190 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { p2wpkh, NETWORK, OutScript, Address } from "@scure/btc-signer";
+import { HDKey } from "@scure/bip32";
+import { mnemonicToSeedSync } from "@scure/bip39";
+import { parseRawTx, extractEcdsaSignatures, inscriptionHints, isPsbtMagic, scriptPushes } from "../src/js/tx.js";
+import { indexHdKey, matchOwnership, addressFromPubkey, OWNERSHIP_GAP } from "../src/js/ownership.js";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const app = readFileSync(join(root, "src/js/app.js"), "utf8");
+const template = readFileSync(join(root, "src/index.html"), "utf8");
+
+const concat = (...parts) => {
+  const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
+  let i = 0;
+  for (const p of parts) { out.set(p, i); i += p.length; }
+  return out;
+};
+const u32 = (n) => {
+  const b = new Uint8Array(4);
+  new DataView(b.buffer).setUint32(0, n >>> 0, true);
+  return b;
+};
+const u64 = (n) => {
+  const b = new Uint8Array(8);
+  let v = BigInt(n);
+  for (let i = 0; i < 8; i++) { b[i] = Number(v & 255n); v >>= 8n; }
+  return b;
+};
+const varint = (n) => n < 253 ? Uint8Array.of(n) : Uint8Array.of(253, n & 255, n >> 8);
+const slice = (bytes) => concat(varint(bytes.length), bytes);
+const push = (bytes) => bytes.length <= 75 ? concat(Uint8Array.of(bytes.length), bytes) : concat(Uint8Array.of(0x4c, bytes.length), bytes);
+
+const MNEMONIC = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+const seed = mnemonicToSeedSync(MNEMONIC, "");
+const hd = HDKey.fromMasterSeed(seed);
+
+test("BIP-84 test vector receive 0 is labeled receive", () => {
+  const map = indexHdKey(hd, "mainnet", { gap: 5, accounts: 1 });
+  const node = hd.derive("m/84'/0'/0'/0/0");
+  const address = addressFromPubkey("p2wpkh", node.publicKey, "mainnet");
+  assert.equal(address, "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu");
+  const hit = matchOwnership(map, address);
+  assert.equal(hit.state, "ours");
+  assert.equal(hit.role, "receive");
+  assert.equal(hit.path, "m/84h/0h/0h/0/0");
+});
+
+test("BIP-84 first change address is labeled change", () => {
+  const map = indexHdKey(hd, "mainnet", { gap: 5, accounts: 1 });
+  const node = hd.derive("m/84'/0'/0'/1/0");
+  const address = addressFromPubkey("p2wpkh", node.publicKey, "mainnet");
+  assert.equal(address, "bc1q8c6fshw2dlwun7ekn9qwf37cu2rn755upcp6el");
+  const hit = matchOwnership(map, address);
+  assert.equal(hit.state, "ours");
+  assert.equal(hit.role, "change");
+});
+
+test("an unrelated address is external when a session key is loaded", () => {
+  const map = indexHdKey(hd, "mainnet", { gap: 2, accounts: 1 });
+  const hit = matchOwnership(map, "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4");
+  assert.equal(hit.state, "external");
+});
+
+test("no session key does not claim an output is foreign", () => {
+  assert.equal(matchOwnership(new Map(), "bc1qcr8te4kr609gcawutmrqneffrxdt543n5s7zkt").state, "no-session");
+});
+
+test("parseRawTx reads a segwit one-in one-out transaction", () => {
+  const der = Uint8Array.of(
+    0x30, 0x44,
+    0x02, 0x20, ...new Uint8Array(31).fill(0), 1,
+    0x02, 0x20, ...new Uint8Array(31).fill(0), 1,
+    0x01,
+  );
+  const pubkey = Uint8Array.of(2, ...new Uint8Array(32).fill(3));
+  const spk = concat(Uint8Array.of(0, 20), new Uint8Array(20).fill(9));
+  const tx = concat(
+    u32(2),
+    Uint8Array.of(0x00, 0x01),
+    Uint8Array.of(1),
+    new Uint8Array(32), u32(0), slice(new Uint8Array()), u32(0xfffffffd),
+    Uint8Array.of(1),
+    u64(1000), slice(spk),
+    varint(2), slice(der), slice(pubkey),
+    u32(0),
+  );
+  const parsed = parseRawTx(tx);
+  assert.equal(parsed.segwit, true);
+  assert.equal(parsed.inputs.length, 1);
+  assert.equal(parsed.outputs.length, 1);
+  assert.equal(parsed.outputs[0].amount, 1000n);
+  assert.equal(parsed.inputs[0].sequence, 0xfffffffd);
+  const sigs = extractEcdsaSignatures(parsed);
+  assert.equal(sigs.length, 1);
+  assert.equal(sigs[0].sighash, 1);
+  assert.equal(sigs[0].pubkey.length, 33);
+});
+
+test("trailing bytes are rejected", () => {
+  const spk = concat(Uint8Array.of(0x51));
+  const tx = concat(
+    u32(1),
+    Uint8Array.of(1),
+    new Uint8Array(32), u32(0), slice(new Uint8Array()), u32(0xffffffff),
+    Uint8Array.of(1),
+    u64(1), slice(spk),
+    u32(0),
+    Uint8Array.of(0xff),
+  );
+  assert.throws(() => parseRawTx(tx), /trailing/);
+});
+
+test("PSBT magic is detected", () => {
+  assert.equal(isPsbtMagic(Uint8Array.of(0x70, 0x73, 0x62, 0x74, 0xff, 1)), true);
+  assert.equal(isPsbtMagic(Uint8Array.of(2, 0, 0, 0, 0)), false);
+});
+
+test("inscription envelope in witness is flagged", () => {
+  const envelope = concat(
+    Uint8Array.of(0x00, 0x63),
+    push(new TextEncoder().encode("ord")),
+    push(Uint8Array.of(1)),
+    push(new TextEncoder().encode("text/plain")),
+    Uint8Array.of(0x00),
+    push(new TextEncoder().encode("hi")),
+    Uint8Array.of(0x68),
+  );
+  const spk = concat(Uint8Array.of(0x51));
+  const tx = concat(
+    u32(2),
+    Uint8Array.of(0x00, 0x01),
+    Uint8Array.of(1),
+    new Uint8Array(32), u32(0), slice(new Uint8Array()), u32(0xffffffff),
+    Uint8Array.of(1),
+    u64(1), slice(spk),
+    varint(3), slice(new Uint8Array(64)), slice(envelope), slice(new Uint8Array(33).fill(0xc0)),
+    u32(0),
+  );
+  const parsed = parseRawTx(tx);
+  const hints = inscriptionHints(parsed);
+  assert.equal(hints.length, 1);
+  assert.equal(hints[0].input, 0);
+});
+
+test("scriptPushes reads a P2PKH scriptSig", () => {
+  const der = Uint8Array.of(0x30, 0x03, 0x02, 0x01, 0x01, 0x01);
+  const pk = Uint8Array.of(2, ...new Uint8Array(32).fill(1));
+  const script = concat(push(der), push(pk));
+  const pushes = scriptPushes(script);
+  assert.equal(pushes.length, 2);
+  assert.equal(pushes[1].length, 33);
+});
+
+test("app inspects raw transactions and labels outputs", () => {
+  assert.match(app, /hodlRenderRawTx/);
+  assert.match(app, /hodlSessionOwnership/);
+  assert.match(app, /Address as or/);
+  assert.match(app, /not in this wallet/);
+  assert.match(app, /No output belongs to this session wallet/);
+  assert.match(app, /Uint8Array\.from\(script\.subarray/);
+  assert.doesNotMatch(app, /debug fp=/);
+  for (const markup of [app, template]) {
+    assert.match(markup, /Read a PSBT or a signed transaction/);
+    assert.match(markup, /raw transaction/);
+  }
+});
+
+test("P2WPKH output scripts encode to the BIP-84 address", () => {
+  const node = hd.derive("m/84'/0'/0'/0/0");
+  const script = p2wpkh(node.publicKey, NETWORK).script;
+  const decoded = OutScript.decode(script);
+  const address = Address(NETWORK).encode(decoded);
+  assert.equal(address, "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu");
+});
+
+test("ownership matches a raw p2wpkh output script, not just the address string", () => {
+  const map = indexHdKey(hd, "mainnet", { gap: 2, accounts: 1 });
+  const script = p2wpkh(hd.derive("m/84'/0'/0'/1/0").publicKey, NETWORK).script;
+  const hit = matchOwnership(map, Uint8Array.from(script));
+  assert.equal(hit.state, "ours");
+  assert.equal(hit.role, "change");
+});
+
+test("ownership gap is the documented window", () => {
+  assert.equal(OWNERSHIP_GAP, 50);
+});


### PR DESCRIPTION
PSBT / Nonce now accepts a fully signed raw Bitcoin transaction (hex or base64) as well as PSBT v0. With a session seed, root xprv, WIF, or hex key it labels each output as receive, change, or not in this wallet (accounts 0-2, 50 receive + 50 change, four script types). Two or more outputs with none ours is a destination-swap warning. Detector only: no chain, no node, no minting.