### PR TITLE
Treat browser online status as unverified

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ modern browser. For sensitive wallet material, use a dedicated air-gapped
 machine and verify important addresses and descriptors with an independent
 wallet or signing device before receiving funds.
 
+The header status is only a browser hint. Some privacy-focused browsers,
+including Tor Browser configurations, deliberately report `navigator.onLine`
+as true even when networking is disabled. EntropyLab therefore labels that
+state **Unverified** and never probes the network. An **Offline** label means
+only that the browser reported offline; verify the air gap yourself before
+entering wallet secrets.
+
 To build the HTML file yourself, see [Building from source](#building-from-source).
 
 ### Verifying the download

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,6 +19,11 @@ material. Its security posture rests on the following model:
 
 - The tool is self-contained and designed for offline, air-gapped use. It does
   not intentionally transmit sensitive data to any server.
+- The header network status is a passive browser hint, not an air-gap test.
+  EntropyLab never probes a remote host, and privacy-focused browsers may force
+  `navigator.onLine` to true to resist fingerprinting. **Unverified** means the
+  browser did not report offline; **Offline** still requires the user to verify
+  that all network interfaces are disabled.
 - EntropyLab's own secp256k1 curve operations (public-key derivation, ECDSA
   signing and verification in PSBT inspection, curve point math) run on
   bitcoin-core/libsecp256k1 (the library securing Bitcoin Core), compiled to

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -520,7 +520,7 @@ td { border-top: 1px solid var(--border); padding: 8px; vertical-align: top; fon
    still writes exactly one attribute. It takes --danger, not --danger-bright:
    a full-width rule at the brighter red would outshout the word it is warning
    about, so the brightest red stays reserved for the tag's text. */
-.site-header:has(.network-status[data-state="online"]) { border-bottom-color: var(--danger); }
+.site-header:has(.network-status[data-state="unverified"]) { border-bottom-color: var(--danger); }
 /* The tight gap belongs to the mark and wordmark, which read as one lockup.
    Everything after them buys its own breathing room back with a margin. */
 .site-header-inner {
@@ -580,7 +580,7 @@ td { border-top: 1px solid var(--border); padding: 8px; vertical-align: top; fon
   text-indent: 0.1em; white-space: nowrap;
 }
 .network-status[data-state="offline"] { color: var(--ok-bright); }
-.network-status[data-state="online"] { color: var(--danger-bright); }
+.network-status[data-state="unverified"] { color: var(--danger-bright); }
 /* min-width: 0 lets the row shrink on narrow screens rather than pushing the
    controls out of the bar. */
 .download-controls { display: flex; flex-wrap: nowrap; align-items: center; gap: 8px; margin-left: auto; min-width: 0; }

--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,7 @@
       <span class="site-logo" aria-hidden="true"></span>
       <span class="site-title">EntropyLab</span>
       <span class="site-version"><span class="site-version-number">v{{VERSION}}</span> <span class="site-version-tag">(Latest)</span></span>
-      <span class="network-status" id="network-status" data-state="online" role="status" aria-label="Network status: online">Online</span>
+      <span class="network-status" id="network-status" data-state="unverified" role="status" aria-label="Network status unverified">Unverified</span>
       <div class="download-controls">
         <a class="btn secondary download-html header-button" href="entropylab.html" download="entropylab.html" aria-label="Download EntropyLab"><svg class="download-mark" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M12 3v12M7 11l5 5 5-5M5 21h14"/></svg><span class="control-label">Download</span></a>
         <a class="btn secondary github-repo-link header-button" href="https://github.com/w-s-bitcoin/entropylab" target="_blank" rel="noopener noreferrer" aria-label="View the EntropyLab GitHub repository in a new tab"><svg class="github-mark" viewBox="0 0 16 16" width="18" height="18" aria-hidden="true" focusable="false"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg><span class="control-label">GitHub</span></a>
@@ -28,12 +28,6 @@
       <div class="online-warning-text"><strong>Online version</strong> Do not enter seed phrases, private keys, or other wallet secrets on an internet-connected device. <a href="entropylab.html" download="entropylab.html">Download EntropyLab</a> and run the HTML file offline on a trusted, air-gapped computer.</div>
       <button type="button" class="online-warning-dismiss" id="online-warning-dismiss" aria-label="Dismiss the online version warning"><svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M18 6 6 18M6 6l12 12"/></svg></button>
     </aside>
-    <!-- TODO: This copy is being kept for the network-detected modal that will
-         replace the banner. Verbatim, with the lead-in as the modal's title:
-         "Network detected:" / "This computer has an active network adapter — it
-         is online and possibly connected to the internet. Do not enter wallet
-         secrets here; disconnect from all networks (Wi-Fi and Ethernet) and use
-         this file on an air-gapped computer." -->
     <section class="card">
       <div class="kicker">Run Offline · Bring your own entropy</div>
       <h1>Hold or receive bitcoin without a signing device.</h1>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -440,7 +440,7 @@ ec.innerHTML = `
       <span class="site-logo" aria-hidden="true"></span>
       <span class="site-title">EntropyLab</span>
       <span class="site-version"><span class="site-version-number">v{{VERSION}}</span> <span class="site-version-tag">(Latest)</span></span>
-      <span class="network-status" id="network-status" data-state="online" role="status" aria-label="Network status: online">Online</span>
+      <span class="network-status" id="network-status" data-state="unverified" role="status" aria-label="Network status unverified">Unverified</span>
       <div class="download-controls">
         <a class="btn secondary download-html header-button" href="entropylab.html" download="entropylab.html" aria-label="Download EntropyLab"><svg class="download-mark" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M12 3v12M7 11l5 5 5-5M5 21h14"/></svg><span class="control-label">Download</span></a>
         <a class="btn secondary github-repo-link header-button" href="https://github.com/w-s-bitcoin/entropylab" target="_blank" rel="noopener noreferrer" aria-label="View the EntropyLab GitHub repository in a new tab"><svg class="github-mark" viewBox="0 0 16 16" width="18" height="18" aria-hidden="true" focusable="false"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg><span class="control-label">GitHub</span></a>
@@ -457,12 +457,6 @@ ec.innerHTML = `
       <div class="online-warning-text"><strong>Online version</strong> Do not enter seed phrases, private keys, or other wallet secrets on an internet-connected device. <a href="entropylab.html" download="entropylab.html">Download EntropyLab</a> and run the HTML file offline on a trusted, air-gapped computer.</div>
       <button type="button" class="online-warning-dismiss" id="online-warning-dismiss" aria-label="Dismiss the online version warning"><svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M18 6 6 18M6 6l12 12"/></svg></button>
     </aside>
-    <!-- TODO: This copy is being kept for the network-detected modal that will
-         replace the banner. Verbatim, with the lead-in as the modal's title:
-         "Network detected:" / "This computer has an active network adapter — it
-         is online and possibly connected to the internet. Do not enter wallet
-         secrets here; disconnect from all networks (Wi-Fi and Ethernet) and use
-         this file on an air-gapped computer." -->
     <section class="card">
       <div class="kicker">Run Offline \xB7 Bring your own entropy</div>
       <h1>Hold or receive bitcoin without a signing device.</h1>

--- a/src/js/network-check.js
+++ b/src/js/network-check.js
@@ -1,24 +1,24 @@
 
-// Network check: drives the header status tag, which reads ONLINE in red when
-// this computer has a network adapter available and OFFLINE in green when it
-// does not. Detection relies on navigator.onLine plus the online/offline
-// events only — no network traffic of any kind is ever generated. When onLine
-// is false the OS reports no usable network adapter, so the machine is
-// offline. When true, an adapter is available with a link; that includes
-// a LAN without internet access, which still matters for an air-gap
-// warning. Browsers intentionally offer no finer-grained adapter
-// introspection, so an OFFLINE tag is not proof of an air gap.
+// Network check: drives the header status tag from navigator.onLine and its
+// events without generating any network traffic. Browsers may force onLine to
+// true for anti-fingerprinting (including Tor Browser), so true is UNVERIFIED,
+// not proof that this computer is connected. False is shown as OFFLINE, but is
+// still only the browser's report and not proof of an air gap.
 (() => {
   const TAG_ID = "network-status";
 
-  // The markup ships in the online state, so every path here either confirms
-  // it or downgrades it; the tag can never be left claiming an unverified gap.
+  // The markup ships unverified, so a script-less or not-yet-checked page can
+  // never claim an air gap.
   const setStatus = (online) => {
     const tag = document.getElementById(TAG_ID);
     if (!tag) return;
-    tag.dataset.state = online ? "online" : "offline";
-    tag.textContent = online ? "Online" : "Offline";
-    tag.setAttribute("aria-label", online ? "Network status: online" : "Network status: offline");
+    tag.dataset.state = online ? "unverified" : "offline";
+    tag.textContent = online ? "Unverified" : "Offline";
+    const message = online
+      ? "Network status unverified; browser reports online"
+      : "Network status: browser reports offline; verify the air gap yourself";
+    tag.setAttribute("aria-label", message);
+    tag.setAttribute("title", message);
   };
 
   const checkNetwork = () => {

--- a/test/network-check.test.mjs
+++ b/test/network-check.test.mjs
@@ -14,8 +14,8 @@ const src = read("src/js/network-check.js");
 
 const loadModule = ({ onLine, withConnectionApi = false, hasElement = true }) => {
   const el = {
-    dataset: { state: "online" },
-    textContent: "Online",
+    dataset: { state: "unverified" },
+    textContent: "Unverified",
     attributes: {},
     setAttribute(name, value) {
       this.attributes[name] = value;
@@ -42,37 +42,39 @@ test("never generates network traffic", () => {
 
 // The tag's three faces move together, so each check reads all of them: a
 // state the colour follows, the visible word, and the label screen readers get.
-const assertOnline = (el) => {
-  assert.equal(el.dataset.state, "online");
-  assert.equal(el.textContent, "Online");
-  assert.equal(el.attributes["aria-label"], "Network status: online");
+const assertUnverified = (el) => {
+  assert.equal(el.dataset.state, "unverified");
+  assert.equal(el.textContent, "Unverified");
+  assert.equal(el.attributes["aria-label"], "Network status unverified; browser reports online");
+  assert.equal(el.attributes.title, el.attributes["aria-label"]);
 };
 
 const assertOffline = (el) => {
   assert.equal(el.dataset.state, "offline");
   assert.equal(el.textContent, "Offline");
-  assert.equal(el.attributes["aria-label"], "Network status: offline");
+  assert.equal(el.attributes["aria-label"], "Network status: browser reports offline; verify the air gap yourself");
+  assert.equal(el.attributes.title, el.attributes["aria-label"]);
 };
 
-test("reads online when a network adapter is available", () => {
-  assertOnline(loadModule({ onLine: true }).el);
+test("treats navigator.onLine true as unverified", () => {
+  assertUnverified(loadModule({ onLine: true }).el);
 });
 
 test("reads offline when no network adapter is available", () => {
   assertOffline(loadModule({ onLine: false }).el);
 });
 
-test("reads online when the online event fires", () => {
+test("returns to unverified when the online event fires", () => {
   const { el, listeners, nav } = loadModule({ onLine: false });
   assertOffline(el);
   nav.onLine = true;
   listeners.online();
-  assertOnline(el);
+  assertUnverified(el);
 });
 
 test("reads offline when the offline event fires", () => {
   const { el, listeners, nav } = loadModule({ onLine: true });
-  assertOnline(el);
+  assertUnverified(el);
   nav.onLine = false;
   listeners.offline();
   assertOffline(el);
@@ -80,7 +82,7 @@ test("reads offline when the offline event fires", () => {
 
 test("re-checks when the Network Information API reports a change", () => {
   const { el, connectionListeners, nav } = loadModule({ onLine: true, withConnectionApi: true });
-  assertOnline(el);
+  assertUnverified(el);
   assert.equal(typeof connectionListeners.change, "function");
   nav.onLine = false;
   connectionListeners.change();
@@ -88,7 +90,7 @@ test("re-checks when the Network Information API reports a change", () => {
 });
 
 test("works without the Network Information API (Firefox/Safari)", () => {
-  assertOnline(loadModule({ onLine: true, withConnectionApi: false }).el);
+  assertUnverified(loadModule({ onLine: true, withConnectionApi: false }).el);
 });
 
 test("never leaves a stale offline tag standing when the adapter returns", () => {
@@ -98,7 +100,7 @@ test("never leaves a stale offline tag standing when the adapter returns", () =>
   assertOffline(el);
   nav.onLine = true;
   listeners.online();
-  assertOnline(el);
+  assertUnverified(el);
   nav.onLine = false;
   listeners.offline();
   assertOffline(el);
@@ -109,7 +111,7 @@ test("does not throw when the status tag is missing", () => {
   assert.doesNotThrow(() => loadModule({ onLine: false, hasElement: false }));
 });
 
-test("the status tag ships online, sits in the header, and is wired to the build", () => {
+test("the status tag ships unverified, sits in the header, and is wired to the build", () => {
   const template = read("src/index.html");
   const app = read("src/js/app.js");
   const build = read("scripts/build.mjs");
@@ -121,24 +123,23 @@ test("the status tag ships online, sits in the header, and is wired to the build
     assert.ok(tag, "the network status tag is missing from the live document");
     // Ships in the cautionary state: a script-less or not-yet-checked render
     // must never claim an air gap that nothing has verified.
-    assert.match(tag, /data-state="online"/);
+    assert.match(tag, /data-state="unverified"/);
     assert.match(tag, /role="status"/);
-    assert.match(doc, /id="network-status"[^>]*>Online</);
+    assert.match(doc, /id="network-status"[^>]*>Unverified</);
     // It belongs to the header, not the page body the banner used to sit in.
     const header = doc.indexOf('<div class="site-header no-print">');
     const wrapper = doc.indexOf('<div class="wrap">');
     const tagAt = doc.indexOf('id="network-status"');
     assert.ok(header < tagAt && tagAt < wrapper, "the status tag must sit inside the header");
-    // The banner it replaced is gone from the live document; only the TODO
-    // comment keeps its copy, for the modal that is to come.
+    // The old banner and its stale network-detected modal copy are gone.
     assert.doesNotMatch(doc, /id="network-warning"/);
-    assert.match(markup, /TODO:[\s\S]*?air-gapped computer\." -->/);
+    assert.doesNotMatch(markup, /Network detected:/);
   }
   assert.match(template, /\/\*@@JS_NETWORK@@\*\//);
   assert.match(build, /network-check\.js/);
-  // Green when offline, bright red when online, carried by the text alone.
+  // Green when the browser reports offline, bright red while unverified.
   assert.match(css, /\.network-status\[data-state="offline"\] \{ color: var\(--ok-bright\); \}/);
-  assert.match(css, /\.network-status\[data-state="online"\] \{ color: var\(--danger-bright\); \}/);
+  assert.match(css, /\.network-status\[data-state="unverified"\] \{ color: var\(--danger-bright\); \}/);
   // Both themes have to define these, or one of them falls back to nothing.
   for (const token of ["--danger-bright", "--ok-bright"]) {
     assert.match(css, new RegExp(":root \\{[^}]*" + token + ":", "s"));
@@ -153,8 +154,8 @@ test("the status tag ships online, sits in the header, and is wired to the build
   // clears that by ~2px, so its height cannot be left to the font's metrics.
   assert.match(css, /\.network-status \{[^}]*line-height: 1;/s);
   // The bar's own rule follows the tag, off the same attribute, so the two can
-  // never disagree about whether an adapter is live.
-  assert.match(css, /\.site-header:has\(\.network-status\[data-state="online"\]\) \{ border-bottom-color: var\(--danger\); \}/);
+  // never disagree about whether network status remains unverified.
+  assert.match(css, /\.site-header:has\(\.network-status\[data-state="unverified"\]\) \{ border-bottom-color: var\(--danger\); \}/);
   // Nothing repaints it for the offline state; it falls back to the grey.
   assert.match(css, /\.site-header \{[^}]*border-bottom: 1px solid var\(--border\);/s);
   // Left-aligned under the lockup, which needs the header row as its containing


### PR DESCRIPTION
Closes #158.

Tails uses Tor Browser, and current Firefox anti-fingerprinting can deliberately force `navigator.onLine` to `true`. That makes passive detection unable to distinguish an offline Tails session from a connected browser. EntropyLab also cannot safely resolve the ambiguity with a connectivity probe because its runtime must remain network-silent.

This changes the header status semantics:

- `navigator.onLine === true` is shown as **Unverified**, not **Online**
- `false` remains **Offline**, with accessible text explaining that it is only the browser report
- the initial markup ships in the cautionary **Unverified** state
- the stale planned "Network detected" modal copy is removed
- README and SECURITY document the limitation
- tests cover initial, online-event, offline-event, and Network Information API transitions

The red caution state and `connect-src 'none'` policy remain intact. No network probe, dependency, application cryptography, or wallet derivation behavior is added or changed.

References:

- Mozilla documents `navigator.onLine` as inherently unreliable: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/onLine
- Firefox anti-fingerprinting forces it true: https://bugzilla.mozilla.org/show_bug.cgi?id=1975851

Validated with:

- `npm run ci`
- `npm run test:network`
- `npm run test:ui`
- `npm run test:validate`
- `git diff --check`