### PR TITLE
Give the beta disclaimer's warning more force

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -677,6 +677,10 @@ td { border-top: 1px solid var(--border); padding: 8px; vertical-align: top; fon
 .disclaimer-overlay {
   position: fixed; inset: 0; z-index: 200; display: grid; place-items: center;
   padding: 24px; box-sizing: border-box; background: rgb(0 0 0 / 55%);
+  /* The blur puts the page out of focus behind the card, so the warning is
+     the only thing that reads. The prefix is for WebKit, which shipped the
+     property unprefixed only recently. */
+  -webkit-backdrop-filter: blur(6px); backdrop-filter: blur(6px);
   opacity: 0; transition: opacity .24s ease;
 }
 .disclaimer-overlay[hidden] { display: none; }
@@ -688,9 +692,20 @@ td { border-top: 1px solid var(--border); padding: 8px; vertical-align: top; fon
   background: color-mix(in oklab, var(--danger) 10%, var(--surface));
   box-shadow: 0 16px 36px rgb(0 0 0 / 55%);
 }
-.disclaimer-icon { width: 48px; height: 48px; color: var(--danger); }
-.disclaimer-title { margin: 12px 0 6px; font-size: 22px; color: var(--fg); }
-.disclaimer-text { margin: 0 0 18px; color: var(--fg); line-height: 1.5; }
+/* The icon and the title take the brighter alert red, the same pairing the
+   beta banner uses at the top of the page. A step above the body size, well
+   short of the heading it used to be. */
+.disclaimer-icon { width: 48px; height: 48px; color: var(--danger-bright); }
+.disclaimer-title { margin: 12px 0 12px; font-size: 18px; font-weight: 700; text-transform: uppercase; color: var(--danger-bright); }
+/* The gap below carries the weight of the decision: the button wants clear
+   air between it and the warning it is answering. The side inset matches the
+   card's own padding, so the sentence sits a clear step inside the frame and
+   breaks into shorter lines. */
+.disclaimer-text { margin: 0 24px 28px; color: var(--fg); line-height: 1.5; }
+/* Scoped to the card: the shared .btn base is every button in the app. The
+   answer to a blocking warning should carry more weight than a toolbar
+   control, so it takes a wider block and the title's size and casing. */
+.disclaimer-card .btn { padding: 0 32px; font-size: 18px; text-transform: uppercase; }
 @media (prefers-reduced-motion: reduce) { .disclaimer-overlay { transition: none; } }
 .sanity-failure {
   min-height: 100dvh; display: grid; place-items: center; padding: 24px; box-sizing: border-box;

--- a/src/index.html
+++ b/src/index.html
@@ -16,7 +16,7 @@
   </div>
   <div class="wrap">
     <aside class="beta-warning no-print" id="beta-warning" role="alert">
-      <div class="beta-warning-text"><strong>Beta software</strong> EntropyLab is experimental and currently should only be used for testing.</div>
+      <div class="beta-warning-text"><strong>Beta software</strong> EntropyLab is experimental and should only be used for testing and educational purposes.</div>
       <button type="button" class="beta-warning-dismiss" id="beta-warning-dismiss" aria-label="Dismiss the beta software warning"><svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M18 6 6 18M6 6l12 12"/></svg></button>
     </aside>
     <noscript>
@@ -289,7 +289,7 @@ words, pick one of the checksum words.</span></span>
   <div class="disclaimer-card">
     <svg class="disclaimer-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3 2.5 20h19L12 3z"/><path d="M12 10v4M12 17.5h.01"/></svg>
     <p class="disclaimer-title" id="beta-disclaimer-title">Beta software</p>
-    <p class="disclaimer-text" id="beta-disclaimer-text">EntropyLab is experimental and can be dangerous: a bug could produce wrong keys or addresses, and funds sent to them could be lost. Do not use it in production, and never with funds you cannot afford to lose.</p>
+    <p class="disclaimer-text" id="beta-disclaimer-text">EntropyLab is experimental and should only be used for testing and educational purposes. This tool is intended for offline use by advanced users only. Any use online or with real funds can be dangerous.</p>
     <button class="btn primary" id="beta-disclaimer-accept" type="button">I understand</button>
   </div>
 </div>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -391,7 +391,7 @@ ec.innerHTML = `
   </div>
   <div class="wrap">
     <aside class="beta-warning no-print" id="beta-warning" role="alert">
-      <div class="beta-warning-text"><strong>Beta software</strong> EntropyLab is experimental and currently should only be used for testing.</div>
+      <div class="beta-warning-text"><strong>Beta software</strong> EntropyLab is experimental and should only be used for testing and educational purposes.</div>
       <button type="button" class="beta-warning-dismiss" id="beta-warning-dismiss" aria-label="Dismiss the beta software warning"><svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M18 6 6 18M6 6l12 12"/></svg></button>
     </aside>
     <aside class="online-warning no-print" id="online-warning" role="alert" hidden>

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -575,6 +575,68 @@
     }
   });
 
+  await test("the beta disclaimer titles its warning the way the banner does", () => {
+    const overlay = document.getElementById("beta-disclaimer");
+    const icon = overlay && overlay.querySelector(".disclaimer-icon");
+    const title = document.getElementById("beta-disclaimer-title");
+    const text = document.getElementById("beta-disclaimer-text");
+    const accept = document.getElementById("beta-disclaimer-accept");
+    assert(overlay && icon && title && text && accept, "Beta disclaimer parts are missing");
+    // The scrim darkens and defocuses the page behind the card.
+    const overlayStyle = getComputedStyle(overlay);
+    assert(/blur\(6px\)/.test(overlayStyle.backdropFilter || overlayStyle.webkitBackdropFilter || ""), "The overlay does not blur the page behind it");
+    const titleStyle = getComputedStyle(title);
+    const textStyle = getComputedStyle(text);
+    // Rendered uppercase, and a step above the sentence it labels.
+    assert(titleStyle.textTransform === "uppercase", "Disclaimer title is not uppercase");
+    // A paragraph, so the weight has to be asked for: it renders at 400 otherwise.
+    assert(Number(titleStyle.fontWeight) >= 700, `Disclaimer title renders at weight ${titleStyle.fontWeight}`);
+    assert(
+      parseFloat(titleStyle.fontSize) > parseFloat(textStyle.fontSize),
+      `Disclaimer title is ${titleStyle.fontSize} against the text's ${textStyle.fontSize}`,
+    );
+    // Title and icon share one red, and it is not the body foreground.
+    assert(
+      titleStyle.color === getComputedStyle(icon).color,
+      "Disclaimer title and icon are not the same colour",
+    );
+    assert(titleStyle.color !== textStyle.color, "Disclaimer title did not take the alert red");
+    // The title has air under it before the sentence starts.
+    assert(
+      text.getBoundingClientRect().top - title.getBoundingClientRect().bottom >= 8,
+      "The warning text crowds the title",
+    );
+    // The sentence is inset from the card, so it wraps shorter than the frame.
+    const card = overlay.querySelector(".disclaimer-card");
+    assert(
+      text.getBoundingClientRect().width < card.getBoundingClientRect().width - 80,
+      "The warning text runs the full width of the card",
+    );
+    // The button answers a blocking warning, so it is not a toolbar control:
+    // wider, uppercase, and set at the title's size.
+    const acceptStyle = getComputedStyle(accept);
+    assert(acceptStyle.textTransform === "uppercase", "Accept button label is not uppercase");
+    assert(
+      parseFloat(acceptStyle.fontSize) > parseFloat(textStyle.fontSize),
+      `Accept label is ${acceptStyle.fontSize} against the text's ${textStyle.fontSize}`,
+    );
+    assert(parseFloat(acceptStyle.paddingLeft) >= 32, `Accept button padding is only ${acceptStyle.paddingLeft}`);
+    // Other buttons keep the shared base.
+    const plain = document.querySelector(".wrap .btn");
+    if (plain) {
+      assert(getComputedStyle(plain).textTransform !== "uppercase", "The card rule leaked onto buttons outside the modal");
+    }
+    // The button stands clear of the warning it answers.
+    assert(
+      parseFloat(textStyle.marginBottom) >= 28,
+      `Only ${textStyle.marginBottom} separates the warning from its button`,
+    );
+    assert(
+      accept.getBoundingClientRect().top - text.getBoundingClientRect().bottom >= 28,
+      "The confirmation button crowds the warning text",
+    );
+  });
+
   await test("the beta banner's dismiss control clears the banner from the page", () => {
     const banner = document.getElementById("beta-warning");
     const dismiss = document.getElementById("beta-warning-dismiss");

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -633,7 +633,7 @@ test("the beta notice sits at the top of the page as a banner", () => {
     const live = markup.slice(wrapper).replace(/<!--[\s\S]*?-->/g, "");
     // It is a load-time warning again, so it keeps the alert role and leads
     // the wrap, ahead of the hosted-site warning and the pitch card.
-    assert.match(live, /<aside class="beta-warning no-print" id="beta-warning" role="alert">\s*<div class="beta-warning-text"><strong>Beta software<\/strong> EntropyLab is experimental and currently should only be used for testing\.<\/div>/);
+    assert.match(live, /<aside class="beta-warning no-print" id="beta-warning" role="alert">\s*<div class="beta-warning-text"><strong>Beta software<\/strong> EntropyLab is experimental and should only be used for testing and educational purposes\.<\/div>/);
     assert.ok(
       live.indexOf("<strong>Beta software") < live.indexOf('id="online-warning"'),
       "the beta banner must precede the online warning",
@@ -726,17 +726,29 @@ test("the beta disclaimer gates the page as a modal until accepted", () => {
   assert.match(template, /<p class="disclaimer-title" id="beta-disclaimer-title">Beta software<\/p>/);
   assert.match(
     template,
-    /<p class="disclaimer-text" id="beta-disclaimer-text">EntropyLab is experimental and can be dangerous:.*Do not use it in production, and never with funds you cannot afford to lose\.<\/p>/,
+    /<p class="disclaimer-text" id="beta-disclaimer-text">EntropyLab is experimental and should only be used for testing and educational purposes\. This tool is intended for offline use by advanced users only\. Any use online or with real funds can be dangerous\.<\/p>/,
   );
   assert.match(template, /<button class="btn primary" id="beta-disclaimer-accept" type="button">I understand<\/button>/);
   // The fade: transparent until .is-visible, faded out and inert once
   // .is-dismissed, and motion-free when the user prefers reduced motion.
   assert.match(css, /\.disclaimer-overlay \{\s*position: fixed; inset: 0;[^}]*opacity: 0; transition: opacity \.24s ease;/s);
+  // The page behind the card is defocused as well as darkened.
+  assert.match(css, /\.disclaimer-overlay \{[^}]*-webkit-backdrop-filter: blur\(6px\); backdrop-filter: blur\(6px\);/s);
   assert.match(css, /\.disclaimer-overlay\[hidden\] \{ display: none; \}/);
   assert.match(css, /\.disclaimer-overlay\.is-visible \{ opacity: 1; \}/);
   assert.match(css, /\.disclaimer-overlay\.is-dismissed \{ opacity: 0; pointer-events: none; \}/);
   assert.match(css, /@media \(prefers-reduced-motion: reduce\) \{ \.disclaimer-overlay \{ transition: none; \} \}/);
   assert.match(css, /\.disclaimer-card \{[^}]*border: 1px solid var\(--danger\);/s);
+  // Icon and title share the banner's brighter alert red, and the title takes
+  // the body size so it labels the sentence instead of heading it.
+  assert.match(css, /\.disclaimer-icon \{[^}]*color: var\(--danger-bright\); \}/);
+  assert.match(css, /\.disclaimer-title \{ margin: 12px 0 12px; font-size: 18px; font-weight: 700; text-transform: uppercase; color: var\(--danger-bright\); \}/);
+  // The button sits clear of the warning it answers.
+  assert.match(css, /\.disclaimer-text \{ margin: 0 24px 28px;/);
+  // The accept button is widened and uppercased in the card only; the shared
+  // .btn base still carries every other button in the app.
+  assert.match(css, /\.disclaimer-card \.btn \{ padding: 0 32px; font-size: 18px; text-transform: uppercase; \}/);
+  assert.match(css, /\.tab, \.btn \{\s*min-height: 44px; padding: 0 14px;/);
 });
 
 test("the lockup steps down again below 400px", () => {


### PR DESCRIPTION
The modal read as a paragraph with a toolbar button under it. Title it the way the top banner titles its own warning — uppercase, bold, in the brighter alert red the header's status tag uses — and take the icon to the same red so the two lead together. The title carries a size of its own again, a step above the sentence rather than the heading it once was.

Rewrite the sentence, and keep the banner's opening line identical to the modal's so the two warnings open the same way. Inset the paragraph by the card's own padding so it breaks into shorter lines, and give the button air above it: the answer to a blocking warning should not sit tight against the text it answers.

The accept button is widened and uppercased through .disclaimer-card, not the shared .btn base, which carries every other button in the application; a test pins that base and another checks the rule has not leaked outside the card. The scrim now blurs as well as darkens, so the page behind reads as out of focus rather than merely dimmed.