### PR TITLE
Derive recommended card counts from the entropy target

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -3026,12 +3026,14 @@ function hodlBinaryEntropy(value, targetWords = Pt) {
   return hodlNumberBaseEntropy(value, "bin", targetWords);
 }
 function hodlCardNeeded(targetWords = Pt) {
+  // Derived from the selected BIP39 entropy target, not policy constants:
+  // the smallest without-replacement deal whose entropy reaches the target.
+  // One deck tops out at ~225.6 bits, so a 256-bit seed finishes with extra
+  // cards from a second shuffled deck.
   let bits = hodlSeedConfig(targetWords).bits;
-  if (bits <= 128) return { first: 25, extra: 0 };
-  if (bits <= 160) return { first: 31, extra: 0 };
-  if (bits <= 192) return { first: 39, extra: 0 };
-  if (bits <= 224) return { first: 50, extra: 0 };
-  return { first: 52, extra: 6 };
+  for (let first = 1; first <= 52; first++) if (hodlCardWithoutReplacementBits(first) >= bits) return { first, extra: 0 };
+  for (let extra = 1; extra <= 52; extra++) if (hodlCardWithoutReplacementBits(52) + hodlCardWithoutReplacementBits(extra) >= bits) return { first: 52, extra };
+  return { first: 52, extra: 52 };
 }
 function hodlCardWithoutReplacementBits(count) {
   let bits = 0, n = Math.min(Math.max(0, Number(count) || 0), 52);

--- a/test/cards.test.mjs
+++ b/test/cards.test.mjs
@@ -6,7 +6,7 @@ import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { mnemonicToEntropy, validateMnemonic } from "@scure/bip39";
+import { entropyToMnemonic, mnemonicToEntropy, validateMnemonic } from "@scure/bip39";
 import { wordlist as bip39English } from "@scure/bip39/wordlists/english.js";
 
 const root = dirname(fileURLToPath(import.meta.url));
@@ -45,7 +45,11 @@ const hodlSeedLengths = {
 function hodlSeedConfig(words = 12) {
   return hodlSeedLengths[words];
 }
-const hodlCardNeeded = new Function("hodlSeedConfig", `${loadSlice("hodlCardNeeded")}; return hodlCardNeeded;`)(hodlSeedConfig);
+const hodlCardNeeded = new Function(
+  "hodlSeedConfig",
+  "hodlCardWithoutReplacementBits",
+  `${loadSlice("hodlCardNeeded")}; return hodlCardNeeded;`,
+)(hodlSeedConfig, hodlCardWithoutReplacementBits);
 const hodlParseCards = new Function(
   "hodlCardNeeded",
   "hodlNormalizeCardToken",
@@ -199,6 +203,35 @@ test("one valid card produces a deterministic testing seed", () => {
   assert.match(entropy.warnings.join(" "), /Use only for testing/);
   assert.equal(hodlCardsEntropy("AS AS", 24).ok, false);
   assert.equal(hodlCardsEntropy("ZZ", 24).ok, false);
+});
+
+test("recommended card counts are the smallest deals reaching the entropy target", () => {
+  for (const [words, first, extra] of [[12, 25, 0], [15, 31, 0], [18, 39, 0], [21, 50, 0], [24, 52, 6]]) {
+    const needed = hodlCardNeeded(words);
+    assert.equal(needed.first, first, `${words}-word first count`);
+    assert.equal(needed.extra, extra, `${words}-word extra count`);
+    const bits = hodlSeedConfig(words).bits;
+    const supplied = hodlCardWithoutReplacementBits(needed.first) + hodlCardWithoutReplacementBits(needed.extra);
+    assert.ok(supplied >= bits, `${words} words: ${supplied.toFixed(1)} bits reaches the ${bits}-bit target`);
+    const oneFewer = needed.extra
+      ? hodlCardWithoutReplacementBits(needed.first) + hodlCardWithoutReplacementBits(needed.extra - 1)
+      : hodlCardWithoutReplacementBits(needed.first - 1);
+    assert.ok(oneFewer < bits, `${words} words: one fewer card falls below the ${bits}-bit target`);
+  }
+});
+
+test("a complete card transcript keeps deriving the expected deterministic seed", () => {
+  // 24 words: full deck plus six cards from a second shuffle.
+  const transcript = `${DECK.join(" ")} ${DECK.slice(0, 6).join(" ")}`;
+  const entropy = hodlCardsEntropy(transcript, 24);
+  assert.equal(entropy.ok, true);
+  assert.equal(entropy.warnings.length, 0);
+  assert.equal(entropy.bytes.length, 32);
+  const expected = createHash("sha256").update(transcript, "utf8").digest();
+  assert.deepEqual([...entropy.bytes], [...expected.subarray(0, 32)]);
+  const mnemonic = entropyToMnemonic(entropy.bytes, bip39English);
+  assert.equal(mnemonic.split(" ").length, 24);
+  assert.ok(validateMnemonic(mnemonic, bip39English));
 });
 
 test("hashed-card controls accept either suit or rank first and filter the other row", () => {


### PR DESCRIPTION
## Summary

Follows up on the maintainer's suggestion in #132: this extracts only the non-blocking parts of that PR — the derived recommendation counts and the complete-transcript vector test. **No behavior change**: below-recommendation transcripts still derive a testing seed with a warning, per the project's documented policy.

## Changes

- **`hodlCardNeeded` derives its counts from the entropy target** instead of duplicating them as independent constants: the smallest without-replacement deal whose entropy (via `hodlCardWithoutReplacementBits`) reaches the selected BIP39 target. Values are unchanged — 25/31/39/50 cards, or 52+6 across two shuffles for 24 words — so nothing shifts in the UI or in existing vectors; the recommendation just can no longer drift from the target if either side changes.
- **New test: counts are minimal and sufficient.** For every phrase length (12/15/18/21/24 words), the recommended deal reaches the target bits and one fewer card falls below it, checked against the entropy math itself rather than repeated constants.
- **New test: complete-transcript determinism.** A full 58-card transcript (52 + 6 from a second shuffle) derives exactly the SHA-256 of the ASCII transcript, carries no warnings, and produces a checksum-valid 24-word mnemonic.

Credit to @russeree — both pieces are adapted from the #109 branch.

## Verification

`npm run build && npm test` passes (325/325, up from 323 on `rock`); `npm run ci` also passes.

References #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
