### PR TITLE
Separate script type from derivation purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ Official website: [entropylab.online](https://entropylab.online)
 - Supports Mainnet and Testnet wallet derivation, multisignature construction,
   and PSBT address rendering. Mainnet is selected by default.
 - Derives watch-only multisignature wallets from extended public keys without
-  requiring private keys.
+  requiring private keys. Multisig script type and hardened purpose are
+  separate as well; conventional script choices restore their standard purpose,
+  while pasted co-signer origins auto-detect and must agree with the selected
+  purpose.
 - Inspects PSBT v0 transactions, reports PSBT-provided amounts and fees, checks
   for repeated ECDSA nonces from the same public key, verifies optional Jade
   anti-exfil (sign-to-contract) transcripts without a key, and can compare supported

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Official website: [entropylab.online](https://entropylab.online)
   next to its deterministic [LifeHash](https://lifehash.info) icon so two
   keys can be told apart at a glance.
 - Supports legacy, nested SegWit, native SegWit, and Taproot single-signature
-  address types.
+  address types. Script type and the hardened BIP32 purpose index are separate:
+  choosing a script restores its conventional 44/49/84/86 purpose, while an
+  advanced user can enter any valid hardened purpose index for a custom path.
 - Supports Mainnet and Testnet wallet derivation, multisignature construction,
   and PSBT address rendering. Mainnet is selected by default.
 - Derives watch-only multisignature wallets from extended public keys without

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -861,11 +861,11 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .key-settings-row {
   display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-component);
 }
-.key-settings.single-key-mode .key-settings-row:first-child { grid-template-columns: minmax(0, 1fr); }
+.key-settings.single-key-mode #account-address-settings { grid-template-columns: minmax(0, 1fr); }
 .key-settings.single-key-mode .network-field { width: 100%; max-width: 50%; }
 .key-settings .field { min-width: 0; margin: 0; }
-#passphrase-field[hidden], #master-fingerprint-preview[hidden], #script-type-field[hidden],
-#account-address-settings[hidden], #address-range-settings[hidden], #derivation-path-preview[hidden] { display: none !important; }
+#passphrase-field[hidden], #master-fingerprint-preview[hidden], #script-type-field[hidden], #purpose-field[hidden],
+#account-field[hidden], #address-range-settings[hidden], #derivation-path-preview[hidden] { display: none !important; }
 .field-note {
   display: block; margin-top: var(--space-control); color: var(--muted); font-size: 12px; font-weight: 400; line-height: 1.4;
 }

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -870,12 +870,14 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
   display: block; margin-top: var(--space-control); color: var(--muted); font-size: 12px; font-weight: 400; line-height: 1.4;
 }
 .address-estimate { color: var(--accent); }
+.derivation-estimate { margin: var(--space-control) 0 0; }
 .msig-legacy-account-toggle { margin: 0; }
 .msig-legacy-account-toggle[hidden] { display: none !important; }
 .msig-legacy-account-toggle input { margin-top: 2px; }
 #msig-account:disabled { cursor: not-allowed; color: var(--muted); opacity: 1; }
 #msig-account[data-state="mixed"] { color: var(--warn); }
 .msig-account-warning { color: var(--warn); }
+.msig-purpose-warning { color: var(--danger); }
 .msig-script-warning { color: var(--danger); }
 .derivation-path-preview {
   margin-top: var(--space-component); padding: var(--space-component); border: 1px solid var(--border); border-radius: 12px;

--- a/src/index.html
+++ b/src/index.html
@@ -131,7 +131,8 @@ words, pick one of the checksum words.</span></span>
         </div>
         <div class="key-settings-row" id="account-address-settings">
           <label class="field network-field">Network
-            <select id="network"><option value="mainnet" selected="selected">Bitcoin mainnet</option><option value="testnet">Testnet (practice)</option></select>
+            <select id="network" aria-describedby="network-help"><option value="mainnet" selected="selected">Bitcoin mainnet · 0h</option><option value="testnet">Testnet (practice) · 1h</option></select>
+            <span class="field-note" id="network-help">Hardened coin type index in the derivation path.</span>
           </label>
           <label class="field" id="account-field">Account
             <input id="account" type="number" min="0" max="2147483647" step="1" inputmode="numeric" value="0" aria-describedby="account-help">
@@ -144,9 +145,8 @@ words, pick one of the checksum words.</span></span>
             <span class="field-note" id="address-start-help">First receive and change index to derive.</span>
           </label>
           <label class="field">Address range
-            <input id="address-range" type="number" min="1" max="10000" step="1" inputmode="numeric" value="5" aria-describedby="address-range-help address-estimate">
+            <input id="address-range" type="number" min="1" max="10000" step="1" inputmode="numeric" value="5" aria-describedby="address-range-help">
             <span class="field-note" id="address-range-help">Derives 5 receive and 5 change addresses.</span>
-            <span class="field-note address-estimate" id="address-estimate" role="status">Measuring this device…</span>
           </label>
         </div>
       </div>
@@ -159,6 +159,7 @@ words, pick one of the checksum words.</span></span>
         </dl>
         <p class="derivation-path-error" id="derivation-path-error" hidden></p>
       </section>
+      <p class="field-note address-estimate derivation-estimate" id="address-estimate" role="status">Measuring this device…</p>
       <div class="row key-action-row current-item-actions">
         <button class="btn primary" id="go" disabled aria-disabled="true">Derive Wallet</button>
         <div class="derive-progress" id="derive-progress" role="progressbar" aria-label="Wallet derivation progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-valuetext="0% complete" hidden><span class="derive-progress-track"><span class="derive-progress-bar"></span></span><span class="derive-progress-label">0%</span></div>
@@ -202,14 +203,20 @@ words, pick one of the checksum words.</span></span>
         </label>
         <div class="key-settings-row">
           <label class="field">Script type
-            <select id="msig-script-type" aria-describedby="msig-script-warning"><option value="p2sh">Legacy · BIP45</option><option value="p2sh-p2wsh">Nested SegWit · BIP48</option><option value="p2wsh" selected="selected">Native SegWit · BIP48</option><option value="p2tr">Taproot · BIP86</option><option value="mixed" disabled data-custom-select-placeholder="true">Mixed · incompatible keys</option></select>
+            <select id="msig-script-type" aria-describedby="msig-script-warning"><option value="p2sh">Legacy</option><option value="p2sh-p2wsh">Nested SegWit</option><option value="p2wsh" selected="selected">Native SegWit</option><option value="p2tr">Taproot</option><option value="mixed" disabled data-custom-select-placeholder="true">Mixed · incompatible keys</option></select>
             <span class="field-note msig-script-warning" id="msig-script-warning" role="status" hidden></span>
           </label>
-          <label class="field">Network
-            <select id="msig-network"><option value="mainnet" selected="selected">Bitcoin mainnet</option><option value="testnet">Testnet (practice)</option></select>
+          <label class="field">Purpose
+            <input id="msig-purpose" type="number" min="0" max="2147483647" step="1" inputmode="numeric" value="48" aria-describedby="msig-purpose-help msig-purpose-warning">
+            <span class="field-note" id="msig-purpose-help">Hardened purpose index · 0 to 2,147,483,647</span>
+            <span class="field-note msig-purpose-warning" id="msig-purpose-warning" role="status" hidden></span>
           </label>
         </div>
         <div class="key-settings-row">
+          <label class="field">Network
+            <select id="msig-network" aria-describedby="msig-network-help"><option value="mainnet" selected="selected">Bitcoin mainnet · 0h</option><option value="testnet">Testnet (practice) · 1h</option></select>
+            <span class="field-note" id="msig-network-help">Hardened coin type index in the derivation path.</span>
+          </label>
           <label class="field">Account
             <input id="msig-account" type="text" value="" placeholder="Derived from keys" disabled aria-describedby="msig-account-help msig-account-warning">
             <span class="field-note" id="msig-account-help">Derived from co-signer key origins.</span>
@@ -222,9 +229,8 @@ words, pick one of the checksum words.</span></span>
             <span class="field-note" id="msig-address-start-help">First receive and change index to derive.</span>
           </label>
           <label class="field">Address range
-            <input id="msig-address-range" type="number" min="1" max="10000" step="1" inputmode="numeric" value="5" aria-describedby="msig-address-range-help msig-address-estimate">
+            <input id="msig-address-range" type="number" min="1" max="10000" step="1" inputmode="numeric" value="5" aria-describedby="msig-address-range-help">
             <span class="field-note" id="msig-address-range-help">Derives 5 receive and 5 change addresses.</span>
-            <span class="field-note address-estimate" id="msig-address-estimate" role="status">Measuring this device…</span>
           </label>
         </div>
         <details class="msig-advanced" id="msig-advanced">
@@ -238,6 +244,7 @@ words, pick one of the checksum words.</span></span>
           </label>
         </details>
       </div>
+      <p class="field-note address-estimate derivation-estimate" id="msig-address-estimate" role="status">Measuring this device…</p>
       <div class="row current-item-actions">
         <button class="btn primary" id="msig-go" type="button" aria-describedby="msig-script-warning" disabled aria-disabled="true">Derive Multisig</button>
         <div class="derive-progress" id="msig-derive-progress" role="progressbar" aria-label="Multisig derivation progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-valuetext="0% complete" hidden><span class="derive-progress-track"><span class="derive-progress-bar"></span></span><span class="derive-progress-label">0%</span></div>

--- a/src/index.html
+++ b/src/index.html
@@ -122,14 +122,18 @@ words, pick one of the checksum words.</span></span>
       <div class="key-settings" id="key-settings">
         <div class="key-settings-row">
           <label class="field" id="script-type-field">Script type
-            <select id="script-type"><option value="bip44">Legacy · BIP44</option><option value="bip49">Nested SegWit · BIP49</option><option value="bip84" selected="selected">Native SegWit · BIP84</option><option value="bip86">Taproot · BIP86</option></select>
+            <select id="script-type"><option value="bip44">Legacy</option><option value="bip49">Nested SegWit</option><option value="bip84" selected="selected">Native SegWit</option><option value="bip86">Taproot</option></select>
           </label>
-          <label class="field network-field">Network
-            <select id="network"><option value="mainnet" selected="selected">Bitcoin mainnet</option><option value="testnet">Testnet (practice)</option></select>
+          <label class="field" id="purpose-field">Purpose
+            <input id="purpose" type="number" min="0" max="2147483647" step="1" inputmode="numeric" value="84" aria-describedby="purpose-help">
+            <span class="field-note" id="purpose-help">Hardened purpose index · 0 to 2,147,483,647</span>
           </label>
         </div>
         <div class="key-settings-row" id="account-address-settings">
-          <label class="field">Account
+          <label class="field network-field">Network
+            <select id="network"><option value="mainnet" selected="selected">Bitcoin mainnet</option><option value="testnet">Testnet (practice)</option></select>
+          </label>
+          <label class="field" id="account-field">Account
             <input id="account" type="number" min="0" max="2147483647" step="1" inputmode="numeric" value="0" aria-describedby="account-help">
             <span class="field-note" id="account-help">Hardened account index · 0 to 2,147,483,647</span>
           </label>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -469,7 +469,8 @@ ec.innerHTML = `
         </div>
         <div class="key-settings-row" id="account-address-settings">
           <label class="field network-field">Network
-            <select id="network"><option value="mainnet" selected>Bitcoin mainnet</option><option value="testnet">Testnet (practice)</option></select>
+            <select id="network" aria-describedby="network-help"><option value="mainnet" selected>Bitcoin mainnet \xB7 0h</option><option value="testnet">Testnet (practice) \xB7 1h</option></select>
+            <span class="field-note" id="network-help">Hardened coin type index in the derivation path.</span>
           </label>
           <label class="field" id="account-field">Account
             <input id="account" type="number" min="0" max="2147483647" step="1" inputmode="numeric" value="0" aria-describedby="account-help">
@@ -482,9 +483,8 @@ ec.innerHTML = `
             <span class="field-note" id="address-start-help">First receive and change index to derive.</span>
           </label>
           <label class="field">Address range
-            <input id="address-range" type="number" min="1" max="10000" step="1" inputmode="numeric" value="5" aria-describedby="address-range-help address-estimate">
+            <input id="address-range" type="number" min="1" max="10000" step="1" inputmode="numeric" value="5" aria-describedby="address-range-help">
             <span class="field-note" id="address-range-help">Derives 5 receive and 5 change addresses.</span>
-            <span class="field-note address-estimate" id="address-estimate" role="status">Measuring this device\u2026</span>
           </label>
         </div>
       </div>
@@ -497,6 +497,7 @@ ec.innerHTML = `
         </dl>
         <p class="derivation-path-error" id="derivation-path-error" hidden></p>
       </section>
+      <p class="field-note address-estimate derivation-estimate" id="address-estimate" role="status">Measuring this device\u2026</p>
       <div class="row key-action-row current-item-actions">
         <button class="btn primary" id="go" disabled aria-disabled="true">Derive Wallet</button>
         <div class="derive-progress" id="derive-progress" role="progressbar" aria-label="Wallet derivation progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-valuetext="0% complete" hidden><span class="derive-progress-track"><span class="derive-progress-bar"></span></span><span class="derive-progress-label">0%</span></div>
@@ -540,14 +541,20 @@ ec.innerHTML = `
         </label>
         <div class="key-settings-row">
           <label class="field">Script type
-            <select id="msig-script-type" aria-describedby="msig-script-warning"><option value="p2sh">Legacy \xB7 BIP45</option><option value="p2sh-p2wsh">Nested SegWit \xB7 BIP48</option><option value="p2wsh" selected>Native SegWit \xB7 BIP48</option><option value="p2tr">Taproot \xB7 BIP86</option><option value="mixed" disabled data-custom-select-placeholder="true">Mixed \xB7 incompatible keys</option></select>
+            <select id="msig-script-type" aria-describedby="msig-script-warning"><option value="p2sh">Legacy</option><option value="p2sh-p2wsh">Nested SegWit</option><option value="p2wsh" selected>Native SegWit</option><option value="p2tr">Taproot</option><option value="mixed" disabled data-custom-select-placeholder="true">Mixed \xB7 incompatible keys</option></select>
             <span class="field-note msig-script-warning" id="msig-script-warning" role="status" hidden></span>
           </label>
-          <label class="field">Network
-            <select id="msig-network"><option value="mainnet" selected>Bitcoin mainnet</option><option value="testnet">Testnet (practice)</option></select>
+          <label class="field">Purpose
+            <input id="msig-purpose" type="number" min="0" max="2147483647" step="1" inputmode="numeric" value="48" aria-describedby="msig-purpose-help msig-purpose-warning">
+            <span class="field-note" id="msig-purpose-help">Hardened purpose index \xB7 0 to 2,147,483,647</span>
+            <span class="field-note msig-purpose-warning" id="msig-purpose-warning" role="status" hidden></span>
           </label>
         </div>
         <div class="key-settings-row">
+          <label class="field">Network
+            <select id="msig-network" aria-describedby="msig-network-help"><option value="mainnet" selected>Bitcoin mainnet \xB7 0h</option><option value="testnet">Testnet (practice) \xB7 1h</option></select>
+            <span class="field-note" id="msig-network-help">Hardened coin type index in the derivation path.</span>
+          </label>
           <label class="field">Account
             <input id="msig-account" type="text" value="" placeholder="Derived from keys" disabled aria-describedby="msig-account-help msig-account-warning">
             <span class="field-note" id="msig-account-help">Derived from co-signer key origins.</span>
@@ -560,9 +567,8 @@ ec.innerHTML = `
             <span class="field-note" id="msig-address-start-help">First receive and change index to derive.</span>
           </label>
           <label class="field">Address range
-            <input id="msig-address-range" type="number" min="1" max="10000" step="1" inputmode="numeric" value="5" aria-describedby="msig-address-range-help msig-address-estimate">
+            <input id="msig-address-range" type="number" min="1" max="10000" step="1" inputmode="numeric" value="5" aria-describedby="msig-address-range-help">
             <span class="field-note" id="msig-address-range-help">Derives 5 receive and 5 change addresses.</span>
-            <span class="field-note address-estimate" id="msig-address-estimate" role="status">Measuring this device\u2026</span>
           </label>
         </div>
         <details class="msig-advanced" id="msig-advanced">
@@ -576,6 +582,7 @@ ec.innerHTML = `
           </label>
         </details>
       </div>
+      <p class="field-note address-estimate derivation-estimate" id="msig-address-estimate" role="status">Measuring this device\u2026</p>
       <div class="row current-item-actions">
         <button class="btn primary" id="msig-go" type="button" aria-describedby="msig-script-warning" disabled aria-disabled="true">Derive Multisig</button>
         <div class="derive-progress" id="msig-derive-progress" role="progressbar" aria-label="Multisig derivation progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-valuetext="0% complete" hidden><span class="derive-progress-track"><span class="derive-progress-bar"></span></span><span class="derive-progress-label">0%</span></div>
@@ -5603,53 +5610,72 @@ function hodlOriginMatchesParsedKey(origin, parsed) {
   if (indexes[indexes.length - 1] !== parsed.childNumber) return "Key origin path does not end at this extended key.";
   return "";
 }
-function hodlMultisigDerivationStandard(origin) {
-  let steps = hodlNormalizeOriginPath(origin?.path).split("/").filter(Boolean);
-  if (steps[0] === "45h") return "bip45";
-  if (steps[0] === "86h") return "bip86";
-  if (steps[0] === "87h") return "bip87";
-  if (steps[0] === "48h") return "bip48";
-  return null;
+function hodlMultisigPurposeIndex(origin) {
+  let first = hodlNormalizeOriginPath(origin?.path).split("/").filter(Boolean)[0], match = first?.match(/^(\d+)h$/);
+  if (!match) throw new Error("The purpose index in the key origin must be hardened.");
+  let purpose = Number(match[1]);
+  if (!Number.isSafeInteger(purpose) || purpose < 0 || purpose > hodlMaxPurpose) throw new Error("The purpose index in the key origin is out of range.");
+  return purpose;
 }
-function hodlOriginScriptError(origin, kind, network, legacyStandard = "bip45") {
+function hodlReadMsigPurpose(mark = true) {
+  let input = document.getElementById("msig-purpose"), raw = String(input?.value ?? "").trim(), value = Number(raw), valid = /^\d+$/.test(raw) && Number.isSafeInteger(value) && value >= 0 && value <= hodlMaxPurpose;
+  if (mark) {
+    input?.classList.toggle("bad", !valid);
+    input?.setAttribute("aria-invalid", String(!valid));
+  }
+  if (!valid) throw new Error("Purpose must be a whole number from 0 to 2,147,483,647.");
+  return value;
+}
+function hodlSetMsigPurpose(value) {
+  let purpose = Number(value), input = document.getElementById("msig-purpose");
+  if (!Number.isSafeInteger(purpose) || purpose < 0 || purpose > hodlMaxPurpose) purpose = 48;
+  if (input) input.value = String(purpose);
+  let state = hodlMsigs[hodlActiveMsig];
+  if (state) state.fields.purpose = String(purpose);
+  return purpose;
+}
+function hodlStandardMsigPurpose(kind = hodlScriptKind()) {
+  if (kind === "p2sh") return document.getElementById("msig-legacy-bip87")?.checked ? 87 : 45;
+  if (kind === "p2tr") return 86;
+  return 48;
+}
+function hodlOriginScriptError(origin, kind, network, purpose) {
   let steps = hodlNormalizeOriginPath(origin.path).split("/");
+  let expectedPurpose = `${purpose}h`;
+  if (steps[0] !== expectedPurpose) return `This key origin uses purpose ${steps[0] || "none"}; the selected Purpose is ${expectedPurpose}.`;
   if (kind === "p2tr") {
-    if (steps[0] !== "86h") return "BIP86 origin must start at 86h.";
     let coin = network === "testnet" ? "1h" : "0h";
-    if (steps[1] !== coin) return `This ${network} BIP86 origin should use ${coin} as the coin type.`;
-    if (steps.length !== 3) return "BIP86 origin must be 86h/coin/account.";
-    if (!/^\d+h$/.test(steps[2])) return "BIP86 account index must be hardened.";
+    if (steps[1] !== coin) return `This ${network} origin should use ${coin} as the coin type.`;
+    if (steps.length !== 3) return "Taproot origin must be purposeh/coinh/accounth.";
+    if (!/^\d+h$/.test(steps[2])) return "The account index must be hardened.";
     return ""
   }
   if (kind === "p2wsh" || kind === "p2sh-p2wsh") {
-    if (steps[0] !== "48h") return "This script type's origin must start at 48h.";
     let coin = network === "testnet" ? "1h" : "0h";
     if (steps[1] !== coin) return `This ${network} origin should use ${coin} as the coin type.`;
-    if (steps.length !== 4) return "BIP48 origin must be 48h/coin/account/script.";
-    if (!/^\d+h$/.test(steps[2])) return "BIP48 account index must be hardened.";
+    if (steps.length !== 4) return "SegWit multisig origin must be purposeh/coinh/accounth/scripth.";
+    if (!/^\d+h$/.test(steps[2])) return "The account index must be hardened.";
     let last = kind === "p2wsh" ? "2h" : "1h";
     if (steps[3] !== last) return `This script type's origin must end in ${last}.`;
     return "";
   }
-  if (legacyStandard === "bip87") {
-    if (steps[0] !== "87h") return "Legacy BIP87 origin must start at 87h.";
+  if (purpose !== 45) {
     let coin = network === "testnet" ? "1h" : "0h";
-    if (steps[1] !== coin) return `This ${network} BIP87 origin should use ${coin} as the coin type.`;
-    if (steps.length !== 3) return "BIP87 origin must be 87h/coin/account.";
-    if (!/^\d+h$/.test(steps[2])) return "BIP87 account index must be hardened.";
+    if (steps[1] !== coin) return `This ${network} origin should use ${coin} as the coin type.`;
+    if (steps.length !== 3) return "Account-based Legacy origin must be purposeh/coinh/accounth.";
+    if (!/^\d+h$/.test(steps[2])) return "The account index must be hardened.";
     return "";
   }
-  if (steps.length !== 1 || steps[0] !== "45h") return "Legacy P2SH requires the BIP45 purpose origin 45h.";
+  if (steps.length !== 1) return "Legacy purpose 45 uses the BIP45 purpose key at m/45h without an account.";
   return "";
 }
-function hodlMultisigAccountNumber(origin, kind) {
+function hodlMultisigAccountNumber(origin, kind, purpose) {
   let steps = hodlNormalizeOriginPath(origin?.path).split("/");
-  if (kind === "p2sh" && steps[0] === "45h") return null;
-  let standard = kind === "p2tr" ? "BIP86" : kind === "p2sh" ? "BIP87" : "BIP48",
-    match = steps[2]?.match(/^(\d+)h$/);
-  if (!match) throw new Error(`${standard} account index must be hardened.`);
+  if (kind === "p2sh" && purpose === 45) return null;
+  let match = steps[2]?.match(/^(\d+)h$/);
+  if (!match) throw new Error("The account index must be hardened.");
   let account = Number(match[1]);
-  if (!Number.isSafeInteger(account) || account < 0 || account > 2147483647) throw new Error(`${standard} account index is out of range.`);
+  if (!Number.isSafeInteger(account) || account < 0 || account > 2147483647) throw new Error("The account index is out of range.");
   return account;
 }
 function hodlSummarizeMultisigAccounts(accountNumbers) {
@@ -5662,8 +5688,9 @@ function hodlMultisigAccountWarning(summary) {
 }
 function hodlMultisigOriginScriptKind(origin) {
   let steps = hodlNormalizeOriginPath(origin?.path).split("/").filter(Boolean);
-  if (steps.length === 1 && steps[0] === "45h") return "p2sh";
+  if (steps.length === 1) return "p2sh";
   if (steps[0] === "86h" && steps.length === 3) return "p2tr";
+  if (steps[0] === "87h" && steps.length === 3) return "p2sh";
   if (steps[0] !== "48h" || steps.length !== 4) return null;
   if (steps[3] === "1h") return "p2sh-p2wsh";
   if (steps[3] === "2h") return "p2wsh";
@@ -5671,7 +5698,7 @@ function hodlMultisigOriginScriptKind(origin) {
 }
 function hodlMultisigScriptEvidence(parsed) {
   let prefixKind = parsed?.scope === "multisig" ? parsed.family === "y" ? "p2sh-p2wsh" : parsed.family === "z" ? "p2wsh" : null : null;
-  return { prefixKind, originKind: hodlMultisigOriginScriptKind(parsed?.origin), standard: hodlMultisigDerivationStandard(parsed?.origin) };
+  return { prefixKind, originKind: hodlMultisigOriginScriptKind(parsed?.origin) };
 }
 function hodlSummarizeMultisigScriptKinds(kinds) {
   let supported = ["p2sh", "p2sh-p2wsh", "p2wsh", "p2tr"],
@@ -5688,47 +5715,86 @@ function hodlParseMultisigCosigner(raw) {
   return parsed;
 }
 function hodlDetectMsigScriptSummary(values = hodlReadMsigXpubs()) {
-  let kinds = [], legacyStandards = [];
+  let kinds = [];
   for (let raw of values) {
     if (!String(raw ?? "").trim()) continue;
     try {
       let evidence = hodlMultisigScriptEvidence(hodlParseMultisigCosigner(raw));
       if (evidence.prefixKind) kinds.push(evidence.prefixKind);
       if (evidence.originKind) kinds.push(evidence.originKind);
-      if (evidence.standard === "bip45" || evidence.standard === "bip87") legacyStandards.push(evidence.standard);
     } catch {
     }
   }
-  let summary = hodlSummarizeMultisigScriptKinds(kinds), standards = [...new Set(legacyStandards)], legacyScriptConflict = standards.includes("bip87") && summary.kinds.some((kind) => kind !== "p2sh");
-  return { ...summary, legacyStandard: standards.length === 1 ? standards[0] : null, legacyStandards: standards, legacyMixed: standards.length > 1, legacyScriptConflict };
+  return hodlSummarizeMultisigScriptKinds(kinds);
 }
 function hodlMultisigScriptLabel(kind) {
   return kind === "p2sh" ? "Legacy" : kind === "p2sh-p2wsh" ? "Nested SegWit" : kind === "p2wsh" ? "Native SegWit" : kind === "p2tr" ? "Taproot" : "Unknown"
 }
 function hodlSelectedLegacyMultisigStandard() {
-  return document.getElementById("msig-legacy-bip87")?.checked ? "bip87" : "bip45";
+  let purpose;
+  try {
+    purpose = hodlReadMsigPurpose(false);
+  } catch {
+    return "custom";
+  }
+  return purpose === 45 ? "bip45" : purpose === 87 ? "bip87" : "custom";
 }
 function hodlUpdateMsigLegacyControls() {
-  let checkbox = document.getElementById("msig-legacy-bip87"), toggle = document.getElementById("msig-legacy-account-toggle"), option = document.querySelector('#msig-script-type option[value="p2sh"]'), legacy = hodlScriptKind() === "p2sh";
+  let checkbox = document.getElementById("msig-legacy-bip87"), toggle = document.getElementById("msig-legacy-account-toggle"), legacy = hodlScriptKind() === "p2sh", purpose;
+  try {
+    purpose = hodlReadMsigPurpose(false);
+  } catch {
+    purpose = null;
+  }
   if (toggle) toggle.hidden = !legacy;
-  if (option) option.textContent = checkbox?.checked ? "Legacy \xB7 BIP87" : "Legacy \xB7 BIP45";
+  if (checkbox) checkbox.checked = purpose === 87;
 }
-function hodlMultisigKeyPlaceholder(kind, network, legacyStandard = "bip45") {
+function hodlMultisigKeyPlaceholder(kind, network, purpose) {
   let testnet = network === "testnet",
-    coin = testnet ? "1h" : "0h";
-  if (kind === "p2sh" && legacyStandard === "bip87") return `[fingerprint/87h/${coin}/0h]${testnet?"tpub":"xpub"}\u2026`;
-  if (kind === "p2sh") return `[fingerprint/45h]${testnet?"tpub":"xpub"}\u2026`;
-  if (kind === "p2sh-p2wsh") return `[fingerprint/48h/${coin}/0h/1h]${testnet?"Upub":"Ypub"}\u2026`;
-  if (kind === "p2wsh") return `[fingerprint/48h/${coin}/0h/2h]${testnet?"Vpub":"Zpub"}\u2026`;
-  if (kind === "p2tr") return `[fingerprint/86h/${coin}/0h]${testnet?"tpub":"xpub"}\u2026`;
+    coin = testnet ? "1h" : "0h", purposeStep = `${purpose}h`;
+  if (kind === "p2sh" && purpose === 45) return `[fingerprint/${purposeStep}]${testnet?"tpub":"xpub"}\u2026`;
+  if (kind === "p2sh") return `[fingerprint/${purposeStep}/${coin}/0h]${testnet?"tpub":"xpub"}\u2026`;
+  if (kind === "p2sh-p2wsh") return `[fingerprint/${purposeStep}/${coin}/0h/1h]${testnet?"Upub":"Ypub"}\u2026`;
+  if (kind === "p2wsh") return `[fingerprint/${purposeStep}/${coin}/0h/2h]${testnet?"Vpub":"Zpub"}\u2026`;
+  if (kind === "p2tr") return `[fingerprint/${purposeStep}/${coin}/0h]${testnet?"tpub":"xpub"}\u2026`;
   return "Use matching multisig extended public keys"
 }
 
 function hodlUpdateMsigKeyPlaceholders() {
-  let kind = hodlScriptKind(), network = hodlSelectedNetwork(document.getElementById("msig-network")), placeholder = hodlMultisigKeyPlaceholder(kind, network, hodlSelectedLegacyMultisigStandard());
+  let kind = hodlScriptKind(), network = hodlSelectedNetwork(document.getElementById("msig-network")), purpose;
+  try {
+    purpose = hodlReadMsigPurpose(false);
+  } catch {
+    purpose = hodlStandardMsigPurpose(kind);
+  }
+  let placeholder = hodlMultisigKeyPlaceholder(kind, network, purpose);
   document.querySelectorAll("#msig-keys textarea").forEach((textarea) => {
     textarea.placeholder = placeholder;
   });
+}
+function hodlUpdateMsigPurposeDetection() {
+  let input = document.getElementById("msig-purpose"), warning = document.getElementById("msig-purpose-warning"), purposes = [];
+  if (!input) return { purposes, mixed: false, purpose: null };
+  for (let raw of hodlReadMsigXpubs()) {
+    if (!String(raw ?? "").trim()) continue;
+    try {
+      let parsed = hodlParseMultisigCosigner(raw);
+      if (parsed.origin) purposes.push(hodlMultisigPurposeIndex(parsed.origin));
+    } catch {
+    }
+  }
+  purposes = [...new Set(purposes)].sort((left, right) => left - right);
+  let mixed = purposes.length > 1, purpose = purposes.length === 1 ? purposes[0] : null;
+  if (purpose != null) hodlSetMsigPurpose(purpose);
+  let message = mixed ? `Co-signer purpose indexes do not match (${purposes.map(value => `${value}h`).join(", ")}).` : "";
+  input.classList.toggle("bad", mixed);
+  input.setAttribute("aria-invalid", String(mixed));
+  if (warning) {
+    warning.textContent = message;
+    warning.hidden = !message;
+  }
+  hodlUpdateMsigLegacyControls();
+  return { purposes, mixed, purpose };
 }
 function hodlSyncMsigDeriveButton() {
   let button = document.getElementById("msig-go");
@@ -5759,7 +5825,7 @@ function hodlSyncMsigDeriveButton() {
 function hodlUpdateMsigScriptDetection() {
   let select = document.getElementById("msig-script-type");
   if (!select) return hodlSummarizeMultisigScriptKinds([]);
-  let summary = hodlDetectMsigScriptSummary(), desired = summary.mixed || summary.legacyMixed || summary.legacyScriptConflict ? "mixed" : summary.kind, checkbox = document.getElementById("msig-legacy-bip87");
+  let summary = hodlDetectMsigScriptSummary(), desired = summary.mixed ? "mixed" : summary.kind;
   if (desired === "mixed") {
     if (select.value !== "mixed") select.dataset.lastConcrete = select.value;
     hodlSyncSelect(select, "mixed");
@@ -5769,9 +5835,9 @@ function hodlUpdateMsigScriptDetection() {
   } else if (select.value === "mixed") {
     hodlSyncSelect(select, select.dataset.lastConcrete || "p2wsh");
   } else select.dataset.lastConcrete = select.value;
-  if ((desired === "p2sh" || select.value === "p2sh") && summary.legacyStandard && checkbox) checkbox.checked = summary.legacyStandard === "bip87";
+  hodlUpdateMsigPurposeDetection();
   hodlUpdateMsigLegacyControls();
-  let warning = document.getElementById("msig-script-warning"), labels = summary.kinds.map(hodlMultisigScriptLabel), bip87NeedsScript = summary.legacyStandard === "bip87" && !summary.kind && select.value !== "p2sh", message = summary.legacyMixed ? "Legacy co-signer exports mix BIP45 and BIP87. Choose one derivation standard and export every key from it." : summary.legacyScriptConflict ? "BIP87 account keys are script-agnostic, but this app uses them only with Legacy P2SH. They cannot be combined here with BIP48 keys." : summary.mixed ? `Co-signer exports indicate different script types (${labels.join(" and ")}). A Mixed selection does not define one multisig output policy; export every key for the same script type before deriving.` : bip87NeedsScript ? "BIP87 keys do not encode a script type. Select Legacy P2SH to use this standardized account key here." : "";
+  let warning = document.getElementById("msig-script-warning"), labels = summary.kinds.map(hodlMultisigScriptLabel), message = summary.mixed ? `Co-signer exports indicate different script types (${labels.join(" and ")}). A Mixed selection does not define one multisig output policy; export every key for the same script type before deriving.` : "";
   if (warning) {
     warning.textContent = message;
     warning.hidden = !message;
@@ -5878,8 +5944,13 @@ function hodlMergeMsigXpubs(state, values) {
 function hodlUpdateMsigAccount() {
   let field = document.getElementById("msig-account");
   if (!field) return hodlSummarizeMultisigAccounts([]);
-  let kind = hodlScriptKind(), legacyStandard = hodlSelectedLegacyMultisigStandard(), help = document.getElementById("msig-account-help"), warning = document.getElementById("msig-account-warning");
-  if (kind === "p2sh" && legacyStandard === "bip45") {
+  let kind = hodlScriptKind(), purpose, help = document.getElementById("msig-account-help"), warning = document.getElementById("msig-account-warning");
+  try {
+    purpose = hodlReadMsigPurpose(false);
+  } catch {
+    purpose = hodlStandardMsigPurpose(kind);
+  }
+  if (kind === "p2sh" && purpose === 45) {
     field.value = "";
     field.placeholder = "Not applicable";
     field.dataset.state = "not-applicable";
@@ -5895,7 +5966,7 @@ function hodlUpdateMsigAccount() {
     if (!raw.trim()) continue;
     try {
       let parsed = hodlParseMultisigCosigner(raw.trim());
-      if (parsed.origin) accountNumbers.push(hodlMultisigAccountNumber(parsed.origin, kind));
+      if (parsed.origin) accountNumbers.push(hodlMultisigAccountNumber(parsed.origin, kind, purpose));
     } catch {
     }
   }
@@ -5903,7 +5974,7 @@ function hodlUpdateMsigAccount() {
   field.value = summary.mixed ? "Mixed" : summary.account == null ? "" : String(summary.account);
   field.placeholder = "Derived from keys";
   field.dataset.state = summary.mixed ? "mixed" : summary.account == null ? "empty" : "account";
-  if (help) help.textContent = summary.mixed ? "Co-signer key origins use different account numbers." : summary.account == null ? kind === "p2sh" ? "Derived from BIP87 co-signer key origins." : "Derived from co-signer key origins." : "Derived from the co-signer account paths.";
+  if (help) help.textContent = summary.mixed ? "Co-signer key origins use different account numbers." : summary.account == null ? "Derived from co-signer key origins." : "Derived from the co-signer account paths.";
   if (warning) {
     warning.textContent = message;
     warning.hidden = !message;
@@ -6244,21 +6315,21 @@ function hodlMultisigPrefixCompatible(parsed, kind) {
   if (kind === "p2wsh") return parsed.family === "z";
   return false;
 }
-function hodlMultisigAccountKeyError(parsed, kind, legacyStandard = "bip45") {
+function hodlMultisigAccountKeyError(parsed, kind, purpose) {
   if (kind === "p2tr") {
-    if (parsed.depth !== 3) return `Taproot BIP86 requires a depth-3 account key at m/86h/coinh/accounth; this key is depth ${parsed.depth}.`;
-    if (parsed.childNumber < 0x80000000) return "A BIP86 account index must be hardened.";
+    if (parsed.depth !== 3) return `Taproot requires a depth-3 account key at m/purposeh/coinh/accounth; this key is depth ${parsed.depth}.`;
+    if (parsed.childNumber < 0x80000000) return "The account index must be hardened.";
     return ""
   }
   if (kind === "p2wsh" || kind === "p2sh-p2wsh") {
     let scriptIndex = kind === "p2wsh" ? 2 : 1, label = kind === "p2wsh" ? "Native SegWit" : "Nested SegWit", expected = 2147483648 + scriptIndex;
-    if (parsed.depth !== 4) return `${label} requires a depth-4 BIP48 script-account key ending in /${scriptIndex}h; this key is depth ${parsed.depth}.`;
-    if (parsed.childNumber !== expected) return `${label} requires a BIP48 script-account key whose final hardened child is ${scriptIndex}h.`;
+    if (parsed.depth !== 4) return `${label} requires a depth-4 script-account key ending in /${scriptIndex}h; this key is depth ${parsed.depth}.`;
+    if (parsed.childNumber !== expected) return `${label} requires a script-account key whose final hardened child is ${scriptIndex}h.`;
     return "";
   }
-  if (legacyStandard === "bip87") {
-    if (parsed.depth !== 3) return `Legacy BIP87 requires a depth-3 account key at m/87h/coinh/accounth; this key is depth ${parsed.depth}.`;
-    if (parsed.childNumber < 2147483648) return "A BIP87 account index must be hardened.";
+  if (purpose !== 45) {
+    if (parsed.depth !== 3) return `Account-based Legacy derivation requires a depth-3 key at m/purposeh/coinh/accounth; this key is depth ${parsed.depth}.`;
+    if (parsed.childNumber < 2147483648) return "The account index must be hardened.";
     return "";
   }
   if (parsed.depth !== 1) return `Legacy P2SH requires the depth-1 BIP45 purpose key at m/45h; this key is depth ${parsed.depth}.`;
@@ -6290,17 +6361,17 @@ function hodlCheckXpub(ta) {
     return;
   }
   try {
-    let parsed = hodlParseMultisigCosigner(value), network = hodlSelectedNetwork(document.getElementById("msig-network")), kind = hodlScriptKind(), legacyStandard = hodlSelectedLegacyMultisigStandard();
-    if (kind === "mixed") throw new Error("These keys do not define one compatible multisig policy. Use one script type and one Legacy derivation standard.");
+    let parsed = hodlParseMultisigCosigner(value), network = hodlSelectedNetwork(document.getElementById("msig-network")), kind = hodlScriptKind(), purpose = hodlReadMsigPurpose();
+    if (kind === "mixed") throw new Error("These keys do not define one compatible multisig policy. Use one script type.");
     if (parsed.isPrivate) throw new Error("Paste an extended public key, never an extended private key.");
     if (parsed.network !== network) throw new Error(`${parsed.prefix} is for ${parsed.network}; the multisig is set to ${network}.`);
     if (!hodlMultisigPrefixCompatible(parsed, kind)) throw new Error(parsed.scope === "singlesig" ? "Use a generic xpub/tpub here, or a proper uppercase multisig SLIP-132 export." : `${parsed.prefix} does not match the selected multisig script type.`);
-    let accountError = hodlMultisigAccountKeyError(parsed, kind, legacyStandard);
+    let accountError = hodlMultisigAccountKeyError(parsed, kind, purpose);
     if (accountError) throw new Error(accountError);
-    if (!parsed.origin) throw new Error(`Paste ${hodlMultisigKeyPlaceholder(kind, network, legacyStandard)} so a signer can recognize this key.`);
+    if (!parsed.origin) throw new Error(`Paste ${hodlMultisigKeyPlaceholder(kind, network, purpose)} so a signer can recognize this key.`);
     let originError = hodlOriginMatchesParsedKey(parsed.origin, parsed);
     if (originError) throw new Error(originError);
-    let scriptOriginError = hodlOriginScriptError(parsed.origin, kind, network, legacyStandard);
+    let scriptOriginError = hodlOriginScriptError(parsed.origin, kind, network, purpose);
     if (scriptOriginError) throw new Error(scriptOriginError);
     if (hodlDuplicateMultisigKey(ta, parsed)) throw new Error("This duplicates another co-signer. Every co-signer must use a distinct extended public key.");
     hodlHint(ta, true, `${parsed.prefix} origin, checksum, and derivation path look valid`);
@@ -6311,6 +6382,7 @@ function hodlCheckXpub(ta) {
 function hodlResetMsigForm() {
   hodlSetMsigThresholds(2, 3);
   hodlSyncSelect(document.getElementById("msig-script-type"), "p2wsh");
+  hodlSetMsigPurpose(48);
   let legacy = document.getElementById("msig-legacy-bip87");
   if (legacy) legacy.checked = false;
   hodlUpdateMsigLegacyControls();
@@ -6334,13 +6406,33 @@ function hodlInitMsig() {
       hodlUpdateMsigKeyOrderStatus()
     },
     script = document.getElementById("msig-script-type"),
+    purpose = document.getElementById("msig-purpose"),
     legacy = document.getElementById("msig-legacy-bip87"),
     keyOrder = document.getElementById("msig-key-order");
   script.addEventListener("change", () => {
     if (script.value !== "mixed") script.dataset.lastConcrete = script.value;
+    hodlSetMsigPurpose(hodlStandardMsigPurpose(script.value));
     recheck();
   });
+  purpose?.addEventListener("keydown", (event) => {
+    if (["e", "E", "+", "-", "."].includes(event.key)) event.preventDefault();
+  });
+  purpose?.addEventListener("paste", (event) => {
+    if (!/^\d+$/.test(event.clipboardData?.getData("text") ?? "")) event.preventDefault();
+  });
+  purpose?.addEventListener("input", () => {
+    try {
+      hodlReadMsigPurpose();
+    } catch {
+    }
+    hodlUpdateMsigLegacyControls();
+    hodlUpdateMsigKeyPlaceholders();
+    hodlInvalidateMsig();
+    document.querySelectorAll("#msig-keys textarea").forEach(hodlCheckXpub);
+    hodlSyncMsigClearButton(true);
+  });
   if (legacy) legacy.addEventListener("change", () => {
+    hodlSetMsigPurpose(legacy.checked ? 87 : 45);
     hodlUpdateMsigLegacyControls();
     hodlUpdateMsigKeyPlaceholders();
     hodlInvalidateMsig();
@@ -6421,7 +6513,7 @@ function hodlMsigAddr(pubkeys, m, network, kind, sorted = !0) {
 function hodlValidatedMsigInputs() {
   let network = hodlSelectedNetwork(document.getElementById("msig-network")), addressWindow = hodlReadAddressWindow("msig-"), count = addressWindow.range, addressStart = addressWindow.start, n = Number(document.getElementById("msig-n")?.value), m = Number(document.getElementById("msig-m")?.value);
   if (!(m >= 1 && n >= 1 && m <= n && n <= 15)) throw new Error("Pick how many signatures out of how many keys.");
-  let kind = hodlScriptKind(), legacyStandard = hodlSelectedLegacyMultisigStandard(), nodes = [], xpubs = [], keyTokens = [], accountNumbers = [];
+  let kind = hodlScriptKind(), purpose = hodlReadMsigPurpose(), legacyStandard = hodlSelectedLegacyMultisigStandard(), nodes = [], xpubs = [], keyTokens = [], accountNumbers = [], purposeIndexes = [];
   if (kind === "mixed") throw new Error("Co-signer keys indicate different script types. Export every key for the same multisig script type before deriving.");
   for (let index = 0; index < n; index++) {
     let field = document.getElementById("msig-x-" + index), raw = field?.value.trim() || "";
@@ -6430,14 +6522,15 @@ function hodlValidatedMsigInputs() {
     if (parsed.isPrivate) throw new Error("Co-signer " + (index + 1) + " is an extended private key. Paste only an extended public key.");
     if (parsed.network !== network) throw new Error(`Co-signer ${index + 1}'s ${parsed.prefix} is for ${parsed.network}, but this multisig is set to ${network}.`);
     if (!hodlMultisigPrefixCompatible(parsed, kind)) throw new Error(parsed.scope === "singlesig" ? `Co-signer ${index + 1} uses a singlesig ${parsed.prefix}. Use a generic ${cr[network].x.pubName}, or the proper uppercase multisig export for this script type.` : `Co-signer ${index + 1}'s ${parsed.prefix} does not match the selected multisig script type.`);
-    let accountError = hodlMultisigAccountKeyError(parsed, kind, legacyStandard);
+    let accountError = hodlMultisigAccountKeyError(parsed, kind, purpose);
     if (accountError) throw new Error(`Co-signer ${index + 1}: ${accountError}`);
-    if (!parsed.origin) throw new Error(`Co-signer ${index + 1} needs a key origin so a signer can recognize this key. Paste ${hodlMultisigKeyPlaceholder(kind, network, legacyStandard)} as exported by the device.`);
+    if (!parsed.origin) throw new Error(`Co-signer ${index + 1} needs a key origin so a signer can recognize this key. Paste ${hodlMultisigKeyPlaceholder(kind, network, purpose)} as exported by the device.`);
+    purposeIndexes.push(hodlMultisigPurposeIndex(parsed.origin));
     let originError = hodlOriginMatchesParsedKey(parsed.origin, parsed);
     if (originError) throw new Error(`Co-signer ${index + 1}: ${originError}`);
-    let scriptOriginError = hodlOriginScriptError(parsed.origin, kind, network, legacyStandard);
+    let scriptOriginError = hodlOriginScriptError(parsed.origin, kind, network, purpose);
     if (scriptOriginError) throw new Error(`Co-signer ${index + 1}: ${scriptOriginError}`);
-    let accountNumber = hodlMultisigAccountNumber(parsed.origin, kind);
+    let accountNumber = hodlMultisigAccountNumber(parsed.origin, kind, purpose);
     if (accountNumber != null) accountNumbers.push(accountNumber);
     let node = parsed.node, canonical = hodlCanonicalMultisigKey(parsed);
     if (xpubs.includes(canonical)) throw new Error(`Co-signer ${index + 1} duplicates an earlier co-signer. Every slot must use a distinct extended public key.`);
@@ -6445,8 +6538,10 @@ function hodlValidatedMsigInputs() {
     xpubs.push(canonical);
     keyTokens.push(hodlMultisigKeyToken(parsed, network));
   }
+  let uniquePurposes = [...new Set(purposeIndexes)];
+  if (uniquePurposes.length !== 1 || uniquePurposes[0] !== purpose) throw new Error("Every co-signer purpose index must match the selected Purpose.");
   let accountSummary = hodlSummarizeMultisigAccounts(accountNumbers), accountWarning = hodlMultisigAccountWarning(accountSummary);
-  return { network, count, addressStart, n, m, kind, legacyStandard, nodes, xpubs, keyTokens, accountSummary, accountWarning };
+  return { network, count, addressStart, n, m, kind, purpose, legacyStandard, nodes, xpubs, keyTokens, accountSummary, accountWarning };
 }
 async function hodlBuildMsig(progress) {
   let error = document.getElementById("msig-error");
@@ -6459,6 +6554,7 @@ async function hodlBuildMsig(progress) {
       n,
       m,
       kind,
+      purpose,
       legacyStandard,
       nodes,
       xpubs,
@@ -6516,9 +6612,10 @@ async function hodlBuildMsig(progress) {
       m,
       n,
       script: kind,
+      purpose,
       sorted,
       scriptOrder: hodlMsigScriptOrder(keyTokens),
-      scriptStandard: kind === "p2tr" ? "bip86" : kind === "p2sh" ? legacyStandard : "bip48",
+      scriptStandard: legacyStandard,
       account: accountSummary.account,
       accountMixed: accountSummary.mixed,
       addressStart,
@@ -6549,10 +6646,10 @@ async function hodlBuildMsig(progress) {
 function hodlShowMsig() {
   if (!re || re.kind !== "msig") return;
   Ge = false;
-  let accountLabel = re.accountMixed ? " \xB7 Account Mixed" : re.account == null ? "" : ` \xB7 Account ${re.account}`, standardLabel = re.scriptStandard ? ` \xB7 ${re.scriptStandard.toUpperCase()}` : "", firstReceive = re.receive[0], firstIndex = firstReceive?.index ?? 0;
+  let accountLabel = re.accountMixed ? " \xB7 Account Mixed" : re.account == null ? "" : ` \xB7 Account ${re.account}`, purposeLabel = Number.isSafeInteger(re.purpose) ? ` \xB7 Purpose ${re.purpose}h` : "", firstReceive = re.receive[0], firstIndex = firstReceive?.index ?? 0;
   dr.innerHTML = `
     <section class="card account-result-card">
-      <div class="kicker">${re.m}-of-${re.n} multisig${standardLabel}${re.sorted===!1?" \xB7 listed order":""} \xB7 ${re.network}${accountLabel}</div>
+      <div class="kicker">${re.m}-of-${re.n} multisig${purposeLabel}${re.sorted===!1?" \xB7 listed order":""} \xB7 ${re.network}${accountLabel}</div>
       <h2 tabindex="-1">Your multisig receive wallet</h2>
       <p class="muted">Anyone can pay these addresses. Spending later needs ${re.m} signature${re.m===1?"":"s"} from the configured ${re.n} signing key${re.n===1?"":"s"}. This screen has no private keys.</p>
       ${hodlWalletMessages(re,"multisig")}
@@ -7765,6 +7862,7 @@ function hodlNewMsigState(name, msigId, msigNumber) {
       m: "2",
       n: "3",
       script: "p2wsh",
+      purpose: "48",
       legacyBip87: !1,
       keyOrder: "sorted",
       xpubs: ["", "", ""],
@@ -7779,7 +7877,7 @@ function hodlMsigStateNeedsClear(state) {
   let fields = state.fields || {},
     xpubs = Array.isArray(fields.xpubs) ? fields.xpubs : [];
   return Boolean(state.result) || String(state.error ?? "").length > 0 || xpubs.some(value => String(value ?? "").length > 0) ||
-    String(fields.m ?? "2") !== "2" || String(fields.n ?? "3") !== "3" || String(fields.script ?? "p2wsh") !== "p2wsh" || Boolean(fields.legacyBip87) || String(fields.keyOrder ?? "sorted") !== "sorted" || String(fields.network ?? "mainnet") !== "mainnet" || String(fields.addressStart ?? "0") !== "0" || String(fields.addressRange ?? fields.count ?? "5") !== "5"
+    String(fields.m ?? "2") !== "2" || String(fields.n ?? "3") !== "3" || String(fields.script ?? "p2wsh") !== "p2wsh" || String(fields.purpose ?? "48") !== "48" || Boolean(fields.legacyBip87) || String(fields.keyOrder ?? "sorted") !== "sorted" || String(fields.network ?? "mainnet") !== "mainnet" || String(fields.addressStart ?? "0") !== "0" || String(fields.addressRange ?? fields.count ?? "5") !== "5"
 }
 
 function hodlSyncMsigClearButton(capture = !1) {
@@ -7795,6 +7893,7 @@ function hodlCaptureMsig() {
   state.fields.n = document.getElementById("msig-n").value || "3";
   state.fields.m = document.getElementById("msig-m").value || "2";
   state.fields.script = hodlScriptKind();
+  state.fields.purpose = document.getElementById("msig-purpose")?.value || "48";
   state.fields.legacyBip87 = hodlSelectedLegacyMultisigStandard() === "bip87";
   state.fields.keyOrder = hodlMsigKeysSorted() ? "sorted" : "listed";
   hodlMergeMsigXpubs(state);
@@ -7817,8 +7916,9 @@ function hodlRestoreMsig() {
   }
   hodlSetMsigThresholds(state.fields.m || "2", state.fields.n || "3");
   let legacy = document.getElementById("msig-legacy-bip87");
-  if (legacy) legacy.checked = Boolean(state.fields.legacyBip87);
   hodlSyncSelect(document.getElementById("msig-script-type"), state.fields.script || "p2wsh");
+  hodlSetMsigPurpose(state.fields.purpose ?? (state.fields.legacyBip87 ? 87 : hodlStandardMsigPurpose(state.fields.script || "p2wsh")));
+  if (legacy) legacy.checked = hodlReadMsigPurpose(false) === 87;
   hodlUpdateMsigLegacyControls();
   state.fields.keyOrder = state.fields.keyOrder === "listed" ? "listed" : "sorted";
   hodlSyncSelect(document.getElementById("msig-key-order"), state.fields.keyOrder);

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -460,14 +460,18 @@ ec.innerHTML = `
       <div class="key-settings" id="key-settings">
         <div class="key-settings-row">
           <label class="field" id="script-type-field">Script type
-            <select id="script-type"><option value="bip44">Legacy \xB7 BIP44</option><option value="bip49">Nested SegWit \xB7 BIP49</option><option value="bip84" selected>Native SegWit \xB7 BIP84</option><option value="bip86">Taproot \xB7 BIP86</option></select>
+            <select id="script-type"><option value="bip44">Legacy</option><option value="bip49">Nested SegWit</option><option value="bip84" selected>Native SegWit</option><option value="bip86">Taproot</option></select>
           </label>
-          <label class="field network-field">Network
-            <select id="network"><option value="mainnet" selected>Bitcoin mainnet</option><option value="testnet">Testnet (practice)</option></select>
+          <label class="field" id="purpose-field">Purpose
+            <input id="purpose" type="number" min="0" max="2147483647" step="1" inputmode="numeric" value="84" aria-describedby="purpose-help">
+            <span class="field-note" id="purpose-help">Hardened purpose index \xB7 0 to 2,147,483,647</span>
           </label>
         </div>
         <div class="key-settings-row" id="account-address-settings">
-          <label class="field">Account
+          <label class="field network-field">Network
+            <select id="network"><option value="mainnet" selected>Bitcoin mainnet</option><option value="testnet">Testnet (practice)</option></select>
+          </label>
+          <label class="field" id="account-field">Account
             <input id="account" type="number" min="0" max="2147483647" step="1" inputmode="numeric" value="0" aria-describedby="account-help">
             <span class="field-note" id="account-help">Hardened account index \xB7 0 to 2,147,483,647</span>
           </label>
@@ -1086,34 +1090,34 @@ async function hodlAccountResultWithProgress(node, definition, network, count, o
   let change = await hodlAddressRowsWithProgress(node, accountPath, definition.script, network, count, "change", options.addressStart ?? 0, tracker);
   return hodlAccountResult(node, definition, network, count, { ...options, receive, change });
 }
-async function hodlRootWalletWithProgress(root, network, count, source, accountIndex, addressStart, tracker) {
+async function hodlRootWalletWithProgress(root, network, count, source, accountIndex, addressStart, tracker, purposeIndex) {
   let addressCount = Math.min(Math.max(count, 1), hodlMaxAddressRange), masterFingerprint = Us(root.fingerprint), accounts = [];
   tracker.setTotal(addressCount * To.length * 2);
   for (let definition of To) {
-    let accountPath = Ao(definition, network, accountIndex), node = root.derive(accountPath), originPath = `${definition.purpose}h/${Rs(network)}h/${accountIndex}h`;
-    accounts.push(await hodlAccountResultWithProgress(node, definition, network, addressCount, { accountPath, accountIndex, masterFingerprint, originFingerprint: masterFingerprint, originPath, addressStart }, tracker));
+    let derivedDefinition = { ...definition, purpose: purposeIndex }, accountPath = Ao(derivedDefinition, network, accountIndex), node = root.derive(accountPath), originPath = `${purposeIndex}h/${Rs(network)}h/${accountIndex}h`;
+    accounts.push(await hodlAccountResultWithProgress(node, derivedDefinition, network, addressCount, { accountPath, accountIndex, masterFingerprint, originFingerprint: masterFingerprint, originPath, addressStart }, tracker));
   }
   return hodlRootWalletResult(root, network, source, accountIndex, masterFingerprint, accounts);
 }
-async function hodlMnemonicWalletWithProgress(value, passphrase, network, count, source, accountIndex, addressStart, tracker) {
+async function hodlMnemonicWalletWithProgress(value, passphrase, network, count, source, accountIndex, addressStart, tracker, purposeIndex) {
   let validation = Mt(value);
   if (!validation.ok) throw new Error(validation.error ?? "Invalid seed phrase");
   let mnemonic = validation.words.join(" "), seed = wi(mnemonic, passphrase), root = Gt.fromMasterSeed(seed), entropyHex = source?.entropyHex ?? M.encode(Er(mnemonic, Ae)), warnings = [...source?.warnings ?? []];
   if (passphrase.length > 0) warnings.push("A passphrase is in use. The same words without this passphrase are a different wallet. Do not store the passphrase with the words.");
-  return hodlRootWalletWithProgress(root, network, count, { mnemonic, passphraseUsed: passphrase.length > 0, entropyHex, seedHex: M.encode(seed), notes: source?.notes ?? [], warnings }, accountIndex, addressStart, tracker);
+  return hodlRootWalletWithProgress(root, network, count, { mnemonic, passphraseUsed: passphrase.length > 0, entropyHex, seedHex: M.encode(seed), notes: source?.notes ?? [], warnings }, accountIndex, addressStart, tracker, purposeIndex);
 }
-async function hodlEntropyWalletWithProgress(entropy, passphrase, network, count, accountIndex, addressStart, tracker) {
-  return hodlMnemonicWalletWithProgress(_n(entropy.bytes), passphrase, network, count, { entropyHex: entropy.hex, notes: entropy.notes, warnings: entropy.warnings }, accountIndex, addressStart, tracker);
+async function hodlEntropyWalletWithProgress(entropy, passphrase, network, count, accountIndex, addressStart, tracker, purposeIndex) {
+  return hodlMnemonicWalletWithProgress(_n(entropy.bytes), passphrase, network, count, { entropyHex: entropy.hex, notes: entropy.notes, warnings: entropy.warnings }, accountIndex, addressStart, tracker, purposeIndex);
 }
-async function hodlImportedWalletWithProgress(value, network, count, accountIndex, addressStart, tracker) {
+async function hodlImportedWalletWithProgress(value, network, count, accountIndex, addressStart, tracker, purposeIndex) {
   let importedValue = String(value ?? "").trim(), parsed = uf(importedValue);
   if (parsed.scope !== "singlesig") throw new Error(`${parsed.prefix} is a multisig extended key. Use it in Multi Signature, not Key Derivation.`);
   if (parsed.network !== network) throw new Error(`This ${parsed.prefix} belongs to Bitcoin ${parsed.network}. Change Network to ${parsed.network} before deriving it.`);
   let node = parsed.node, notes = [parsed.isPrivate ? "Imported an extended private key. Addresses and WIF keys are derived from it." : "Imported an extended public key. This is watch-only: it can derive addresses but cannot spend."];
   if (node.depth === 0) {
-    if (!parsed.isPrivate) throw new Error("A root extended public key cannot derive the hardened BIP44/49/84/86 account paths. Import an account-level extended public key, or use the root xprv/tprv offline.");
+    if (!parsed.isPrivate) throw new Error("A root extended public key cannot derive hardened account paths. Import an account-level extended public key, or use the root xprv/tprv offline.");
     if (parsed.family !== "x") throw new Error("A BIP32 root private key must use the generic xprv/tprv prefix.");
-    return hodlRootWalletWithProgress(node, network, count, { mnemonic: null, passphraseUsed: false, entropyHex: null, seedHex: null, notes, warnings: [] }, accountIndex, addressStart, tracker);
+    return hodlRootWalletWithProgress(node, network, count, { mnemonic: null, passphraseUsed: false, entropyHex: null, seedHex: null, notes, warnings: [] }, accountIndex, addressStart, tracker, purposeIndex);
   }
   if (node.depth !== 3) throw new Error(`This extended key is depth ${node.depth}. Key Derivation accepts a BIP32 root private key (depth 0) or an account-level extended key (depth 3).`);
   let definition = hodlImportedScriptDefinition(parsed), addressCount = Math.min(Math.max(count, 1), hodlMaxAddressRange), parentFingerprint = Us(node.parentFingerprint), nodeFingerprint = Us(node.fingerprint);
@@ -1385,7 +1389,7 @@ function Qs(id) {
     </section>` : "";
   W("#acct").innerHTML = `
     <section class="card account-result-card">
-      <div class="kicker">${$t(account.def.bip)} \xB7 ${$t(re.network)}</div>
+      <div class="kicker">${$t(account.imported ? account.def.bip : `Purpose ${account.def.purpose}h`)} \xB7 ${$t(re.network)}</div>
       <h2>${$t(account.def.label)}</h2>
       <p class="muted">${$t(account.def.beginner)}</p>
       ${privateSection}
@@ -1675,7 +1679,7 @@ Oo = function(wallet, revealPrivate) {
     if (wallet.importedPrivateKey) lines.push("", `IMPORTED ${(wallet.importedPrivateLabel || "EXTENDED PRIVATE KEY").toUpperCase()}`, wallet.importedPrivateKey);
     for (let account of wallet.accounts) {
       if (!hodlAccountHasPrivate(account)) continue;
-      lines.push("", `-- ${account.def.label} (${account.def.bip}) PRIVATE ACCOUNT MATERIAL --`);
+      lines.push("", `-- ${account.def.label} (${account.imported ? account.def.bip : `Purpose ${account.def.purpose}h`}) PRIVATE ACCOUNT MATERIAL --`);
       if (account.primaryPrivate) lines.push(`${account.primaryPrivateLabel}: ${account.primaryPrivate}`);
       if (account.hasAlternateExport && account.genericPrivate) lines.push(`Advanced ${account.genericPrivateLabel} descriptor export: ${account.genericPrivate}`);
       if (account.receiveDescriptorPriv) lines.push(`Spending receive descriptor: ${account.receiveDescriptorPriv}`);
@@ -1700,7 +1704,7 @@ Oo = function(wallet, revealPrivate) {
   }
   if (wallet.importedPublicKey) lines.push(`Imported ${(wallet.importedPublicLabel || "extended public key").toUpperCase()}: ${wallet.importedPublicKey}`);
   for (let account of wallet.accounts) {
-    lines.push("", `=== ${account.def.label} (${account.def.bip}) ===`, account.def.beginner, `Network: ${wallet.network}`, `Account: ${account.imported ? "Imported account key" : account.accountIndex ?? 0}`, `Account path: ${hodlDisplayDerivationPath(account.accountPath)}`);
+    lines.push("", `=== ${account.def.label} (${account.imported ? account.def.bip : `Purpose ${account.def.purpose}h`}) ===`, account.def.beginner, `Network: ${wallet.network}`, `Account: ${account.imported ? "Imported account key" : account.accountIndex ?? 0}`, `Account path: ${hodlDisplayDerivationPath(account.accountPath)}`);
     if (account.masterFingerprint || wallet.masterFingerprint) lines.push(`Master fingerprint: ${account.masterFingerprint || wallet.masterFingerprint}`);
     else if (account.parentFingerprint) lines.push(`Encoded parent fingerprint (not a master fingerprint): ${account.parentFingerprint}`);
     if (!account.masterFingerprint && !wallet.masterFingerprint && account.nodeFingerprint) lines.push(`Imported key fingerprint (not a master fingerprint): ${account.nodeFingerprint}`);
@@ -1712,18 +1716,37 @@ Oo = function(wallet, revealPrivate) {
   }
   return lines.join("\n");
 };
-var hodlMaxAccount = 2147483647;
+var hodlMaxPurpose = 2147483647, hodlMaxAccount = 2147483647;
 function hodlScriptDefinition(id) {
   return To.find((definition) => definition.id === id) || To.find((definition) => definition.id === "bip84") || To[0];
+}
+function hodlReadPurpose(mark = true) {
+  let input = document.getElementById("purpose"), raw = String(input?.value ?? "").trim(), message = "Purpose must be a whole number from 0 to 2,147,483,647.";
+  let value = Number(raw), valid = /^\d+$/.test(raw) && Number.isSafeInteger(value) && value >= 0 && value <= hodlMaxPurpose;
+  if (mark) {
+    input?.classList.toggle("bad", !valid);
+    input?.setAttribute("aria-invalid", String(!valid));
+  }
+  if (!valid) throw new Error(message);
+  return value;
+}
+function hodlSetPurpose(value) {
+  let purpose = Number(value), input = document.getElementById("purpose");
+  if (!Number.isSafeInteger(purpose) || purpose < 0 || purpose > hodlMaxPurpose) purpose = 84;
+  if (input) input.value = String(purpose);
+  let state = hodlKeys[hodlActiveKey];
+  if (state) state.fields.purpose = String(purpose);
+  return purpose;
 }
 function hodlSelectedScriptType() {
   let value = document.getElementById("script-type")?.value || hodlAccountId || "bip84";
   return hodlScriptDefinition(value).id;
 }
-function hodlSetSelectedScriptType(value) {
-  let id = hodlScriptDefinition(value).id;
+function hodlSetSelectedScriptType(value, resetPurpose = false) {
+  let definition = hodlScriptDefinition(value), id = definition.id;
   hodlAccountId = id;
   hodlSyncSelect(document.getElementById("script-type"), id);
+  if (resetPurpose) hodlSetPurpose(definition.purpose);
   let state = hodlKeys[hodlActiveKey];
   if (state) {
     state.accountId = id;
@@ -1987,14 +2010,14 @@ function hodlImportedExtendedKeyDepth() {
 }
 function hodlUpdateKeyModeControls() {
   let singleKey = Ne === "key", settings = document.getElementById("key-settings");
-  ["passphrase-field", "master-fingerprint-preview", "script-type-field", "account-address-settings", "address-range-settings", "derivation-path-preview"].forEach((id) => {
+  ["passphrase-field", "master-fingerprint-preview", "script-type-field", "purpose-field", "account-field", "address-range-settings", "derivation-path-preview"].forEach((id) => {
     let element = document.getElementById(id);
     if (element) element.hidden = singleKey;
   });
   settings?.classList.toggle("single-key-mode", singleKey);
 }
 function hodlUpdateDerivationPathPreview() {
-  let panel = document.getElementById("derivation-path-preview"), list = panel?.querySelector(".derivation-path-list"), context = document.getElementById("derivation-path-context"), message = document.getElementById("derivation-path-error"), accountInput = document.getElementById("account");
+  let panel = document.getElementById("derivation-path-preview"), list = panel?.querySelector(".derivation-path-list"), context = document.getElementById("derivation-path-context"), message = document.getElementById("derivation-path-error"), purposeInput = document.getElementById("purpose"), accountInput = document.getElementById("account");
   if (!panel || !list || !context || !message) return;
   hodlUpdateKeyModeControls();
   let setPath = (name, value) => {
@@ -2017,6 +2040,8 @@ function hodlUpdateDerivationPathPreview() {
   };
   let definition = hodlScriptDefinition(hodlSelectedScriptType());
   if (Ne === "key") {
+    purposeInput?.classList.remove("bad");
+    purposeInput?.setAttribute("aria-invalid", "false");
     accountInput?.classList.remove("bad");
     accountInput?.setAttribute("aria-invalid", "false");
     context.textContent = "";
@@ -2024,7 +2049,14 @@ function hodlUpdateDerivationPathPreview() {
     panel.classList.remove("is-invalid");
     return;
   }
-  let account;
+  let purpose, account;
+  try {
+    purpose = hodlReadPurpose();
+  } catch (error) {
+    context.textContent = "Invalid purpose";
+    showMessage(error.message || "Invalid purpose.", true);
+    return;
+  }
   try {
     account = hodlReadAccount();
   } catch (error) {
@@ -2041,18 +2073,19 @@ function hodlUpdateDerivationPathPreview() {
     return;
   }
   let first = addressWindow.start, last = addressWindow.end, pathRange = (base) => first === last ? `${base}/${first}` : `${base}/${first} \u2192 ${base}/${last}`;
-  context.textContent = `${definition.label} \xB7 ${definition.bip}`;
   clearMessage();
   if ((hodlImportedExtendedKeyDepth() ?? 0) > 0) {
+    context.textContent = `${definition.label} \xB7 Imported account key`;
     setPath("account", "Imported key base");
     setPath("receive", pathRange("imported-key/0"));
     setPath("change", pathRange("imported-key/1"));
     message.hidden = false;
     message.classList.add("is-note");
-    message.textContent = `This non-root extended key is reused directly. Account ${account} cannot select a hardened sibling.`;
+    message.textContent = "This non-root extended key is reused directly. Purpose and Account cannot select a different hardened sibling.";
     return;
   }
-  let base = `m/${definition.purpose}h/${network === "mainnet" ? 0 : 1}h/${account}h`;
+  context.textContent = `${definition.label} \xB7 Purpose ${purpose}h`;
+  let base = `m/${purpose}h/${network === "mainnet" ? 0 : 1}h/${account}h`;
   setPath("account", base);
   setPath("receive", pathRange(`${base}/0`));
   setPath("change", pathRange(`${base}/1`));
@@ -2060,12 +2093,19 @@ function hodlUpdateDerivationPathPreview() {
 function hodlInitDerivationControls() {
   let panel = document.getElementById("calc-card");
   if (!panel) return;
+  let purposeInput = document.getElementById("purpose");
+  purposeInput?.addEventListener("keydown", (event) => {
+    if (["e", "E", "+", "-", "."].includes(event.key)) event.preventDefault();
+  });
+  purposeInput?.addEventListener("paste", (event) => {
+    if (!/^\d+$/.test(event.clipboardData?.getData("text") ?? "")) event.preventDefault();
+  });
   panel.addEventListener("input", (event) => {
     let target = event.target;
     if (!(target instanceof Element)) return;
-    if (["account", "address-start", "address-range"].includes(target.id)) {
+    if (["purpose", "account", "address-start", "address-range"].includes(target.id)) {
       let state = hodlKeys[hodlActiveKey];
-      if (state) state.fields[target.id === "account" ? "account" : target.id === "address-start" ? "addressStart" : "addressRange"] = target.value;
+      if (state) state.fields[target.id === "address-start" ? "addressStart" : target.id === "address-range" ? "addressRange" : target.id] = target.value;
       hodlInvalidateLiveKeyResult();
       let error = document.getElementById("error");
       if (error) error.textContent = "";
@@ -2078,9 +2118,9 @@ function hodlInitDerivationControls() {
     let target = event.target;
     if (!(target instanceof Element)) return;
     if (target.id === "script-type") {
-      let id = hodlSetSelectedScriptType(target.value);
+      let id = hodlSetSelectedScriptType(target.value, true), purpose = hodlReadPurpose(false);
       if (re?.kind === "hd") {
-        if (re.accounts.some((account) => account.def.id === id)) Qs(id);
+        if (re.accounts.some((account) => account.def.id === id && account.def.purpose === purpose)) Qs(id);
         else hodlInvalidateLiveKeyResult();
       }
       let seed = document.getElementById("seed");
@@ -5171,6 +5211,7 @@ function hodlPrivateKeyInputIsValid() {
 function hodlCanDeriveCurrentKey() {
   try {
     if (Ne !== "key") {
+      hodlReadPurpose();
       hodlReadAccount();
       hodlReadAddressWindow();
       let passphrase = document.getElementById("pass");
@@ -5400,7 +5441,7 @@ async function hodlCalculateKey(progress) {
   // recovery export.
   hodlWalletDatBirthday = "genesis";
   try {
-    let network = hodlSelectedNetwork(document.getElementById("network")), addressWindow = Ne === "key" ? { start: 0, range: 1 } : hodlReadAddressWindow(), count = addressWindow.range, addressStart = addressWindow.start, passphrase = document.getElementById("pass").value, scriptType = hodlSelectedScriptType(), account = Ne === "key" ? 0 : hodlReadAccount();
+    let network = hodlSelectedNetwork(document.getElementById("network")), addressWindow = Ne === "key" ? { start: 0, range: 1 } : hodlReadAddressWindow(), count = addressWindow.range, addressStart = addressWindow.start, passphrase = document.getElementById("pass").value, scriptType = hodlSelectedScriptType(), purpose = Ne === "key" ? 84 : hodlReadPurpose(), account = Ne === "key" ? 0 : hodlReadAccount();
     if (Ne !== "key" && hodlPassphraseBip39Enabled() && passphrase) {
       let passphraseAnalysis = hodlAnalyzeBip39Passphrase(passphrase);
       if (passphraseAnalysis.invalidRanges.length || passphraseAnalysis.incomplete || passphraseAnalysis.trailingSeparator) throw new Error("Correct the highlighted BIP39-word passphrase inconsistencies before deriving.");
@@ -5432,7 +5473,7 @@ async function hodlCalculateKey(progress) {
         re = await hodlMnemonicWalletWithProgress(phrase, passphrase, network, count, {
           notes,
           warnings: parsed.warnings
-        }, account, addressStart, progress)
+        }, account, addressStart, progress, purpose)
       } else if (ge === "bitbox") {
         let parsed = hodlBitBoxRolls(document.getElementById("dice").value, Pt);
         if (parsed.leftover) throw new Error(`Invalid characters: ${parsed.leftover}`);
@@ -5441,30 +5482,30 @@ async function hodlCalculateKey(progress) {
         if (!ft || !possible?.candidates.includes(ft)) throw new Error(`Choose one of the ${hodlSeedConfig().candidates} valid final checksum words before deriving the wallet.`);
         let phrase = [...parsed.words, ft].join(" "), validation = hodlValidateTargetMnemonic(phrase, Pt);
         if (!validation.ok) throw new Error(validation.error);
-        re = await hodlMnemonicWalletWithProgress(phrase, passphrase, network, count, { notes: parsed.notes, warnings: parsed.warnings }, account, addressStart, progress);
+        re = await hodlMnemonicWalletWithProgress(phrase, passphrase, network, count, { notes: parsed.notes, warnings: parsed.warnings }, account, addressStart, progress, purpose);
       } else {
         let diceValue = document.getElementById("dice").value;
         if (hodlAnalyzeDiceInput(diceValue, ge, Pt).coinDerivedCount) throw new Error("Coin-button digits are entropy-equivalent only in BitBox mode. Clear them and enter fair die rolls for this conversion method.");
         let entropy = hodlDiceEntropy(diceValue, ge, Pt);
         if (!entropy.ok) throw new Error(entropy.error);
-        re = await hodlEntropyWalletWithProgress(entropy, passphrase, network, count, account, addressStart, progress);
+        re = await hodlEntropyWalletWithProgress(entropy, passphrase, network, count, account, addressStart, progress, purpose);
       }
     } else if (Ne === "cards") {
       let entropy = hodlSelectedCardsEntropy(Pt);
       if (!entropy.ok) throw new Error(entropy.error);
-      re = await hodlEntropyWalletWithProgress(entropy, passphrase, network, count, account, addressStart, progress);
+      re = await hodlEntropyWalletWithProgress(entropy, passphrase, network, count, account, addressStart, progress, purpose);
     } else if (Ne === "hex") {
       let entropy = hodlSelectedEntropy();
       if (!entropy.ok) throw new Error(entropy.error);
-      re = await hodlEntropyWalletWithProgress(entropy, passphrase, network, count, account, addressStart, progress);
+      re = await hodlEntropyWalletWithProgress(entropy, passphrase, network, count, account, addressStart, progress, purpose);
     } else if (Ne === "seed") {
       let selected = hodlSelectedSeedInput(Pt), value = selected.value;
-      if (selected.extended) re = await hodlImportedWalletWithProgress(value, network, count, account, addressStart, progress);
+      if (selected.extended) re = await hodlImportedWalletWithProgress(value, network, count, account, addressStart, progress, purpose);
       else {
         if (hodlSeedMethod === "numbers" && !selected.parsed?.complete) throw new Error(selected.parsed?.invalidEntries.length ? `Word numbers must be between ${selected.parsed.minimum} and ${selected.parsed.maximum}.` : selected.parsed?.extraEntries.length ? `Enter exactly ${Pt} BIP39 word numbers.` : selected.parsed?.checksumInvalid ? "The entered word numbers do not have a valid BIP39 checksum." : `Enter exactly ${Pt} BIP39 word numbers before deriving the wallet.`);
         let validation = hodlValidateTargetMnemonic(value, Pt);
         if (!validation.ok) throw new Error(validation.error);
-        re = await hodlMnemonicWalletWithProgress(validation.words.join(" "), passphrase, network, count, void 0, account, addressStart, progress);
+        re = await hodlMnemonicWalletWithProgress(validation.words.join(" "), passphrase, network, count, void 0, account, addressStart, progress, purpose);
       }
     } else {
       let value = document.getElementById("key").value, kind = hodlNormalizePrivateKeyKind(document.querySelector("input[name=kk]:checked")?.value, value);
@@ -7291,7 +7332,7 @@ function hodlPrivateKeyValues(fields) {
 }
 function hodlNewKeyState(name, keyId, keyNumber) {
   let id = keyId ?? hodlNextKeyId++, number = keyNumber ?? hodlNextKeyNumber++;
-  return { id, number, color: hodlKeyColor(id), name: name || hodlDefaultKeyName(number), mode: "dice", diceMethod: "coldcard", cardMethod: "hashed", seedMethod: "words", seedZeroIndexed: false, cardColemanSymbols: false, entropyFormat: "bin", syncNumberBases: false, numberBaseSyncSource: "", numberBasesSynced: false, seedAutocomplete: false, passphraseBip39Words: false, brainWalletTrim: false, showCards: false, showDiceFairness: false, targetWords: 24, diceCoinPositions: [], lastWord: "", dplusLastWord: "", result: null, reveal: false, accountId: "bip84", error: "", fields: { pass: "", script: "bip84", network: "mainnet", account: "0", addressStart: "0", addressRange: "5", dice: "", dplusDice: "", hex: "", bin: "", base4: "", base8: "", base32: "", base64: "", cards: "", directCards: "", seed: "", seedNumbers: "", key: "", keyKind: "wif", privateKeys: { wif: "", "hex-key": "", minikey: "", brain: "" } } };
+  return { id, number, color: hodlKeyColor(id), name: name || hodlDefaultKeyName(number), mode: "dice", diceMethod: "coldcard", cardMethod: "hashed", seedMethod: "words", seedZeroIndexed: false, cardColemanSymbols: false, entropyFormat: "bin", syncNumberBases: false, numberBaseSyncSource: "", numberBasesSynced: false, seedAutocomplete: false, passphraseBip39Words: false, brainWalletTrim: false, showCards: false, showDiceFairness: false, targetWords: 24, diceCoinPositions: [], lastWord: "", dplusLastWord: "", result: null, reveal: false, accountId: "bip84", error: "", fields: { pass: "", script: "bip84", purpose: "84", network: "mainnet", account: "0", addressStart: "0", addressRange: "5", dice: "", dplusDice: "", hex: "", bin: "", base4: "", base8: "", base32: "", base64: "", cards: "", directCards: "", seed: "", seedNumbers: "", key: "", keyKind: "wif", privateKeys: { wif: "", "hex-key": "", minikey: "", brain: "" } } };
 }
 function hodlRestoreFormFields(state) {
   if (!state) return;
@@ -7341,7 +7382,7 @@ function hodlSetMode(mode) {
 function hodlKeyStateNeedsClear(state) {
   if (!state) return false;
   let fields = state.fields || {}, privateKeys = hodlPrivateKeyValues(fields), hasText = (id) => String(fields[id] ?? "").length > 0;
-  return String(state.mode ?? "dice") !== "dice" || String(state.diceMethod ?? "coldcard") !== "coldcard" || String(state.cardMethod ?? "hashed") !== "hashed" || String(state.seedMethod ?? "words") !== "words" || Boolean(state.seedZeroIndexed) || Boolean(state.cardColemanSymbols) || String(state.entropyFormat ?? "bin") !== "bin" || Boolean(state.syncNumberBases) || Boolean(state.seedAutocomplete) || Boolean(state.passphraseBip39Words) || Boolean(state.brainWalletTrim) || Boolean(state.showCards) || Boolean(state.showDiceFairness) || Number(state.targetWords ?? 24) !== 24 || Array.isArray(state.diceCoinPositions) && state.diceCoinPositions.length > 0 || String(state.lastWord ?? "").length > 0 || String(state.dplusLastWord ?? "").length > 0 || Boolean(state.result) || Boolean(state.reveal) || String(state.error ?? "").length > 0 || String(state.accountId ?? "bip84") !== "bip84" || String(fields.script ?? "bip84") !== "bip84" || String(fields.network ?? "mainnet") !== "mainnet" || String(fields.account ?? "0") !== "0" || String(fields.addressStart ?? "0") !== "0" || String(fields.addressRange ?? fields.count ?? "5") !== "5" || hodlNormalizePrivateKeyKind(fields.keyKind, privateKeys[fields.keyKind] || "") !== "wif" || ["pass", "dice", "dplusDice", "hex", "bin", "base4", "base8", "base32", "base64", "cards", "directCards", "seed", "seedNumbers", "key"].some(hasText) || hodlPrivateKeyKinds.some((kind) => privateKeys[kind].length > 0);
+  return String(state.mode ?? "dice") !== "dice" || String(state.diceMethod ?? "coldcard") !== "coldcard" || String(state.cardMethod ?? "hashed") !== "hashed" || String(state.seedMethod ?? "words") !== "words" || Boolean(state.seedZeroIndexed) || Boolean(state.cardColemanSymbols) || String(state.entropyFormat ?? "bin") !== "bin" || Boolean(state.syncNumberBases) || Boolean(state.seedAutocomplete) || Boolean(state.passphraseBip39Words) || Boolean(state.brainWalletTrim) || Boolean(state.showCards) || Boolean(state.showDiceFairness) || Number(state.targetWords ?? 24) !== 24 || Array.isArray(state.diceCoinPositions) && state.diceCoinPositions.length > 0 || String(state.lastWord ?? "").length > 0 || String(state.dplusLastWord ?? "").length > 0 || Boolean(state.result) || Boolean(state.reveal) || String(state.error ?? "").length > 0 || String(state.accountId ?? "bip84") !== "bip84" || String(fields.script ?? "bip84") !== "bip84" || String(fields.purpose ?? "84") !== "84" || String(fields.network ?? "mainnet") !== "mainnet" || String(fields.account ?? "0") !== "0" || String(fields.addressStart ?? "0") !== "0" || String(fields.addressRange ?? fields.count ?? "5") !== "5" || hodlNormalizePrivateKeyKind(fields.keyKind, privateKeys[fields.keyKind] || "") !== "wif" || ["pass", "dice", "dplusDice", "hex", "bin", "base4", "base8", "base32", "base64", "cards", "directCards", "seed", "seedNumbers", "key"].some(hasText) || hodlPrivateKeyKinds.some((kind) => privateKeys[kind].length > 0);
 }
 function hodlSyncKeyClearButton(capture = false) {
   if (capture) hodlCaptureKey();
@@ -7387,7 +7428,7 @@ function hodlCaptureKey() {
   state.accountId = hodlSelectedScriptType();
   state.fields.script = state.accountId;
   state.error = document.getElementById("error")?.textContent || "";
-  ["pass", "account", "address-start", "address-range", "hex", "bin", "base4", "base8", "base32", "base64", "seed", "cards"].forEach((id) => {
+  ["pass", "purpose", "account", "address-start", "address-range", "hex", "bin", "base4", "base8", "base32", "base64", "seed", "cards"].forEach((id) => {
     let el = document.getElementById(id);
     if (el) state.fields[id === "address-start" ? "addressStart" : id === "address-range" ? "addressRange" : id] = el.value;
   });
@@ -7439,6 +7480,7 @@ function hodlRestoreKey() {
       hodlRenderPassphraseInputState(pass2, false);
     }
     hodlSyncSelect(document.getElementById("script-type"), "bip84");
+    hodlSetPurpose(84);
     hodlSyncSelect(document.getElementById("network"), "mainnet");
     let account2 = document.getElementById("account");
     if (account2) account2.value = "0";
@@ -7478,6 +7520,7 @@ function hodlRestoreKey() {
   }
   hodlAccountId = state.accountId || state.fields.script || "bip84";
   hodlSyncSelect(document.getElementById("script-type"), hodlAccountId);
+  hodlSetPurpose(state.fields.purpose ?? hodlScriptDefinition(hodlAccountId).purpose);
   state.fields.network = state.fields.network === "testnet" ? "testnet" : "mainnet";
   hodlSyncSelect(document.getElementById("network"), state.fields.network);
   let account = document.getElementById("account");

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -8,7 +8,7 @@ import { createBase58check as fi, hex as M } from "@scure/base";
 import { HDKey as Gt } from "@scure/bip32";
 import { entropyToMnemonic as bi, mnemonicToEntropy as Er, mnemonicToSeedSync as wi, validateMnemonic as Pn } from "@scure/bip39";
 import { wordlist as bip39English } from "@scure/bip39/wordlists/english.js";
-import { NETWORK as Ie, OutScript as Oe, TEST_NETWORK as mo, p2pkh as ir, p2sh as Jr, p2tr as en, p2wpkh as Tt, utils as bitcoinUtils } from "@scure/btc-signer";
+import { Address as hodlBitcoinAddress, NETWORK as Ie, OutScript as Oe, TEST_NETWORK as mo, p2pkh as ir, p2sh as Jr, p2tr as en, p2wpkh as Tt, utils as bitcoinUtils } from "@scure/btc-signer";
 import { renderSVG as Xs } from "uqr";
 const Ae = Object.freeze(bip39English);
 const tr = Z;
@@ -6499,7 +6499,7 @@ function hodlMsigAddr(pubkeys, m, network, kind, sorted = !0) {
   });
   if (kind === "p2wsh") {
     let hash = tr(ms);
-    return { address: or(net).encode({ type: "wsh", hash }), scriptHex: M.encode(ms), kind };
+    return { address: hodlBitcoinAddress(net).encode({ type: "wsh", hash }), scriptHex: M.encode(ms), kind };
   }
   if (kind === "p2sh-p2wsh") {
     let hash = tr(ms);
@@ -6871,7 +6871,7 @@ function hodlSats(number) {
 }
 function hodlAddr(script, network) {
   try {
-    return or(_s(network)).encode(Oe.decode(script));
+    return hodlBitcoinAddress(_s(network)).encode(Oe.decode(script));
   } catch {
     return "script " + M.encode(script);
   }

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -1189,7 +1189,10 @@
     const deriveCustomMultisig = await until(() => !document.getElementById("msig-go").disabled && document.getElementById("msig-go"), "custom-purpose multisig derive button");
     deriveCustomMultisig.click();
     await until(() => document.getElementById("out").textContent.includes("Purpose 69420h") || document.getElementById("msig-error").textContent, "custom-purpose multisig result");
-    assert(!document.getElementById("msig-error").textContent, "Custom-purpose multisig derivation failed");
+    assert(
+      !document.getElementById("msig-error").textContent,
+      `Custom-purpose multisig derivation failed: ${document.getElementById("msig-error").textContent}`,
+    );
     assert(document.getElementById("out").textContent.includes("/69420h/1h/0h/2h"), "Custom multisig purpose was not preserved in the descriptor origin");
 
     document.querySelector('#workspace [data-workspace="calc"]').click();

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -1104,6 +1104,9 @@
   });
 
   await test("Legacy key derivation exports BIP87 and can derive a 1-of-1 Legacy BIP87 wallet", async () => {
+    const legacyTab = [...document.querySelectorAll("#acct-tabs button")].find((button) => button.textContent.includes("Legacy"));
+    assert(legacyTab, "Legacy account tab is missing");
+    legacyTab.click();
     const exportRow = [...document.querySelectorAll("#acct p")].find((row) =>
       row.textContent.includes("Legacy · BIP87 · Account 0")
     );

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -986,6 +986,20 @@
     const scriptType = document.getElementById("script-type");
     scriptType.value = "bip44";
     scriptType.dispatchEvent(new Event("change", { bubbles: true }));
+    const purpose = document.getElementById("purpose");
+    equal(purpose.value, "44", "Legacy did not restore its standard purpose");
+    scriptType.value = "bip49";
+    scriptType.dispatchEvent(new Event("change", { bubbles: true }));
+    equal(purpose.value, "49", "Nested SegWit did not restore its standard purpose");
+    scriptType.value = "bip86";
+    scriptType.dispatchEvent(new Event("change", { bubbles: true }));
+    equal(purpose.value, "86", "Taproot did not restore its standard purpose");
+    scriptType.value = "bip84";
+    scriptType.dispatchEvent(new Event("change", { bubbles: true }));
+    equal(purpose.value, "84", "Native SegWit did not restore its standard purpose");
+    input(purpose, "2147483648");
+    assert(document.getElementById("go").disabled && purpose.classList.contains("bad"), "An out-of-range purpose did not block derivation");
+    input(purpose, "69420");
     const network = document.getElementById("network");
     assert(network && [...network.options].some((option) => option.value === "testnet"), "Network selector is missing or has no testnet option");
     network.value = "testnet";
@@ -1003,6 +1017,10 @@
     const receiveLead = document.querySelector("#acct .account-address-lead");
     assert(receiveLead?.querySelector("h4")?.textContent.includes("#7"), "The first requested address was not used for the receive QR");
     assert(receiveLead?.querySelector('.qr[aria-label="Receive address 7 QR code"]'), "The receive QR did not use the starting address index");
+    equal(receiveLead?.querySelector("p.mono:not(.muted)")?.textContent.trim(), "tb1qq88mz59zeavyc2nvncjmr5fnyhy9wfgg7spmjf", "The custom-purpose Native SegWit address did not match the independent BIP32 vector");
+    assert(receiveLead?.querySelector(".muted.mono")?.textContent.includes("m/69420h/1h/0h/0/7"), "The custom purpose was not used in the displayed address path");
+    assert(document.querySelector("#acct .kicker")?.textContent.includes("Purpose 69420h"), "The result mislabeled the custom purpose as a standard BIP");
+    assert(document.querySelector("#acct .account-watch-section")?.textContent.includes("/69420h/1h/0h]"), "The custom purpose was not used in the descriptor origin");
     const receiveRows = document.querySelectorAll('#acct [data-address-table="hd-receive"] tbody tr');
     equal(receiveRows.length, 5, "The requested receive address range was not rendered");
     equal(receiveRows[0].querySelector("th")?.textContent.trim(), "7", "The receive table did not start at the requested index");
@@ -1166,6 +1184,7 @@
     const text = await blob.text();
     assert(state.downloadName === "bitcoin-recovery-sheet.txt", "Unexpected filename");
     assert(text.includes(versionHeader) && text.includes("Network: testnet"), "Export headers are missing");
+    assert(text.includes("Native SegWit (Purpose 69420h)") && text.includes("m/69420h/1h/0h"), "The recovery sheet omitted the custom purpose");
     assert(text.includes("PRIVATE RECOVERY MATERIAL OMITTED"), "Omission notice is missing");
     assert(!text.includes("YOUR SEED PHRASE") && !text.includes("MASTER SEED HEX") && !text.includes("BIP32 ROOT TPRV"), "Watch-only export leaked private data");
 

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -1103,7 +1103,7 @@
     equal(multisigDerive.title === "A derivation is already running.", false, "The multisig derive button kept its busy hint after the run");
   });
 
-  await test("Legacy key derivation exports BIP87 and can derive a 1-of-1 Legacy BIP87 wallet", async () => {
+  await test("multisig purpose follows standard selections, detects origins, and accepts a custom index", async () => {
     const legacyTab = [...document.querySelectorAll("#acct-tabs button")].find((button) => button.textContent.includes("Legacy"));
     assert(legacyTab, "Legacy account tab is missing");
     legacyTab.click();
@@ -1126,12 +1126,16 @@
     document.querySelector('#workspace [data-workspace="msig"]').click();
     await until(() => !document.getElementById("msig-card").hidden, "multisig workspace");
     const multisigScript = document.getElementById("msig-script-type");
+    const multisigPurpose = document.getElementById("msig-purpose");
+    equal(multisigPurpose.value, "48", "Native SegWit multisig did not default to purpose 48");
     multisigScript.value = "p2sh";
     multisigScript.dispatchEvent(new Event("change", { bubbles: true }));
+    equal(multisigPurpose.value, "45", "Legacy multisig did not default to purpose 45");
     const bip87Toggle = document.getElementById("msig-legacy-bip87");
     assert(!document.getElementById("msig-legacy-account-toggle").hidden, "BIP87 option stayed hidden for Legacy");
     bip87Toggle.checked = true;
     bip87Toggle.dispatchEvent(new Event("change", { bubbles: true }));
+    equal(multisigPurpose.value, "87", "The BIP87 shortcut did not select purpose 87");
     const multisigNetwork = document.getElementById("msig-network");
     multisigNetwork.value = "testnet";
     multisigNetwork.dispatchEvent(new Event("change", { bubbles: true }));
@@ -1148,9 +1152,10 @@
     input(document.getElementById("msig-x-1"), bip48Export);
     equal(multisigScript.value, "mixed");
     assert(
-      document.getElementById("msig-script-warning").textContent.includes("cannot be combined here with BIP48 keys"),
-      "BIP87 and BIP48 keys did not show an explicit incompatibility",
+      document.getElementById("msig-script-warning").textContent.includes("different script types"),
+      "Legacy and Native SegWit keys did not show an explicit incompatibility",
     );
+    assert(document.getElementById("msig-purpose-warning").textContent.includes("do not match"), "Mixed co-signer purposes did not show a warning");
     input(document.getElementById("msig-x-1"), "");
     input(document.getElementById("msig-n-number"), "1");
     equal(document.getElementById("msig-m").value, "1");
@@ -1168,12 +1173,23 @@
     equal(multisigProgress.getAttribute("aria-valuenow"), "100", "Multisig progress did not reach 100%");
     assert(multisigProgress.querySelector(".derive-progress-label")?.textContent.includes("Done"), "Completed multisig progress did not show Done");
     const resultText = document.getElementById("out").textContent;
-    assert(resultText.includes("1-of-1 multisig · BIP87"), "Result did not identify the 1-of-1 BIP87 policy");
+    assert(resultText.includes("1-of-1 multisig · Purpose 87h"), "Result did not identify purpose 87 separately from script type");
     assert(resultText.includes("/87h/1h/0h") && resultText.includes("/<0;1>/*"), "BIP87 wallet descriptor paths are wrong");
     assert(resultText.includes("Receive address #11"), "The multisig receive QR did not use the starting address index");
     const multisigReceiveRows = document.querySelectorAll('#out [data-address-table="msig-receive"] tbody tr');
     equal(multisigReceiveRows.length, 5, "The requested multisig receive address range was not rendered");
     equal(multisigReceiveRows[0].querySelector("th")?.textContent.trim(), "11", "The multisig receive table did not start at the requested index");
+
+    multisigScript.value = "p2wsh";
+    multisigScript.dispatchEvent(new Event("change", { bubbles: true }));
+    equal(multisigPurpose.value, "48", "Native SegWit did not restore its standard multisig purpose");
+    input(document.getElementById("msig-x-0"), bip48Export.replace("/48h/", "/69420h/"));
+    equal(multisigPurpose.value, "69420", "A custom co-signer purpose was not auto-detected");
+    const deriveCustomMultisig = await until(() => !document.getElementById("msig-go").disabled && document.getElementById("msig-go"), "custom-purpose multisig derive button");
+    deriveCustomMultisig.click();
+    await until(() => document.getElementById("out").textContent.includes("Purpose 69420h") || document.getElementById("msig-error").textContent, "custom-purpose multisig result");
+    assert(!document.getElementById("msig-error").textContent, "Custom-purpose multisig derivation failed");
+    assert(document.getElementById("out").textContent.includes("/69420h/1h/0h/2h"), "Custom multisig purpose was not preserved in the descriptor origin");
 
     document.querySelector('#workspace [data-workspace="calc"]').click();
     await until(() => !document.getElementById("calc-card").hidden, "key workspace");

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -1180,6 +1180,7 @@
     equal(multisigReceiveRows.length, 5, "The requested multisig receive address range was not rendered");
     equal(multisigReceiveRows[0].querySelector("th")?.textContent.trim(), "11", "The multisig receive table did not start at the requested index");
 
+    input(document.getElementById("msig-x-0"), "");
     multisigScript.value = "p2wsh";
     multisigScript.dispatchEvent(new Event("change", { bubbles: true }));
     equal(multisigPurpose.value, "48", "Native SegWit did not restore its standard multisig purpose");

--- a/test/descriptor.test.mjs
+++ b/test/descriptor.test.mjs
@@ -66,7 +66,7 @@ function loadSlice(startNeedle, endNeedle, extra) {
 const originPath = loadSlice(
   "function hodlFilterXpub",
   "function hodlParseMultisigCosigner",
-  "export { hodlFilterXpub, hodlNormalizeOriginPath, hodlParseKeyOrigin, hodlOriginPathIndexes, hodlOriginMatchesParsedKey, hodlMultisigDerivationStandard, hodlOriginScriptError, hodlMultisigAccountNumber, hodlSummarizeMultisigAccounts, hodlMultisigAccountWarning, hodlMultisigOriginScriptKind, hodlMultisigScriptEvidence, hodlSummarizeMultisigScriptKinds };",
+  "const hodlMaxPurpose = 2147483647;\nexport { hodlFilterXpub, hodlNormalizeOriginPath, hodlParseKeyOrigin, hodlOriginPathIndexes, hodlOriginMatchesParsedKey, hodlMultisigPurposeIndex, hodlOriginScriptError, hodlMultisigAccountNumber, hodlSummarizeMultisigAccounts, hodlMultisigAccountWarning, hodlMultisigOriginScriptKind, hodlMultisigScriptEvidence, hodlSummarizeMultisigScriptKinds };",
 );
 const {
   hodlFilterXpub,
@@ -74,7 +74,7 @@ const {
   hodlParseKeyOrigin,
   hodlOriginPathIndexes,
   hodlOriginMatchesParsedKey,
-  hodlMultisigDerivationStandard,
+  hodlMultisigPurposeIndex,
   hodlOriginScriptError,
   hodlMultisigAccountNumber,
   hodlSummarizeMultisigAccounts,
@@ -131,40 +131,36 @@ test("origin path must match key depth and script", () => {
   const mock = { depth: 4, childNumber: 0x80000002 };
   assert.equal(hodlOriginMatchesParsedKey(origin, mock), "");
   assert.match(hodlOriginMatchesParsedKey({ fingerprint: "73c5da0a", path: "48h/1h/0h" }, mock), /steps/);
-  assert.equal(hodlOriginScriptError(origin, "p2wsh", "testnet"), "");
-  assert.equal(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "48h/0h/0h/2h" }, "p2wsh", "mainnet"), "");
-  assert.match(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "48h/0h/0h/2h" }, "p2wsh", "testnet"), /1h/);
+  assert.equal(hodlOriginScriptError(origin, "p2wsh", "testnet", 48), "");
+  assert.equal(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "48h/0h/0h/2h" }, "p2wsh", "mainnet", 48), "");
+  assert.match(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "48h/0h/0h/2h" }, "p2wsh", "testnet", 48), /1h/);
   assert.equal(hodlOriginMatchesParsedKey({ fingerprint: "73c5da0a", path: "45h" }, { depth: 1, childNumber: 0x8000002d }), "");
-  assert.equal(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "45h" }, "p2sh", "mainnet"), "");
-  assert.match(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "45h/0" }, "p2sh", "mainnet"), /purpose origin/);
+  assert.equal(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "45h" }, "p2sh", "mainnet", 45), "");
+  assert.match(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "45h/0" }, "p2sh", "mainnet", 45), /without an account/);
   const bip87 = { fingerprint: "73c5da0a", path: "87h/0h/7h" };
   assert.equal(hodlOriginMatchesParsedKey(bip87, { depth: 3, childNumber: 0x80000007 }), "");
   assert.match(
-    hodlOriginScriptError({ fingerprint: "73c5da0a", path: "45h" }, "p2sh", "mainnet", "bip87"),
+    hodlOriginScriptError({ fingerprint: "73c5da0a", path: "45h" }, "p2sh", "mainnet", 87),
     /87h/,
   );
-  assert.equal(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "86h/0h/0h" }, "p2tr", "mainnet"), "");
-  assert.match(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "48h/0h/0h/3h" }, "p2tr", "mainnet"), /86h/);
-  assert.match(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "84h/0h/0h" }, "p2tr", "mainnet"), /86h/);
-  assert.match(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "48h/0h/0h/2h" }, "p2tr", "mainnet"), /86h/);
-  assert.match(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "44h/0h/0h" }, "p2tr", "mainnet"), /86h/);
-  assert.match(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "45h" }, "p2tr", "mainnet"), /86h/);
-  assert.match(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "87h/0h/0h" }, "p2tr", "mainnet"), /86h/);
-  assert.match(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "86h/0h/0h/0h" }, "p2tr", "mainnet"), /86h\/coin\/account/);
-  assert.match(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "86h/1h/0h" }, "p2tr", "mainnet"), /0h/);
+  assert.equal(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "86h/0h/0h" }, "p2tr", "mainnet", 86), "");
+  assert.equal(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "69420h/0h/0h" }, "p2tr", "mainnet", 69420), "");
+  assert.match(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "84h/0h/0h" }, "p2tr", "mainnet", 86), /selected Purpose is 86h/);
+  assert.match(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "86h/0h/0h/0h" }, "p2tr", "mainnet", 86), /purposeh\/coinh\/accounth/);
+  assert.match(hodlOriginScriptError({ fingerprint: "73c5da0a", path: "86h/1h/0h" }, "p2tr", "mainnet", 86), /0h/);
   assert.equal(hodlOriginPathIndexes("48h/1h/0h/2h").at(-1), 0x80000002);
 });
 test("multisig account is derived from BIP48 and BIP87 origins", () => {
-  assert.equal(hodlMultisigAccountNumber({ path: "48h/0h/7h/2h" }, "p2wsh"), 7);
-  assert.equal(hodlMultisigAccountNumber({ path: "48h/0h/3h/1h" }, "p2sh-p2wsh"), 3);
-  assert.equal(hodlMultisigAccountNumber({ path: "87h/0h/9h" }, "p2sh"), 9);
-  assert.equal(hodlMultisigAccountNumber({ path: "86h/0h/4h" }, "p2tr"), 4);
-  assert.equal(hodlMultisigAccountNumber({ path: "45h" }, "p2sh"), null);
+  assert.equal(hodlMultisigAccountNumber({ path: "48h/0h/7h/2h" }, "p2wsh", 48), 7);
+  assert.equal(hodlMultisigAccountNumber({ path: "48h/0h/3h/1h" }, "p2sh-p2wsh", 48), 3);
+  assert.equal(hodlMultisigAccountNumber({ path: "87h/0h/9h" }, "p2sh", 87), 9);
+  assert.equal(hodlMultisigAccountNumber({ path: "86h/0h/4h" }, "p2tr", 86), 4);
+  assert.equal(hodlMultisigAccountNumber({ path: "45h" }, "p2sh", 45), null);
   assert.throws(
-    () => hodlMultisigAccountNumber({ path: "48h/0h/7/2h" }, "p2wsh"),
+    () => hodlMultisigAccountNumber({ path: "48h/0h/7/2h" }, "p2wsh", 48),
     /must be hardened/,
   );
-  assert.match(hodlOriginScriptError({ path: "48h/0h/7/2h" }, "p2wsh", "mainnet"), /must be hardened/);
+  assert.match(hodlOriginScriptError({ path: "48h/0h/7/2h" }, "p2wsh", "mainnet", 48), /must be hardened/);
 });
 
 test("multisig account summary reports mismatched accounts as mixed", () => {
@@ -179,28 +175,27 @@ test("multisig account summary reports mismatched accounts as mixed", () => {
 
 test("multisig script type is inferred from SLIP-132 prefixes and key origins", () => {
   assert.equal(hodlMultisigOriginScriptKind({ path: "45h" }), "p2sh");
-  assert.equal(hodlMultisigOriginScriptKind({ path: "87h/0h/0h" }), null);
+  assert.equal(hodlMultisigOriginScriptKind({ path: "87h/0h/0h" }), "p2sh");
   assert.equal(hodlMultisigOriginScriptKind({ path: "48h/0h/0h/1h" }), "p2sh-p2wsh");
   assert.equal(hodlMultisigOriginScriptKind({ path: "48h/0h/0h/2h" }), "p2wsh");
   assert.equal(hodlMultisigOriginScriptKind({ path: "86h/0h/0h" }), "p2tr");
   assert.equal(hodlMultisigOriginScriptKind({ path: "48h/0h/0h/3h" }), null);
   assert.equal(hodlMultisigOriginScriptKind({ path: "84h/0h/0h" }), null);
-  assert.equal(hodlMultisigDerivationStandard({ path: "45h" }), "bip45");
-  assert.equal(hodlMultisigDerivationStandard({ path: "86h/0h/0h" }), "bip86");
-  assert.equal(hodlMultisigDerivationStandard({ path: "87h/0h/0h" }), "bip87");
-  assert.equal(hodlMultisigDerivationStandard({ path: "48h/0h/0h/2h" }), "bip48");
+  assert.equal(hodlMultisigPurposeIndex({ path: "45h" }), 45);
+  assert.equal(hodlMultisigPurposeIndex({ path: "69420h/0h/0h/2h" }), 69420);
+  assert.throws(() => hodlMultisigPurposeIndex({ path: "48/0h/0h/2h" }), /must be hardened/);
 
   assert.deepEqual(
     hodlMultisigScriptEvidence({ scope: "multisig", family: "y", origin: { path: "48h/0h/0h/1h" } }),
-    { prefixKind: "p2sh-p2wsh", originKind: "p2sh-p2wsh", standard: "bip48" },
+    { prefixKind: "p2sh-p2wsh", originKind: "p2sh-p2wsh" },
   );
   assert.deepEqual(
     hodlMultisigScriptEvidence({ scope: "multisig", family: "z", origin: { path: "48h/0h/0h/1h" } }),
-    { prefixKind: "p2wsh", originKind: "p2sh-p2wsh", standard: "bip48" },
+    { prefixKind: "p2wsh", originKind: "p2sh-p2wsh" },
   );
   assert.deepEqual(
     hodlMultisigScriptEvidence({ scope: "singlesig", family: "x", origin: { path: "87h/0h/0h" } }),
-    { prefixKind: null, originKind: null, standard: "bip87" },
+    { prefixKind: null, originKind: "p2sh" },
   );
 
   assert.deepEqual(hodlSummarizeMultisigScriptKinds(["p2wsh", "p2wsh"]), {

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -395,6 +395,21 @@ test("key derivation and multisig use the accurate Script type label", () => {
   }
 });
 
+test("key derivation separates script type from the hardened purpose index", () => {
+  for (const markup of [template, appWhitespace]) {
+    assert.match(markup, /id="script-type-field">Script type\s*<select id="script-type"><option value="bip44">Legacy<\/option><option value="bip49">Nested SegWit<\/option><option value="bip84" selected(?:="selected")?>Native SegWit<\/option><option value="bip86">Taproot<\/option><\/select>/);
+    assert.match(markup, /id="script-type"[\s\S]*id="purpose"[\s\S]*id="network"[\s\S]*id="account"/);
+    assert.match(markup, /id="purpose" type="number" min="0" max="2147483647" step="1" inputmode="numeric" value="84"/);
+    assert.match(markup, /id="purpose-help">Hardened purpose index (?:·|\\xB7) 0 to 2,147,483,647/);
+  }
+  assert.match(appSource, /function hodlReadPurpose\(mark = true\)/);
+  assert.match(appSource, /hodlSetSelectedScriptType\(target\.value, true\)/);
+  assert.match(appSource, /let derivedDefinition = \{ \.\.\.definition, purpose: purposeIndex \}/);
+  assert.match(appSource, /originPath = `\$\{purposeIndex\}h\/\$\{Rs\(network\)\}h\/\$\{accountIndex\}h`/);
+  assert.match(appSource, /context\.textContent = `\$\{definition\.label\} \\xB7 Purpose \$\{purpose\}h`/);
+  assert.match(appSource, /fields: \{ pass: "", script: "bip84", purpose: "84", network: "mainnet"/);
+});
+
 test("multisig script type and placeholders follow detected co-signer exports", () => {
   for (const markup of [template, appWhitespace]) {
     assert.match(markup, /option value="mixed" disabled data-custom-select-placeholder="true">Mixed · incompatible keys/);

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -47,12 +47,17 @@ test("every enabled button uses orange and black momentary press feedback", () =
 });
 
 test("all wallet network selectors enable and default to mainnet", () => {
-  for (const id of ["network", "msig-network", "psbt-network"]) {
+  for (const id of ["network", "msig-network"]) {
     const selectedMainnet = new RegExp(
-      `<select id="${id}"><option value="mainnet" selected(?:="selected")?>Bitcoin mainnet</option>`,
+      `<select id="${id}"[^>]*><option value="mainnet" selected(?:="selected")?>Bitcoin mainnet · 0h</option>`,
     );
     assert.match(template, selectedMainnet);
-    assert.match(app, selectedMainnet);
+    assert.match(appWhitespace, selectedMainnet);
+  }
+  for (const markup of [template, appWhitespace]) {
+    assert.match(markup, /id="network-help">Hardened coin type index in the derivation path\./);
+    assert.match(markup, /id="msig-network-help">Hardened coin type index in the derivation path\./);
+    assert.match(markup, /<select id="psbt-network"><option value="mainnet" selected(?:="selected")?>Bitcoin mainnet<\/option>/);
   }
   assert.doesNotMatch(`${template}\n${app}`, /option value="mainnet"[^>]*disabled/);
   assert.doesNotMatch(app, /hodlForceTestnet|temporarily disabled/);
@@ -60,8 +65,8 @@ test("all wallet network selectors enable and default to mainnet", () => {
 });
 
 test("single-key network selector is half width on wide screens and full width on narrow screens", () => {
-  assert.match(template, /<label class="field network-field">Network\s*<select id="network">/);
-  assert.match(app, /<label class="field network-field">Network\s*<select id="network">/);
+  assert.match(template, /<label class="field network-field">Network\s*<select id="network"[^>]*>/);
+  assert.match(app, /<label class="field network-field">Network\s*<select id="network"[^>]*>/);
   assert.match(css, /\.key-settings\.single-key-mode \.network-field \{ width: 100%; max-width: 50%; \}/);
   assert.match(
     css,
@@ -78,6 +83,8 @@ test("key and multisig derivation use an indexed address window with an estimate
     assert.match(markup, /id="derive-progress"[^>]*role="progressbar"/);
     assert.match(markup, /id="msig-derive-progress"[^>]*role="progressbar"/);
     assert.doesNotMatch(markup, /id="(?:msig-)?count"/);
+    assert.match(markup, /id="derivation-path-preview"[\s\S]*id="address-estimate"[\s\S]*id="go"/);
+    assert.match(markup, /id="msig-address-range"[\s\S]*id="msig-address-estimate"[\s\S]*id="msig-go"/);
   }
   assert.match(appSource, /function hodlReadAddressWindow\(prefix = "", mark = true\)/);
   assert.match(appSource, /for \(let index = startIndex; index < startIndex \+ o; index\+\+\)/);
@@ -379,7 +386,7 @@ test("seed phrase mode has a lowercase Jade-style on-screen keyboard", () => {
 });
 
 test("multisig derivation settings follow the key inputs", () => {
-  const fieldOrder = /id="msig-keys"[\s\S]*id="msig-key-order-status"[\s\S]*id="msig-hint"[\s\S]*id="msig-script-type"[\s\S]*id="msig-network"[\s\S]*id="msig-account"[\s\S]*id="msig-address-start"[\s\S]*id="msig-address-range"[\s\S]*id="msig-key-order"[\s\S]*id="msig-go"/;
+  const fieldOrder = /id="msig-keys"[\s\S]*id="msig-key-order-status"[\s\S]*id="msig-hint"[\s\S]*id="msig-script-type"[\s\S]*id="msig-purpose"[\s\S]*id="msig-network"[\s\S]*id="msig-account"[\s\S]*id="msig-address-start"[\s\S]*id="msig-address-range"[\s\S]*id="msig-key-order"[\s\S]*id="msig-go"/;
   assert.match(template, fieldOrder);
   assert.match(app, fieldOrder);
 });
@@ -388,8 +395,9 @@ test("key derivation and multisig use the accurate Script type label", () => {
   for (const markup of [template, appWhitespace]) {
     assert.match(markup, /id="script-type-field">Script type\s*<select/);
     assert.match(markup, /<label class="field">Script type\s*<select id="msig-script-type"[^>]*>/);
-    assert.match(markup, /<option value="p2wsh" selected(?:="selected")?>Native SegWit (?:·|\\xB7) BIP48<\/option>/);
-    assert.match(markup, /<option value="p2tr">Taproot (?:·|\\xB7) BIP86<\/option>/);
+    assert.match(markup, /<option value="p2wsh" selected(?:="selected")?>Native SegWit<\/option>/);
+    assert.match(markup, /<option value="p2tr">Taproot<\/option>/);
+    assert.doesNotMatch(markup, /<option value="p2wsh"[^>]*>[^<]*BIP48/);
     assert.doesNotMatch(markup, /name="msig-script"|Matches BIP48 script type|Bare P2SH/);
     assert.doesNotMatch(markup, />Address type</);
   }
@@ -417,19 +425,17 @@ test("multisig script type and placeholders follow detected co-signer exports", 
     assert.match(markup, /id="msig-go"[^>]*aria-describedby="msig-script-warning"/);
   }
   assert.match(template, /placeholder="\[fingerprint\/48h\/0h\/0h\/2h\]Zpub…"/);
-  assert.match(app, /function hodlMultisigKeyPlaceholder\(kind,network,legacyStandard="bip45"\)/);
-  assert.match(appWhitespace, /kind==="p2sh"\)return`\[fingerprint\/45h\]\$\{testnet\?"tpub":"xpub"\}(?:…|\\u2026)`/);
-  assert.match(appWhitespace, /kind==="p2sh"&&legacyStandard==="bip87"\)return`\[fingerprint\/87h\/\$\{coin\}\/0h\]\$\{testnet\?"tpub":"xpub"\}(?:…|\\u2026)`/);
+  assert.match(app, /function hodlMultisigKeyPlaceholder\(kind,network,purpose\)/);
+  assert.match(appWhitespace, /kind==="p2sh"&&purpose===45\)return`\[fingerprint\/\$\{purposeStep\}\]\$\{testnet\?"tpub":"xpub"\}(?:…|\\u2026)`/);
+  assert.match(appWhitespace, /kind==="p2sh"\)return`\[fingerprint\/\$\{purposeStep\}\/\$\{coin\}\/0h\]\$\{testnet\?"tpub":"xpub"\}(?:…|\\u2026)`/);
   assert.match(app, /testnet\?"Upub":"Ypub"/);
   assert.match(app, /testnet\?"Vpub":"Zpub"/);
-  assert.match(appWhitespace, /kind==="p2tr"\)return`\[fingerprint\/86h\/\$\{coin\}\/0h\]\$\{testnet\?"tpub":"xpub"\}(?:…|\\u2026)`/);
-  assert.match(app, /if\(steps\[0\]!=="86h"\)return"BIP86 origin must start at 86h."/);
-  assert.match(app, /Taproot BIP86 requires a depth-3 account key at m\/86h\/coinh\/accounth/);
+  assert.match(appWhitespace, /kind==="p2tr"\)return`\[fingerprint\/\$\{purposeStep\}\/\$\{coin\}\/0h\]\$\{testnet\?"tpub":"xpub"\}(?:…|\\u2026)`/);
+  assert.match(app, /function hodlMultisigPurposeIndex\(origin\)/);
+  assert.match(app, /function hodlUpdateMsigPurposeDetection\(\)/);
   assert.doesNotMatch(app, /or BIP48 script 3h/);
   assert.doesNotMatch(app, /if\(steps\[3\]==="3h"\)return"p2tr"/);
-  assert.match(app, /summary\.legacyMixed\?"Legacy co-signer exports mix BIP45 and BIP87/);
-  assert.match(app, /summary\.legacyScriptConflict\?"BIP87 account keys are script-agnostic/);
-  assert.match(app, /BIP87 keys do not encode a script type\. Select Legacy P2SH/);
+  assert.match(app, /Co-signer purpose indexes do not match/);
   assert.match(app, /button\.disabled=!ready/);
   assert.match(app, /if\(kind==="mixed"\)throw new Error\("Co-signer keys indicate different script types/);
 });
@@ -500,8 +506,11 @@ test("multisig key order is sorted by default and listed order is advanced", () 
   assert.match(app, /notes\.push\("This wallet uses "/);
 });
 
-test("Legacy multisig defaults to BIP45 and offers BIP87 accounts only for Legacy", () => {
+test("multisig separates script type from purpose and keeps the Legacy BIP87 shortcut", () => {
   for (const markup of [template, app]) {
+    assert.match(markup, /id="msig-script-type"[\s\S]*id="msig-purpose"[\s\S]*id="msig-network"[\s\S]*id="msig-account"/);
+    assert.match(markup, /id="msig-purpose" type="number" min="0" max="2147483647" step="1" inputmode="numeric" value="48"/);
+    assert.match(markup, /id="msig-purpose-help">Hardened purpose index (?:·|\\xB7) 0 to 2,147,483,647/);
     assert.match(markup, /id="msig-legacy-account-toggle" hidden/);
     assert.match(markup, /id="msig-legacy-bip87" type="checkbox"/);
     assert.match(markup, />Use standardized BIP87 accounts</);
@@ -510,10 +519,11 @@ test("Legacy multisig defaults to BIP45 and offers BIP87 accounts only for Legac
   assert.match(css, /\.msig-legacy-account-toggle\[hidden\] \{ display: none !important; \}/);
   assert.match(app, /legacy=hodlScriptKind\(\)==="p2sh"/);
   assert.match(appSource, /if \(toggle\) toggle\.hidden = !legacy/);
-  assert.match(appWhitespace, /checkbox\?\.checked\?"Legacy · BIP87":"Legacy · BIP45"/);
+  assert.match(app, /hodlSetMsigPurpose\(legacy\.checked\?87:45\)/);
+  assert.match(app, /hodlSetMsigPurpose\(hodlStandardMsigPurpose\(script\.value\)\)/);
   assert.match(app, /legacyBip87:!1/);
-  assert.match(app, /scriptStandard:kind==="p2tr"\?"bip86":kind==="p2sh"\?legacyStandard:"bip48"/);
-  assert.match(app, /legacyScriptConflict=standards\.includes\("bip87"\)&&summary\.kinds\.some\(kind=>kind!=="p2sh"\)/);
+  assert.match(app, /purpose:"48"/);
+  assert.match(app, /purposeIndexes\.push\(hodlMultisigPurposeIndex\(parsed\.origin\)\)/);
 });
 
 test("the master fingerprint cards reserve a compact empty square for each LifeHash", () => {
@@ -602,7 +612,7 @@ test("multisig consistently uses derive for its heading and action", () => {
   assert.match(app, /function hodlValidatedMsigInputs\(\)/);
   assert.match(appSource, /hodlValidatedMsigInputs\(\);\s*ready = true/);
   assert.match(app, /button\.disabled=!ready/);
-  assert.match(app, /let\{network,count,addressStart,n,m,kind,legacyStandard,nodes,xpubs,keyTokens,accountSummary,accountWarning\}=hodlValidatedMsigInputs\(\)/);
+  assert.match(app, /let\{network,count,addressStart,n,m,kind,purpose,legacyStandard,nodes,xpubs,keyTokens,accountSummary,accountWarning\}=hodlValidatedMsigInputs\(\)/);
 });
 
 test("key and multisig add controls stay pinned to the right of their tab strips", () => {

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -526,6 +526,12 @@ test("multisig separates script type from purpose and keeps the Legacy BIP87 sho
   assert.match(app, /purposeIndexes\.push\(hodlMultisigPurposeIndex\(parsed\.origin\)\)/);
 });
 
+test("Native SegWit multisig uses the imported Bitcoin address encoder", () => {
+  assert.match(appSource, /import \{ Address as hodlBitcoinAddress,/);
+  assert.match(appSource, /hodlBitcoinAddress\(net\)\.encode\(\{ type: "wsh", hash \}\)/);
+  assert.doesNotMatch(appSource, /\bor\(net\)\.encode/);
+});
+
 test("the master fingerprint cards reserve a compact empty square for each LifeHash", () => {
   // Both cards keep a frame beside the value, while the image itself starts hidden.
   assert.match(app, /id="base-master-fingerprint-card"[\s\S]*?class="master-fingerprint-lifehash-frame"[\s\S]*?id="base-master-fingerprint-lifehash"[^>]*hidden/);


### PR DESCRIPTION
## Summary
- split Script type from a numeric hardened Purpose field for both single-key and multisig derivation
- restore each conventional purpose when Script type changes while allowing custom values from 0 through 2,147,483,647
- auto-detect multisig purposes from co-signer origins and block derivation when co-signers disagree
- apply custom purposes to paths, descriptors, labels, recovery sheets, and saved state
- label Network choices with their hardened coin-type indexes and explain that the path component is hardened
- place device derivation-time estimates below the path/settings area immediately above each Derive button
- fix the Native SegWit multisig address-encoder import uncovered by the new end-to-end coverage

## Tests
- `npm run ci` (326 passed)
- GitHub Firefox integration suite (passed)
- all PR CI/CD checks (passed)
- descriptor coverage for standard and custom multisig purposes, origin validation, and mixed-purpose rejection
- browser integration coverage for standard-purpose resets, origin auto-detection, and Native SegWit multisig at purpose `69420h`