### PR TITLE
Normalize card transcript suit notation

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -3093,7 +3093,8 @@ function hodlFilterCards(value, coleman = false) {
     text = text.replace(/10\0([CDHS])/g, (_, suit) => "10" + ({ C: "\u2663", D: "\u2666", H: "\u2665", S: "\u2660" })[suit]);
     return text.replace(/[^0-9A-Z\s,.;:_|/\-\u2660\u2663\u2665\u2666]/g, "").replace(/[\s,.;:_|/-]+/g, " ");
   }
-  return text.replace(/[^0-9A-Z\s,.;:_|/-]/g, "").replace(/[\s,.;:_|/-]+/g, " ");
+  text = text.replace(/[^0-9A-Z\s,.;:_|/-]/g, "").replace(/[\s,.;:_|/-]+/g, " ");
+  return text.replace(/(^| )(10|[A2-9TJQK])([CDHS])(?= |$)/g, (_, separator, rank, suit) => separator + rank + suit.toLowerCase());
 }
 function hodlCardTypedCharactersAllowed(value) {
   return [...String(value ?? "")].every((character) => /[A2-9TJQKCDHS10\s,.;:_|/\-\u2660\u2663\u2665\u2666]/i.test(character));
@@ -3120,7 +3121,7 @@ function hodlDealtCardMarkup(card) {
 }
 function hodlCardsEntropy(value, targetWords = Pt, coleman = false) {
   let config = hodlSeedConfig(targetWords), notes = [], warnings = [], parsed = hodlParseCards(value, config.words);
-  if (parsed.invalid.length) return { ok: false, error: `Cards use rank then suit, like AS, 10H, or TD. Ignored: ${parsed.invalid.slice(0, 8).join(" ")}`, notes, warnings, parsed };
+  if (parsed.invalid.length) return { ok: false, error: `Cards use rank then suit, like As, 10h, or Td. Ignored: ${parsed.invalid.slice(0, 8).join(" ")}`, notes, warnings, parsed };
   if (parsed.duplicates.length) return { ok: false, error: `Do not repeat a card in the same shuffle. Repeated: ${parsed.duplicates[0]}.`, notes, warnings, parsed };
   if (!parsed.cards.length) return { ok: false, error: "Deal at least one card from a shuffled deck.", notes, warnings, parsed };
   let required = parsed.needed.first + parsed.needed.extra, hashInput = hodlCardsHashInput(parsed.cards, coleman);
@@ -3326,7 +3327,7 @@ function hodlUpdateCards() {
   if (parsed.pending) status += ` \xB7 finish ${parsed.pending.token} with a suit`;
   if (parsed.invalidEntries.length - (parsed.pending ? 1 : 0) > 0) {
     let count = parsed.invalidEntries.length - (parsed.pending ? 1 : 0);
-    status += ` \xB7 ${count} invalid card${count === 1 ? "" : "s"} highlighted \xB7 use AS, 10H, or TD`;
+    status += ` \xB7 ${count} invalid card${count === 1 ? "" : "s"} highlighted \xB7 use As, 10h, or Td`;
   }
   if (parsed.duplicateEntries.length) status += ` \xB7 repeated ${parsed.duplicateEntries[0].card} highlighted \xB7 deal a different card`;
   let invalid = parsed.invalidRanges.length > 0;
@@ -4558,7 +4559,7 @@ function hodlRenderKeyForm() {
     if (!direct) hodlCardSuit = hodlCardRank = "";
     let suitPad = hodlCardSuits.map((suit) => `<button type="button" class="card-suit${suit.red ? " is-red" : ""}" data-card-suit="${suit.code}" aria-label="${suit.label}" aria-pressed="false">${suit.symbol}</button>`).join("");
     let rankPad = direct ? hodlDirectCardRanks.map((rank) => `<button type="button" data-direct-card-rank="${rank}" aria-label="Enter rank ${rank}">${rank}</button>`).join("") : hodlCardRanks.map((rank) => `<button type="button" data-card-rank="${rank}" aria-label="${rank === "T" ? "10" : rank}">${rank === "T" ? "10" : rank}</button>`).join("");
-    let inputId = direct ? "direct-cards" : "cards", inputLabel = direct ? "Rank-only draw transcript" : "Card transcript", inputHelp = direct ? `For each of the first ${config.partialWords} words, shuffle and draw from A\u20138 three times, then A\u20134 once. Each four-character group selects one word; spaces separate the groups. The shorter final group supplies the remaining entropy bits, and EntropyLab calculates the BIP39 checksum bits.` : `Each valid card updates a deterministic test seed. For real security, ${config.words === 24 ? "deal all 52 unique cards, shuffle again, then deal 6 more" : `deal ${needed.first} unique cards without putting them back`}. SHA-256 hashes the ASCII transcript (AS 2C TD).`, placeholder = direct ? "A284 37A2 \u2026" : hodlCardColemanSymbols ? "A\u2660 2\u2663 10\u2665 T\u2666\u2026" : "AS 2C 10H TD\u2026";
+    let inputId = direct ? "direct-cards" : "cards", inputLabel = direct ? "Rank-only draw transcript" : "Card transcript", inputHelp = direct ? `For each of the first ${config.partialWords} words, shuffle and draw from A\u20138 three times, then A\u20134 once. Each four-character group selects one word; spaces separate the groups. The shorter final group supplies the remaining entropy bits, and EntropyLab calculates the BIP39 checksum bits.` : `Each valid card updates a deterministic test seed. For real security, ${config.words === 24 ? "deal all 52 unique cards, shuffle again, then deal 6 more" : `deal ${needed.first} unique cards without putting them back`}. SHA-256 hashes the canonical ASCII transcript (AS 2C TD).`, placeholder = direct ? "A284 37A2 \u2026" : hodlCardColemanSymbols ? "A\u2660 2\u2663 10\u2665 T\u2666\u2026" : "As 2c 10h Td\u2026";
     at.innerHTML = `
       <p class="label">How to turn cards into a ${config.words}-word seed</p>
       <div class="choice-grid">
@@ -4566,9 +4567,9 @@ function hodlRenderKeyForm() {
         <label class="choice"><input type="radio" name="card-method" value="direct" ${direct ? "checked" : ""} /><span><strong>Direct word selection</strong><span class="desc">Ignore suits. Reshuffle and draw A\u20138, A\u20138, A\u20138, then A\u20134 for each full word. Finish with the shorter rank sequence shown for the checksum-valid final word.</span></span></label>
       </div>
       <p class="muted" id="cards-help">${inputHelp}</p>
-      ${direct ? "" : `<label class="seed-autocomplete-toggle seed-zero-index-toggle"><input type="checkbox" id="cards-ian-coleman" ${hodlCardColemanSymbols ? "checked" : ""} /><span><strong>Match Ian Coleman method</strong> <span class="seed-autocomplete-note">(show and hash A\u2660 2\u2663 instead of AS 2C)</span></span></label>`}
+      ${direct ? "" : `<label class="seed-autocomplete-toggle seed-zero-index-toggle"><input type="checkbox" id="cards-ian-coleman" ${hodlCardColemanSymbols ? "checked" : ""} /><span><strong>Match Ian Coleman method</strong> <span class="seed-autocomplete-note">(show and hash A\u2660 2\u2663 instead of As 2c)</span></span></label>`}
       <label class="field" id="cards-input-label" for="${inputId}">${inputLabel}</label>
-      <div class="dice-input-shell cards-input-shell"><pre class="dice-input-highlight" id="cards-highlight" aria-hidden="true"></pre><textarea id="${inputId}" placeholder="${placeholder}" autocomplete="off" spellcheck="false" autocapitalize="characters" aria-labelledby="cards-input-label" aria-describedby="cards-help cards-meta"></textarea></div>
+      <div class="dice-input-shell cards-input-shell"><pre class="dice-input-highlight" id="cards-highlight" aria-hidden="true"></pre><textarea id="${inputId}" placeholder="${placeholder}" autocomplete="off" spellcheck="false" autocapitalize="off" aria-labelledby="cards-input-label" aria-describedby="cards-help cards-meta"></textarea></div>
       ${hodlSeedMetaRowMarkup("cards-meta")}
       ${direct ? "" : `<div class="card-suit-pad" role="group" aria-label="Suit">${suitPad}</div>`}
       <div class="card-rank-pad dice-input-pad${direct ? " direct-card-rank-pad" : ""}" role="group" aria-label="${direct ? "Rank-only draw" : "Rank"}">${rankPad}</div>
@@ -4632,7 +4633,7 @@ function hodlRenderKeyForm() {
     if (colemanToggle) colemanToggle.onchange = () => {
       hodlCardColemanSymbols = colemanToggle.checked;
       input.value = hodlFilterCards(input.value, hodlCardColemanSymbols);
-      input.placeholder = hodlCardColemanSymbols ? "A\u2660 2\u2663 10\u2665 T\u2666\u2026" : "AS 2C 10H TD\u2026";
+      input.placeholder = hodlCardColemanSymbols ? "A\u2660 2\u2663 10\u2665 T\u2666\u2026" : "As 2c 10h Td\u2026";
       input.setSelectionRange(input.value.length, input.value.length);
       if (state) {
         state.cardColemanSymbols = hodlCardColemanSymbols;

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -414,7 +414,7 @@
     const emptyHistoryHeight = dealt.getBoundingClientRect().height;
     input(cards, "as");
     await wait(0);
-    equal(cards.value, "AS");
+    equal(cards.value, "As");
     assert(!document.getElementById("go").disabled, "One valid card did not enable derivation");
     assert(document.getElementById("cards-meta").textContent.includes("seed available for testing"), "One-card warning is missing");
     equal([...document.querySelectorAll("#dice-words [data-word]")].filter((word) => word.textContent !== "—").length, 24);
@@ -427,10 +427,10 @@
     assert(document.querySelector("#cards-highlight .dice-roll-invalid")?.textContent === "ZZ", "Invalid card was not highlighted red");
     assert(document.getElementById("go").disabled && document.getElementById("cards-meta").classList.contains("err"), "Invalid card did not disable derivation");
     input(cards, "AS AS");
-    assert(document.querySelector("#cards-highlight .dice-roll-invalid")?.textContent === "AS", "Repeated card was not highlighted red");
+    assert(document.querySelector("#cards-highlight .dice-roll-invalid")?.textContent === "As", "Repeated card was not highlighted red");
     input(cards, "as, 10♥; td");
     await wait(0);
-    equal(cards.value, "AS 10H TD");
+    equal(cards.value, "As 10h Td");
     assert(!document.getElementById("go").disabled, "Normalized valid cards did not enable derivation");
     cards.focus();
     const disallowed = new InputEvent("beforeinput", { bubbles: true, cancelable: true, inputType: "insertText", data: "B" });

--- a/test/cards.test.mjs
+++ b/test/cards.test.mjs
@@ -124,12 +124,16 @@ test("card tokens normalize 10 and suit glyphs to ASCII", () => {
   assert.equal(hodlNormalizeCardToken("foo"), "");
 });
 
-test("card transcript input normalizes its limited character set", () => {
-  assert.equal(hodlFilterCards("as, 10♥;td"), "AS 10H TD");
-  assert.equal(hodlFilterCards("as <img>"), "AS IMG");
-  assert.equal(hodlFilterCards("AS 2C TD", true), "A\u2660 2\u2663 T\u2666");
-  assert.equal(hodlFilterCards("A\u2660 2\u2663 T\u2666", false), "AS 2C TD");
-  assert.equal(hodlFilterCards("AS 10H", true), "A\u2660 10\u2665");
+test("card transcript input uses uppercase ranks and lowercase suits", () => {
+  assert.equal(hodlFilterCards("4h"), "4h");
+  assert.equal(hodlFilterCards("js"), "Js");
+  assert.equal(hodlFilterCards("td"), "Td");
+  assert.equal(hodlFilterCards("4H"), "4h");
+  assert.equal(hodlFilterCards("as, 10♥;td"), "As 10h Td");
+  assert.equal(hodlFilterCards("as <img>"), "As IMG");
+  assert.equal(hodlFilterCards("AS 2C TD", true), "A♠ 2♣ T♦");
+  assert.equal(hodlFilterCards("A♠ 2♣ T♦", false), "As 2c Td");
+  assert.equal(hodlFilterCards("AS 10H", true), "A♠ 10♥");
   assert.equal(hodlCardTypedCharactersAllowed("aS 10♥, TD"), true);
   assert.equal(hodlCardTypedCharactersAllowed("B"), false);
 });
@@ -172,12 +176,15 @@ test("24-word extra cards may repeat the first shuffle", () => {
   assert.ok(parsed.bits >= 256);
 });
 
-test("hashed transcript is SHA-256 of ASCII codes", () => {
+test("hashed transcript is SHA-256 of canonical ASCII codes", () => {
   const transcript = "AS 2C TD";
+  const displayedTranscript = "As 2c Td";
   const digest = createHash("sha256").update(transcript, "utf8").digest("hex");
   assert.match(app, /Z\(new TextEncoder\(\)\.encode\(hashInput\)\)/);
   assert.equal(hodlParseCards(transcript, 12).hashInput, transcript);
+  assert.equal(hodlParseCards(displayedTranscript, 12).hashInput, transcript);
   assert.equal(hodlCardsHashInput(["AS", "2C", "TD"], false), transcript);
+  assert.equal(hodlCardsEntropy(displayedTranscript, 12).hex, hodlCardsEntropy(transcript, 12).hex);
   assert.equal(digest.length, 64);
 });
 

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -157,7 +157,9 @@ test("Seed phrase offers one-based or zero-based BIP39 word-number entry", () =>
 test("hashed cards can match Ian Coleman's suit-symbol SHA-256 transcript", () => {
   assert.match(appSource, /id="cards-ian-coleman"/);
   assert.match(appSource, /Match Ian Coleman method/);
-  assert.match(appSource, /show and hash A\\u2660 2\\u2663 instead of AS 2C/);
+  assert.match(appSource, /show and hash A\\u2660 2\\u2663 instead of As 2c/);
+  assert.match(appSource, /placeholder = direct \? "A284 37A2 \\u2026" : hodlCardColemanSymbols \? "A\\u2660 2\\u2663 10\\u2665 T\\u2666\\u2026" : "As 2c 10h Td\\u2026"/);
+  assert.match(appSource, /autocapitalize="off" aria-labelledby="cards-input-label"/);
   assert.match(appSource, /function hodlCardsHashInput\(cards, coleman = false\)/);
   assert.match(appSource, /transcript\.replace\(\/C\/g, "\\u2663"\)\.replace\(\/D\/g, "\\u2666"\)\.replace\(\/H\/g, "\\u2665"\)\.replace\(\/S\/g, "\\u2660"\)/);
   assert.match(appSource, /hodlFilterCards\(value, hodlCardColemanSymbols\)/);


### PR DESCRIPTION
## Summary

- display card transcripts with uppercase ranks and lowercase suits (`As`, `4h`, `Td`)
- normalize mixed-case pasted input while keeping the existing canonical uppercase card codes used for parsing and SHA-256
- disable browser autocapitalization and update the card examples/placeholders
- keep Ian Coleman suit-symbol mode and deterministic wallet outputs unchanged

## Tests

- `npm run ci` — 324/324 passed; build and artifact verification passed
- `node --test test/cards.test.mjs` — 21/21 passed
- `node --test test/ui-defaults.test.mjs` — 54/54 passed
- all 56 rank/suit forms and both Coleman notation round-trips passed an independent property probe
- regression test was confirmed failing against the previous uppercase-suit behavior

`npm test` additionally passed 330/331 locally; the sole failure was the repository's Firefox integration test because Firefox is not installed on this machine. GitHub CI remains the Firefox/browser gate.

Closes #122.
