### PR TITLE
Parse BitBox anti-klepto transcripts (do not treat SHA256(nonce) as Jade ρ).

### DIFF
--- a/src/js/psbt-bitbox.js
+++ b/src/js/psbt-bitbox.js
@@ -1,0 +1,82 @@
+// BitBox02 anti-klepto transcript parse.
+// Mix is secp256k1-zkp s2c (same tagged hash as Jade) but the host first
+// sends SHA256(host_nonce). Pasting that commitment as Jade ρ is the trap.
+// Inspect only. No signing.
+
+function concatBytes(...parts) {
+  const out = new Uint8Array(parts.reduce((sum, part) => sum + part.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+function eq(a, b) {
+  if (!a || !b || a.length !== b.length) return false;
+  let different = 0;
+  for (let i = 0; i < a.length; i++) different |= a[i] ^ b[i];
+  return different === 0;
+}
+
+export function hodlBitboxTaggedSha256(sha256, tag, ...chunks) {
+  const tagHash = sha256(new TextEncoder().encode(tag));
+  return sha256(concatBytes(tagHash, tagHash, ...chunks));
+}
+
+export function hodlBitboxS2cTweak(sha256, opening, hostNonce) {
+  return hodlBitboxTaggedSha256(sha256, "s2c/ecdsa/point", opening, hostNonce);
+}
+
+export function hodlParseBitboxTranscript(raw, hexDecode, sha256) {
+  if (!raw || !String(raw).trim()) return null;
+  const text = String(raw).replace(/0x/gi, "");
+  const tokens = text.split(/[^0-9a-fA-F]+/).filter((token) => token.length);
+  const thirtyTwo = [];
+  const openings = [];
+  for (const token of tokens) {
+    if (token.length === 64) thirtyTwo.push(hexDecode(token.toLowerCase()));
+    else if (token.length === 66) {
+      const opening = hexDecode(token.toLowerCase());
+      if (opening[0] !== 2 && opening[0] !== 3) {
+        throw new Error("BitBox signer commitment must be a compressed secp256k1 point.");
+      }
+      openings.push(opening);
+    } else if (token.length < 64) continue;
+    else throw new Error("BitBox anti-klepto wants 32-byte host fields and a 33-byte compressed opening, as hex.");
+  }
+  if (!openings.length) throw new Error("BitBox anti-klepto needs the 33-byte signer opening R.");
+  if (openings.length !== 1) throw new Error("Paste one BitBox signer opening.");
+  if (!thirtyTwo.length) throw new Error("BitBox anti-klepto needs the revealed 32-byte host nonce.");
+
+  let hostNonce = null;
+  let commitment = null;
+  if (thirtyTwo.length === 1) {
+    hostNonce = thirtyTwo[0];
+    commitment = sha256(hostNonce);
+  } else if (thirtyTwo.length === 2) {
+    const a = thirtyTwo[0];
+    const b = thirtyTwo[1];
+    const aHash = sha256(a);
+    const bHash = sha256(b);
+    if (eq(aHash, b)) {
+      hostNonce = a;
+      commitment = b;
+    } else if (eq(bHash, a)) {
+      hostNonce = b;
+      commitment = a;
+    } else {
+      throw new Error("The two 32-byte BitBox fields are not SHA256(host_nonce) and host_nonce. Do not paste a Jade ρ here.");
+    }
+  } else {
+    throw new Error("Paste the BitBox host nonce, optional SHA256 commitment, and one opening.");
+  }
+
+  return {
+    hostNonce,
+    commitment,
+    opening: openings[0],
+    commitmentMatches: eq(sha256(hostNonce), commitment),
+  };
+}

--- a/test/psbt-bitbox-s2c.test.mjs
+++ b/test/psbt-bitbox-s2c.test.mjs
@@ -1,0 +1,61 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { hodlParseBitboxTranscript, hodlBitboxS2cTweak } from "../src/js/psbt-bitbox.js";
+
+const hexDecode = (hex) => Uint8Array.from(Buffer.from(hex, "hex"));
+const hexEncode = (bytes) => Buffer.from(bytes).toString("hex");
+const sha256 = (bytes) => Uint8Array.from(createHash("sha256").update(Buffer.from(bytes)).digest());
+
+const HOST = "11".repeat(32);
+const OPENING = "02466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f27";
+const COMMITMENT = hexEncode(sha256(hexDecode(HOST)));
+
+test("empty transcript is inspect-only", () => {
+  assert.equal(hodlParseBitboxTranscript("", hexDecode, sha256), null);
+  assert.equal(hodlParseBitboxTranscript("   ", hexDecode, sha256), null);
+});
+
+test("one 32-byte field is the revealed host nonce, not the SHA256 commitment", () => {
+  const parsed = hodlParseBitboxTranscript(`${HOST} ${OPENING}`, hexDecode, sha256);
+  assert.equal(hexEncode(parsed.hostNonce), HOST);
+  assert.equal(hexEncode(parsed.opening), OPENING);
+  assert.equal(hexEncode(parsed.commitment), COMMITMENT);
+  assert.equal(parsed.commitmentMatches, true);
+});
+
+test("SHA256(host_nonce) plus nonce plus opening is accepted in either 32-byte order", () => {
+  const a = hodlParseBitboxTranscript(`${COMMITMENT}\n${OPENING}\n${HOST}`, hexDecode, sha256);
+  const b = hodlParseBitboxTranscript(`${HOST} ${COMMITMENT} ${OPENING}`, hexDecode, sha256);
+  assert.equal(hexEncode(a.hostNonce), HOST);
+  assert.equal(hexEncode(b.hostNonce), HOST);
+  assert.equal(a.commitmentMatches, true);
+  assert.equal(b.commitmentMatches, true);
+});
+
+test("two unrelated 32-byte fields are rejected (Jade ρ is not a BitBox commitment)", () => {
+  const other = "22".repeat(32);
+  assert.throws(
+    () => hodlParseBitboxTranscript(`${other} ${HOST} ${OPENING}`, hexDecode, sha256),
+    /not SHA256\(host_nonce\)/,
+  );
+});
+
+test("s2c tweak is tagged_hash(opening || host_nonce), never SHA256(host_nonce)", () => {
+  const opening = hexDecode(OPENING);
+  const nonce = hexDecode(HOST);
+  const tweak = hodlBitboxS2cTweak(sha256, opening, nonce);
+  assert.equal(
+    hexEncode(tweak),
+    "52be4b29692b2aa0d852edd9a5451e8ca2e6759b41c4bf0dc290f99cf145bea2",
+  );
+  const trap = hodlBitboxS2cTweak(sha256, opening, sha256(nonce));
+  assert.notEqual(hexEncode(tweak), hexEncode(trap));
+});
+
+test("uncompressed opening is rejected", () => {
+  assert.throws(
+    () => hodlParseBitboxTranscript(`${HOST} ${"04" + "aa".repeat(32)}`, hexDecode, sha256),
+    /compressed secp256k1 point/,
+  );
+});


### PR DESCRIPTION
Jade anti-exfil is already in the inspector. BitBox logs SHA256(host_nonce) first, then the opening, then the revealed nonce. Pasting that commitment into the Jade box is the wrong 32 bytes.

- src/js/psbt-bitbox.js
- test/psbt-bitbox-s2c.test.mjs
- Same secp256k1-zkp s2c tweak as Jade, over the revealed nonce
- Inspect only. No signing.

Run: node --test test/psbt-bitbox-s2c.test.mjs