### PR TITLE
FIX: Keep native keyboard closed when using virtual keypads

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -668,7 +668,7 @@ function lr() {
     `;
     let e = document.getElementById("dice");
     e.dataset.previousValue = e.value;
-    at.querySelectorAll("[data-d]").forEach((t) => {
+    hodlBindKeypadPointer(at.querySelectorAll("[data-d]"), () => e), at.querySelectorAll("[data-d]").forEach((t) => {
       t.onclick = () => hodlInsertDiceControl(e, t, At);
     }), e.oninput = () => {
       hodlTrackDiceInputEdit(e);
@@ -2725,6 +2725,15 @@ function hodlSanitizeDPlusInput(input, targetWords = Pt) {
   input.setSelectionRange(cleanSelectionStart, cleanSelectionEnd, selectionDirection);
   return true;
 }
+function hodlBindKeypadPointer(buttons, getInput) {
+  buttons.forEach((button) => button.addEventListener("pointerdown", (event) => {
+    event.preventDefault();
+    if (event.pointerType === "mouse") getInput()?.focus({ preventScroll: true });
+  }));
+}
+function hodlPlaceCaret(input, start, end = start) {
+  if (document.activeElement === input) input.setSelectionRange(start, end);
+}
 function hodlInsertDiceControl(input, button, update = hodlUpdateDice) {
   let inserted;
   try {
@@ -2739,9 +2748,7 @@ function hodlInsertDiceControl(input, button, update = hodlUpdateDice) {
   if (ge !== "dplus") hodlRebaseDiceCoinPositions(start, end, inserted.length, Boolean(button.dataset.coin));
   input.value = input.value.slice(0, start) + inserted + input.value.slice(end);
   input.dataset.previousValue = input.value;
-  let caret = start + inserted.length;
-  input.focus({ preventScroll: true });
-  input.setSelectionRange(caret, caret);
+  hodlPlaceCaret(input, start + inserted.length);
   hodlSanitizeDiceInput(input);
   update();
 }
@@ -2749,7 +2756,6 @@ function hodlInsertEntropyControl(input, button) {
   let inserted = button.dataset.entropyDigit || "";
   if (!input || !inserted) return;
   let start = Number.isInteger(input.selectionStart) ? input.selectionStart : input.value.length, end = Number.isInteger(input.selectionEnd) ? input.selectionEnd : start;
-  input.focus({ preventScroll: true });
   input.setRangeText(inserted, start, end, "end");
   input.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText", data: inserted }));
 }
@@ -3335,8 +3341,7 @@ function hodlUpdateCards() {
 }
 function hodlSetInputValueAtEnd(input, value) {
   input.value = value;
-  input.focus({ preventScroll: true });
-  input.setSelectionRange(input.value.length, input.value.length);
+  hodlPlaceCaret(input, input.value.length);
 }
 function hodlUndoCard() {
   let input = document.getElementById(hodlCardMethod === "direct" ? "direct-cards" : "cards");
@@ -3853,7 +3858,6 @@ function hodlApplySeedKeyboardKey(input, key, deleteBackward = false) {
   } else input.setRangeText(String(key ?? ""), start, end, "end");
   let event = typeof InputEvent === "function" ? new InputEvent("input", { bubbles: true, inputType, data }) : new Event("input", { bubbles: true });
   input.dispatchEvent(event);
-  input.focus({ preventScroll: true });
 }
 function hodlApplySeedNumberPadKey(input, key, deleteBackward = false) {
   if (!input) return;
@@ -3909,10 +3913,7 @@ function hodlUpdateSeedNumberPad(input, parsed = hodlParseSeedNumbers(input?.val
 function hodlBindSeedNumberPad(input, update) {
   let pad = document.querySelector(".seed-number-pad");
   if (!pad || !input) return;
-  pad.querySelectorAll("button").forEach((button) => button.addEventListener("pointerdown", (event) => {
-    event.preventDefault();
-    input.focus({ preventScroll: true });
-  }));
+  hodlBindKeypadPointer(pad.querySelectorAll("button"), () => input);
   pad.querySelectorAll("[data-seed-number-digit]").forEach((button) => {
     button.onclick = () => {
       let digit = button.dataset.seedNumberDigit || "";
@@ -4003,12 +4004,7 @@ function hodlBindSeedKeyboard(input, targetWords = Pt) {
     hodlSetOnScreenKeyboardOpen(!hodlOnScreenKeyboardOpen);
     refresh();
   };
-  keyboard.querySelectorAll("button").forEach((button) => {
-    button.addEventListener("pointerdown", (event) => {
-      event.preventDefault();
-      activeInput.focus({ preventScroll: true });
-    });
-  });
+  hodlBindKeypadPointer(keyboard.querySelectorAll("button"), () => activeInput);
   keyboard.querySelectorAll("[data-seed-character-key],.seed-keyboard-space").forEach((button) => {
     button.onclick = () => hodlApplySeedKeyboardKey(activeInput, button.dataset.seedKey || "");
   });
@@ -4033,12 +4029,7 @@ function hodlBindPassphraseKeyboard(inputId = "pass", toggleId = "passphrase-key
     hodlSetOnScreenKeyboardOpen(!hodlOnScreenKeyboardOpen);
     refresh();
   };
-  keyboard.querySelectorAll("button").forEach((button) => {
-    button.addEventListener("pointerdown", (event) => {
-      event.preventDefault();
-      input.focus({ preventScroll: true });
-    });
-  });
+  hodlBindKeypadPointer(keyboard.querySelectorAll("button"), () => input);
   keyboard.querySelectorAll("[data-seed-character-key],.seed-keyboard-space").forEach((button) => {
     button.onclick = () => hodlApplySeedKeyboardKey(input, button.dataset.seedKey || "");
   });
@@ -4073,12 +4064,7 @@ function hodlBindBase64Keyboard(input) {
     hodlSetOnScreenKeyboardOpen(!hodlOnScreenKeyboardOpen);
     refresh();
   };
-  keyboard.querySelectorAll("button").forEach((button) => {
-    button.addEventListener("pointerdown", (event) => {
-      event.preventDefault();
-      input.focus({ preventScroll: true });
-    });
-  });
+  hodlBindKeypadPointer(keyboard.querySelectorAll("button"), () => input);
   keyboard.querySelectorAll("[data-seed-character-key],.seed-keyboard-space").forEach((button) => {
     button.onclick = () => hodlApplySeedKeyboardKey(input, button.dataset.seedKey || "");
   });
@@ -4503,6 +4489,7 @@ function hodlRenderKeyForm() {
     input.dataset.previousValue = input.value;
     let fairnessToggle = document.getElementById("dice-fairness-toggle");
     if (fairnessToggle) fairnessToggle.onclick = () => hodlSetDiceFairnessOpen(!hodlDiceFairnessIsOpen());
+    hodlBindKeypadPointer(at.querySelectorAll("[data-d]"), () => input);
     at.querySelectorAll("[data-d]").forEach((button) => {
       button.onclick = () => hodlInsertDiceControl(input, button);
     });
@@ -4607,11 +4594,11 @@ function hodlRenderKeyForm() {
         hodlUpdateCards();
       };
     });
+    hodlBindKeypadPointer(at.querySelectorAll("[data-direct-card-rank], #card-undo"), () => input);
     at.querySelectorAll("[data-direct-card-rank]").forEach((button) => {
       button.onclick = () => {
         let rank = button.getAttribute("data-direct-card-rank");
         let start = Number.isInteger(input.selectionStart) ? input.selectionStart : input.value.length, end = Number.isInteger(input.selectionEnd) ? input.selectionEnd : start;
-        input.focus({ preventScroll: true });
         input.setRangeText(rank, start, end, "end");
         input.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText", data: rank }));
       };
@@ -4686,6 +4673,7 @@ function hodlRenderKeyForm() {
     hodlBindKeyFields();
     let entropyInput = document.getElementById(inputId);
     if (entropyInput) {
+      hodlBindKeypadPointer(at.querySelectorAll("[data-entropy-digit]"), () => entropyInput);
       at.querySelectorAll("[data-entropy-digit]").forEach((button) => {
         button.onclick = () => hodlInsertEntropyControl(entropyInput, button);
       });

--- a/test/cards.test.mjs
+++ b/test/cards.test.mjs
@@ -71,7 +71,7 @@ const hodlCardSelectionState = new Function(
   `${loadSlice("hodlCardSelectionState")}; return hodlCardSelectionState;`,
 )(hodlCardRanks, hodlCardSuits);
 const hodlToggleCardChoice = new Function(`${loadSlice("hodlToggleCardChoice")}; return hodlToggleCardChoice;`)();
-const hodlSetInputValueAtEnd = new Function(`${loadSlice("hodlSetInputValueAtEnd")}; return hodlSetInputValueAtEnd;`)();
+const hodlSetInputValueAtEnd = (input, value, focused) => new Function("document", `${loadSlice("hodlPlaceCaret")}; ${loadSlice("hodlSetInputValueAtEnd")}; return hodlSetInputValueAtEnd;`)({ activeElement: focused ? input : null })(input, value);
 const Ae = Object.freeze(bip39English);
 const hodlBip39WordIndex = new Map(Ae.map((word, index) => [word, index]));
 function hodlTargetLastWords(value, targetWords) {
@@ -223,22 +223,27 @@ test("hashed-card suit and rank selections toggle off when clicked again", () =>
   assert.equal(hodlToggleCardChoice("S", "H"), "H");
 });
 
-test("card undo restores focus and places the caret after the rewritten transcript", () => {
-  const input = {
+test("card undo never focuses the field and only moves the caret when the field already has focus (#123)", () => {
+  const makeInput = () => ({
     value: "A284 37A2",
     focused: false,
     selection: null,
-    focus(options) {
-      this.focused = options?.preventScroll === true;
+    focus() {
+      this.focused = true;
     },
     setSelectionRange(start, end) {
       this.selection = [start, end];
     },
-  };
-  hodlSetInputValueAtEnd(input, "A284 37A");
-  assert.equal(input.value, "A284 37A");
-  assert.equal(input.focused, true);
-  assert.deepEqual(input.selection, [8, 8]);
+  });
+  const blurred = makeInput();
+  hodlSetInputValueAtEnd(blurred, "A284 37A", false);
+  assert.equal(blurred.value, "A284 37A");
+  assert.equal(blurred.focused, false);
+  assert.equal(blurred.selection, null);
+  const focused = makeInput();
+  hodlSetInputValueAtEnd(focused, "A284 37A", true);
+  assert.equal(focused.focused, false);
+  assert.deepEqual(focused.selection, [8, 8]);
 });
 
 test("hashed-card controls disable exhausted suits and ranks", () => {

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -352,7 +352,7 @@ test("seed phrase mode has a lowercase Jade-style on-screen keyboard", () => {
   assert.match(app, /modeButton\.disabled=!pass/);
   assert.match(app, /hodlSetSeedKeyboardLayout\(keyboard,modeButton,"lower"\)/);
   assert.match(app, /hodlApplySeedKeyboardKey\(activeInput,button\.dataset\.seedKey\|\|""\)/);
-  assert.match(appWhitespace, /addEventListener\("pointerdown",event=>\{event\.preventDefault\(\);activeInput\.focus/);
+  assert.match(appWhitespace, /hodlBindKeypadPointer\(keyboard\.querySelectorAll\("button"\),\(\)=>activeInput\)/);
   assert.match(app, /function hodlFilterSeed\(e\)\{[^}]*hodlLooksExtendedKey\(value\)\?value:value\.toLowerCase\(\)/);
   assert.match(css, /\.seed-entry-tools\s*\{[^}]*align-items: stretch[^}]*margin-top: var\(--space-component\)/s);
   assert.match(css, /\.passphrase-keyboard-tools \{[^}]*display: flex[^}]*margin-top: var\(--space-control\)/s);
@@ -904,4 +904,18 @@ test("card suit glyphs have explicit local symbol-font fallbacks (issue #104)", 
   // Fonts are local system fonts only: no webfont may ever be downloaded.
   assert.doesNotMatch(css, /@font-face|\.woff2?|fonts\.googleapis|fonts\.gstatic/);
   assert.doesNotMatch(template, /@font-face|\.woff2?|fonts\.googleapis|fonts\.gstatic/);
+});
+
+test("virtual keypads never focus the field on touch so the mobile keyboard stays closed (#123)", () => {
+  const body = (name) => appSource.slice(appSource.indexOf(`function ${name}(`), appSource.indexOf("\nfunction ", appSource.indexOf(`function ${name}(`) + 1));
+  for (const name of ["hodlInsertDiceControl", "hodlInsertEntropyControl", "hodlApplySeedKeyboardKey", "hodlSetInputValueAtEnd", "hodlBindSeedNumberPad"]) {
+    assert.doesNotMatch(body(name), /\.focus\(/, `${name} must not focus the input`);
+  }
+  assert.match(body("hodlBindKeypadPointer"), /event\.preventDefault\(\);\s*if \(event\.pointerType === "mouse"\) getInput\(\)\?\.focus\(/);
+  assert.match(body("hodlPlaceCaret"), /document\.activeElement === input/);
+  // Every keypad routes pointerdown through the shared binder; no pad focuses the input directly.
+  assert.doesNotMatch(appSource, /pointerdown", \(event\) => \{\s*event\.preventDefault\(\);\s*\w+\.focus\(/);
+  for (const call of ['at.querySelectorAll("[data-d]")', 'at.querySelectorAll("[data-entropy-digit]")', 'at.querySelectorAll("[data-direct-card-rank], #card-undo")', 'pad.querySelectorAll("button")', 'keyboard.querySelectorAll("button")']) {
+    assert.ok(appSource.includes(`hodlBindKeypadPointer(${call}`), `${call} keypad is bound`);
+  }
 });


### PR DESCRIPTION
Fixes #123

Tapping the on-page keypad buttons opened the native keyboard on mobile. 

**Cause**
Mobile browsers open the native keyboard whenever a text field is focused by a user gesture.

**Fix**
All keypads now share one `pointerdown` handler that only focuses the field when the press comes from a mouse (`event.pointerType === "mouse"`). This way, desktop keeps the cursor in the field, touch never opens the native keyboard when tapping virtual keypads, and tapping the field directly still does.

Tested on iOS and Android. `npm run test:ci` passes.