### PR TITLE
Flag reused BIP340 Schnorr nonces in Taproot signatures.

### DIFF
--- a/src/js/psbt-schnorr.js
+++ b/src/js/psbt-schnorr.js
@@ -1,0 +1,59 @@
+// BIP340 / Taproot nonce compare. R is the first 32 bytes of a 64/65-byte sig.
+
+export function hodlLooksSchnorr(item) {
+  return !!item && (item.length === 64 || (item.length === 65 && item[0] !== 48));
+}
+
+export function hodlParseSchnorr(raw) {
+  if (!hodlLooksSchnorr(raw)) return null;
+  return {
+    r: raw.slice(0, 32),
+    s: raw.slice(32, 64),
+    sighash: raw.length === 65 ? raw[64] : 0,
+    raw,
+  };
+}
+
+export function hodlTapSighashProblems(declared, suffix, hodlSighashLabel) {
+  const problems = [];
+  const declaredUnsafe = declared !== null && declared !== 0 && declared !== 1;
+  const suffixUnsafe = suffix !== null && suffix !== 0 && suffix !== 1;
+  if (declaredUnsafe) problems.push("The PSBT requests " + hodlSighashLabel(declared) + ", which does not commit to all shown outputs.");
+  if (suffixUnsafe) problems.push("This Schnorr signature uses " + hodlSighashLabel(suffix) + ", which does not commit to all shown outputs.");
+  if (declared !== null && suffix !== null && declared !== suffix && !((declared === 0 || declared === 1) && (suffix === 0 || suffix === 1))) {
+    problems.push("The PSBT-declared policy and the Schnorr signature's sighash byte disagree.");
+  }
+  return problems;
+}
+
+export function hodlTapKeySigs(entries, hodlFind) {
+  return hodlFind(entries, 19).filter((entry) => entry.keydata.length === 0).map((entry) => {
+    const parsed = hodlParseSchnorr(entry.val);
+    return parsed
+      ? Object.assign({ pubkey: new Uint8Array(), source: "tap-key" }, parsed)
+      : { pubkey: new Uint8Array(), r: null, s: null, sighash: null, raw: entry.val, source: "tap-key" };
+  });
+}
+
+export function hodlTapScriptSigs(entries, hodlFind) {
+  return hodlFind(entries, 20).map((entry) => {
+    const parsed = hodlParseSchnorr(entry.val);
+    const pubkey = entry.keydata.length >= 32 ? entry.keydata.slice(0, 32) : new Uint8Array();
+    return parsed
+      ? Object.assign({ pubkey, source: "tap-script" }, parsed)
+      : { pubkey, r: null, s: null, sighash: null, raw: entry.val, source: "tap-script" };
+  });
+}
+
+export function hodlCompareSchnorrNonces(rValues, hodlEq) {
+  const possible = [];
+  for (let first = 0; first < rValues.length; first++) {
+    for (let second = first + 1; second < rValues.length; second++) {
+      const a = rValues[first], b = rValues[second];
+      if (!a.r || !b.r || !hodlEq(a.r, b.r)) continue;
+      if (a.pubkey && b.pubkey && a.pubkey.length && b.pubkey.length && !hodlEq(a.pubkey, b.pubkey)) continue;
+      if (a.input !== b.input) possible.push([a, b]);
+    }
+  }
+  return { reused: [], possible };
+}

--- a/test/psbt-schnorr-nonce.test.mjs
+++ b/test/psbt-schnorr-nonce.test.mjs
@@ -1,0 +1,38 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { hodlParseSchnorr, hodlTapSighashProblems, hodlCompareSchnorrNonces, hodlTapKeySigs } from "../src/js/psbt-schnorr.js";
+
+const eq = (a, b) => a.length === b.length && a.every((x, i) => x === b[i]);
+const rA = new Uint8Array(32).fill(0x11);
+const key = new Uint8Array(32).fill(0x33);
+
+test("parses 64 and 65 byte Schnorr signatures", () => {
+  const raw = new Uint8Array(64);
+  raw.set(rA);
+  assert.equal(hodlParseSchnorr(raw).sighash, 0);
+  const raw2 = new Uint8Array(65);
+  raw2.set(rA);
+  raw2[64] = 0x81;
+  assert.equal(hodlParseSchnorr(raw2).sighash, 0x81);
+});
+
+test("DEFAULT and ALL are safe; ANYONECANPAY is not", () => {
+  const label = (p) => "0x" + p.toString(16);
+  assert.deepEqual(hodlTapSighashProblems(0, 1, label), []);
+  assert.ok(hodlTapSighashProblems(0x82, 0x82, label).length >= 2);
+});
+
+test("same R on two inputs is flagged", () => {
+  const scan = hodlCompareSchnorrNonces([
+    { input: 0, r: rA, pubkey: key },
+    { input: 1, r: rA, pubkey: key },
+  ], eq);
+  assert.equal(scan.possible.length, 1);
+});
+
+test("tap key sig records are collected", () => {
+  const raw = new Uint8Array(64);
+  raw.set(rA);
+  const keys = hodlTapKeySigs([{ type: 19, keydata: new Uint8Array(), val: raw }], (e, t) => e.filter((x) => x.type === t));
+  assert.equal(keys.length, 1);
+});


### PR DESCRIPTION
ECDSA nonce-reuse already exists. This adds the same check for 64/65-byte BIP340 signatures (key-path and script-path).

- src/js/psbt-schnorr.js
- test/psbt-schnorr-nonce.test.mjs
- Inspect only. No signing. Does not reconstruct Taproot sighashes.

Run: node --test test/psbt-schnorr-nonce.test.mjs