### PR TITLE
Parse PSBT v2 (BIP370) into the existing inspector.

### DIFF
--- a/src/js/psbt-v2.js
+++ b/src/js/psbt-v2.js
@@ -1,0 +1,59 @@
+// BIP370 PSBT v2: synthesize the unsigned tx the inspector already walks.
+// Depends on the same helpers the v0 parser uses (passed in).
+
+export function hodlPsbtVersion(entries, hodlR32) {
+  const found = entries.filter((entry) => entry.type === 251 && entry.keydata.length === 0);
+  if (!found.length) return 0;
+  if (found[0].val.length !== 4) throw new Error("PSBT version field is malformed.");
+  return hodlR32(found[0].val, 0);
+}
+
+export function hodlPsbtGlobalU32(entries, type, label, hodlR32) {
+  const found = entries.filter((entry) => entry.type === type && entry.keydata.length === 0);
+  if (!found.length) return null;
+  if (found[0].val.length !== 4) throw new Error(label + " is malformed.");
+  return hodlR32(found[0].val, 0);
+}
+
+export function hodlPsbtGlobalCount(entries, type, hodlVarInt) {
+  const found = entries.filter((entry) => entry.type === type && entry.keydata.length === 0);
+  if (!found.length) return null;
+  return hodlVarInt(found[0].val, 0)[0];
+}
+
+export function hodlTxFromPsbtV2(global, inputMaps, outputMaps, helpers) {
+  const { hodlFind, hodlR32, hodlR64, hodlVarInt } = helpers;
+  const version = hodlPsbtGlobalU32(global, 2, "PSBT v2 transaction version", hodlR32);
+  if (version === null) throw new Error("A PSBT v2 is missing the transaction version.");
+  let locktime = hodlPsbtGlobalU32(global, 3, "PSBT v2 fallback locktime", hodlR32);
+  if (locktime === null) locktime = 0;
+  const declaredInputs = hodlPsbtGlobalCount(global, 4, hodlVarInt);
+  const declaredOutputs = hodlPsbtGlobalCount(global, 5, hodlVarInt);
+  if (declaredInputs !== null && declaredInputs !== inputMaps.length) {
+    throw new Error("PSBT v2 input count does not match the number of input maps.");
+  }
+  if (declaredOutputs !== null && declaredOutputs !== outputMaps.length) {
+    throw new Error("PSBT v2 output count does not match the number of output maps.");
+  }
+  const inputs = inputMaps.map((entries, index) => {
+    const txidEntry = hodlFind(entries, 14).find((entry) => entry.keydata.length === 0);
+    const voutEntry = hodlFind(entries, 15).find((entry) => entry.keydata.length === 0);
+    if (!txidEntry || txidEntry.val.length !== 32) throw new Error("PSBT v2 input " + index + " is missing a previous txid.");
+    if (!voutEntry || voutEntry.val.length !== 4) throw new Error("PSBT v2 input " + index + " is missing an output index.");
+    const seqEntry = hodlFind(entries, 16).find((entry) => entry.keydata.length === 0);
+    let sequence = 0xffffffff;
+    if (seqEntry) {
+      if (seqEntry.val.length !== 4) throw new Error("PSBT v2 input " + index + " sequence is malformed.");
+      sequence = hodlR32(seqEntry.val, 0);
+    }
+    return { txid: txidEntry.val, vout: hodlR32(voutEntry.val, 0), script: new Uint8Array(), sequence };
+  });
+  const outputs = outputMaps.map((entries, index) => {
+    const amountEntry = hodlFind(entries, 3).find((entry) => entry.keydata.length === 0);
+    const scriptEntry = hodlFind(entries, 4).find((entry) => entry.keydata.length === 0);
+    if (!amountEntry || amountEntry.val.length !== 8) throw new Error("PSBT v2 output " + index + " is missing an amount.");
+    if (!scriptEntry) throw new Error("PSBT v2 output " + index + " is missing a script.");
+    return { amount: hodlR64(amountEntry.val, 0), script: scriptEntry.val };
+  });
+  return { version, inputs, outputs, locktime };
+}

--- a/test/psbt-v2.test.mjs
+++ b/test/psbt-v2.test.mjs
@@ -1,0 +1,33 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { hodlPsbtVersion, hodlTxFromPsbtV2 } from "../src/js/psbt-v2.js";
+
+const u32 = (n) => Uint8Array.of(n & 255, n >>> 8 & 255, n >>> 16 & 255, n >>> 24 & 255);
+const r32 = (b) => new DataView(b.buffer, b.byteOffset, 4).getUint32(0, true);
+const r64 = (b) => {
+  let v = 0n;
+  for (let i = 0; i < 8; i++) v |= BigInt(b[i]) << BigInt(8 * i);
+  return v;
+};
+const find = (entries, type) => entries.filter((e) => e.type === type);
+const varint = (b) => [b[0], 1];
+
+test("missing version field is v0", () => {
+  assert.equal(hodlPsbtVersion([], r32), 0);
+  assert.equal(hodlPsbtVersion([{ type: 251, keydata: new Uint8Array(), val: u32(2) }], r32), 2);
+});
+
+test("v2 tx is built from input 0x0e/0x0f and output 0x03/0x04", () => {
+  const txid = new Uint8Array(32).fill(9);
+  const amount = Uint8Array.of(0xe8, 0x03, 0, 0, 0, 0, 0, 0);
+  const script = Uint8Array.of(0x00, 0x14, ...new Uint8Array(20));
+  const tx = hodlTxFromPsbtV2(
+    [{ type: 2, keydata: new Uint8Array(), val: u32(2) }],
+    [[{ type: 14, keydata: new Uint8Array(), val: txid }, { type: 15, keydata: new Uint8Array(), val: u32(1) }]],
+    [[{ type: 3, keydata: new Uint8Array(), val: amount }, { type: 4, keydata: new Uint8Array(), val: script }]],
+    { hodlFind: find, hodlR32: r32, hodlR64: r64, hodlVarInt: varint },
+  );
+  assert.equal(tx.version, 2);
+  assert.equal(tx.inputs[0].vout, 1);
+  assert.equal(tx.outputs[0].amount, 1000n);
+});


### PR DESCRIPTION
PSBT inspector currently dies on v2 files. This adds helpers that turn a BIP370 v2 PSBT into the same unsigned-tx shape the v0 inspector already walks.

- src/js/psbt-v2.js
- test/psbt-v2.test.mjs
- Inspect only. No signing.

Replaces #152 (that PR accidentally included OP_RETURN / raw-tx commits).

Run: node --test test/psbt-v2.test.mjs