### PR TITLE
FIX: Keep custom selects out of their labels so iOS never native dropdown

### DIFF
--- a/src/js/enhanced-inputs.js
+++ b/src/js/enhanced-inputs.js
@@ -40,6 +40,8 @@
     root.append(button, list);
     select.after(root);
     roots.add(root);
+    select.closest("label")?.after(select);
+    select.tabIndex = -1;
 
     const sync = () => {
       const selected = select.options[select.selectedIndex] || select.options[0];
@@ -53,7 +55,8 @@
         item.setAttribute("aria-selected", String(option.value === select.value));
         item.disabled = option.disabled;
         item.textContent = option.textContent;
-        item.onclick = () => {
+        item.onclick = (event) => {
+          event.preventDefault();
           select.value = option.value;
           select.dispatchEvent(new Event("change", { bubbles: true }));
           sync();
@@ -113,7 +116,7 @@
 
   document.addEventListener("click", (event) => {
     roots.forEach((root) => {
-      if (!root.contains(event.target)) close(root);
+      if (!root.contains(event.target) && !root.closest("label")?.contains(event.target)) close(root);
     });
   });
 })();

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -905,3 +905,13 @@ test("card suit glyphs have explicit local symbol-font fallbacks (issue #104)", 
   assert.doesNotMatch(css, /@font-face|\.woff2?|fonts\.googleapis|fonts\.gstatic/);
   assert.doesNotMatch(template, /@font-face|\.woff2?|fonts\.googleapis|fonts\.gstatic/);
 });
+
+test("custom selects move the native select out of its label so iOS never opens the native picker (#121)", () => {
+  const enhanced = read("src/js/enhanced-inputs.js");
+  assert.match(enhanced, /select\.closest\("label"\)\?\.after\(select\)/);
+  assert.match(enhanced, /select\.tabIndex = -1/);
+  // WebKit forwards an option click to the label's control after the option is removed; cancel it.
+  assert.match(enhanced, /item\.onclick = \(event\) => \{\s*event\.preventDefault\(\);/);
+  // The label now controls the trigger, so a label click must not be treated as an outside click.
+  assert.match(enhanced, /!root\.contains\(event\.target\) && !root\.closest\("label"\)\?\.contains\(event\.target\)/);
+});


### PR DESCRIPTION
Fixes #121

**Problem**
On iOS Safari, picking an option from a dropdown closed it and then would open the native menu on top.

**Cause**
The custom dropdown keeps the original `<select>` hidden in the DOM as its data source, inside the field's `<label>`. When an option is tapped, that option button is removed while its click is still being handled. WebKit then treats the click as a click on the `<label>` and forwards it to the label's hidden `<select>`. iOS opens the native menu whenever a `<select>` gets focus from a tap. Chrome and Firefox don't forward the click, so only Safari showed it.

**Fix (src/js/enhanced-inputs.js)**

- Move the native `<select>` out of its `<label>` so the label controls the visible button instead.
- Cancel the option click's default action so WebKit can't forward it to the button and re-open the dropdown.
- Treat a tap on the label text as part of the dropdown so it opens/closes instead of flickering.

Verified on iOS and npm run test:ci passes.