### PR TITLE
Add educational BIP39 calculations for entropy inputs

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -171,6 +171,80 @@ textarea { display: block; min-height: 96px; letter-spacing: 0.08em; }
 }
 .number-base-sync-status[hidden] { display: none; }
 .number-base-sync-status svg { display: block; width: 16px; height: 16px; }
+.number-base-calculations-toggle { width: 100%; margin-top: var(--space-control); }
+.number-base-calculations-panel { margin-top: var(--space-section); }
+.number-base-calculations-panel[hidden] { display: none; }
+.number-base-binary-conversion { margin-bottom: var(--space-section); }
+.number-base-conversion-list { display: grid; grid-template-columns: repeat(auto-fill, minmax(72px, 1fr)); gap: 6px; }
+.number-base-conversion-cell { display: flex; align-items: center; justify-content: center; gap: 6px; min-height: 34px; padding: 6px 8px; border: 1px solid var(--border); border-radius: 7px; background: var(--surface-2); font-family: var(--mono); font-size: 12px; }
+.number-base-conversion-cell strong { color: var(--accent); font-weight: 700; }
+.number-base-conversion-cell b { color: var(--faint); font-family: var(--sans); font-weight: 400; }
+.number-base-conversion-cell > span { color: var(--fg); }
+.number-base-calculation-list { display: grid; gap: var(--space-control); }
+.number-base-calculation {
+  overflow-x: auto; padding: 14px 12px 12px; border: 1px solid var(--border); border-radius: 10px;
+  background: var(--surface-2); font-family: var(--mono); font-size: 12px;
+}
+.number-base-calculation-title { display: flex; justify-content: space-between; gap: 12px; margin: 0 0 12px; color: var(--muted); }
+.number-base-calculation-title span, .number-base-calculation-label { letter-spacing: 0.04em; }
+.number-base-calculation-title strong { color: var(--fg); font-family: var(--mono); font-size: 13px; font-weight: 400; }
+.number-base-calculation-row { display: grid; grid-template-columns: 88px minmax(396px, 1fr); align-items: center; gap: 8px; margin-top: 6px; }
+.number-base-calculation-label { color: var(--muted); font-family: var(--sans); font-size: 11px; font-weight: 600; }
+.number-base-calculation-powers, .number-base-calculation-bits, .number-base-calculation-products { display: grid; grid-template-columns: repeat(11, minmax(32px, 1fr)); gap: 4px; min-width: 396px; text-align: center; }
+.number-base-calculation-powers { color: var(--accent); font-weight: 700; }
+.number-base-calculation-bits span { padding: 8px 4px; border: 1px solid var(--border); border-radius: 6px; color: var(--fg); background: var(--bg); font-size: 14px; font-weight: 700; }
+.number-base-calculation-products { color: var(--fg); font-weight: 600; }
+.number-base-calculation-sum { display: flex; align-items: baseline; justify-content: flex-end; flex-wrap: wrap; gap: 6px 16px; min-width: 484px; margin-top: 12px; padding-top: 9px; border-top: 1px solid var(--border); color: var(--muted); white-space: nowrap; }
+.number-base-calculation-sum > span { display: inline-flex; align-items: baseline; gap: 5px; }
+.number-base-calculation-sum strong { color: var(--accent); font-size: 13px; font-weight: 700; }
+.number-base-calculation-sum b { color: var(--faint); }
+.manual-calculations-toggle { width: 100%; }
+.manual-calculations-container { margin-top: var(--space-section); }
+.manual-calculations-container[hidden] { display: none; }
+.manual-calculation-panel > .label { margin-top: 0; }
+.manual-calculation-list { display: grid; gap: var(--space-control); }
+.manual-calculation-row {
+  display: grid; grid-template-columns: auto auto minmax(220px, 1fr) auto; align-items: baseline; gap: 8px 14px;
+  overflow-x: auto; padding: 12px; border: 1px solid var(--border); border-radius: 10px; background: var(--surface-2);
+  color: var(--muted); font-family: var(--mono); font-size: 12px;
+}
+.manual-calculation-row strong { color: var(--fg); font-size: 13px; font-weight: 400; }
+.manual-calculation-row code { color: var(--fg); white-space: nowrap; }
+.manual-calculation-row b { color: var(--accent); font-weight: 700; white-space: nowrap; }
+.manual-calculation-heading { display: flex; justify-content: space-between; gap: 12px; color: var(--muted); }
+.manual-calculation-heading strong { color: var(--fg); }
+.dplus-calculation-row { display: block; }
+.dplus-calculation-stages { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 6px; margin-top: 10px; }
+.dplus-calculation-stage { display: grid; grid-template-columns: auto auto 1fr auto; align-items: center; gap: 4px 7px; min-width: 0; padding: 6px 8px; border: 1px solid var(--border); border-radius: 7px; background: var(--bg); }
+.dplus-calculation-stage span { color: var(--muted); font-family: var(--sans); font-size: 10px; font-weight: 600; }
+.dplus-calculation-stage strong { color: var(--fg); font-size: 13px; }
+.dplus-calculation-stage small { color: var(--muted); white-space: nowrap; }
+.dplus-calculation-stage b { color: var(--accent); font-weight: 700; white-space: nowrap; }
+.dplus-calculation-sum { display: flex; justify-content: flex-end; gap: 8px; margin-top: 10px; padding-top: 9px; border-top: 1px solid var(--border); white-space: nowrap; }
+.dplus-calculation-sum b { color: var(--accent); }
+@media (max-width: 760px) {
+  .number-base-calculation { overflow: visible; padding: 10px 8px 9px; }
+  .number-base-calculation-title { margin-bottom: 8px; }
+  .number-base-calculation-row { display: block; margin-top: 4px; }
+  .number-base-calculation-label { display: none; }
+  .number-base-calculation-powers, .number-base-calculation-bits, .number-base-calculation-products { grid-template-columns: repeat(11, minmax(0, 1fr)); gap: 2px; min-width: 0; font-size: 9px; }
+  .number-base-calculation-powers span, .number-base-calculation-bits span, .number-base-calculation-products span { min-width: 0; white-space: nowrap; }
+  .number-base-calculation-bits span { padding: 6px 1px; font-size: 12px; }
+  .number-base-calculation-sum { display: block; min-width: 0; margin-top: 8px; padding-top: 7px; white-space: normal; font-size: 10px; }
+  .number-base-calculation-sum > span { display: block; margin-top: 3px; white-space: normal; overflow-wrap: anywhere; }
+  .number-base-calculation-sum > span:first-child { margin-top: 0; }
+  .number-base-calculation-sum strong { font-size: 11px; }
+  .manual-calculation-row { grid-template-columns: auto auto; }
+  .manual-calculation-row code, .manual-calculation-row b { grid-column: 1 / -1; }
+  .manual-calculations-container { margin-top: var(--space-control); }
+  .manual-calculation-panel > .muted { margin-bottom: var(--space-control); }
+  .dplus-calculation-row { overflow: visible; padding: 8px; }
+  .dplus-calculation-stages { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 4px; margin-top: 7px; }
+  .dplus-calculation-stage { gap: 3px 5px; padding: 5px 6px; font-size: 10px; }
+  .dplus-calculation-stage strong { font-size: 12px; }
+  .dplus-calculation-stage small { font-size: 10px; }
+  .dplus-calculation-sum { justify-content: flex-start; flex-wrap: wrap; margin-top: 7px; padding-top: 6px; gap: 4px; font-size: 10px; white-space: normal; overflow: visible; }
+}
 .passphrase-field { margin-top: var(--space-component); font-size: 14px; font-weight: 600; }
 .passphrase-keyboard-tools { display: flex; align-items: stretch; gap: var(--space-control); margin-top: var(--space-control); }
 .passphrase-keyboard-tools[hidden] { display: none; }

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -214,9 +214,9 @@ textarea { display: block; min-height: 96px; letter-spacing: 0.08em; }
 .manual-calculation-heading { display: flex; justify-content: space-between; gap: 12px; color: var(--muted); }
 .manual-calculation-heading strong { color: var(--fg); }
 .dplus-calculation-row { display: block; }
-.dplus-calculation-stages { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 6px; margin-top: 10px; }
-.dplus-calculation-stage { display: grid; grid-template-columns: auto auto 1fr auto; align-items: center; gap: 4px 7px; min-width: 0; padding: 6px 8px; border: 1px solid var(--border); border-radius: 7px; background: var(--bg); }
-.dplus-calculation-stage span { color: var(--muted); font-family: var(--sans); font-size: 10px; font-weight: 600; }
+.dplus-calculation-stages { display: grid; grid-template-columns: repeat(6, minmax(0, 1fr)); gap: 6px; margin-top: 10px; }
+.dplus-calculation-stage { display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: 4px 7px; min-width: 0; padding: 6px 8px; border: 1px solid var(--border); border-radius: 7px; background: var(--bg); }
+.dplus-calculation-stage span { grid-column: 1 / -1; color: var(--muted); font-family: var(--sans); font-size: 10px; font-weight: 600; }
 .dplus-calculation-stage strong { color: var(--fg); font-size: 13px; }
 .dplus-calculation-stage small { color: var(--muted); white-space: nowrap; }
 .dplus-calculation-stage b { color: var(--accent); font-weight: 700; white-space: nowrap; }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1005,6 +1005,7 @@ ec.innerHTML = `
 `;
 if (/^(www\.)?entropylab\.online$/i.test(location.hostname)) document.getElementById("online-warning")?.removeAttribute("hidden");
 var hodlKeyModes = ["dice", "cards", "hex", "seed", "key", "brain-lab"], hodlBrainLabAck = false, hodlWorkspaceSyncMsig = [], hodlWorkspaceSyncResult = null, hodlCardRanks = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "T", "J", "Q", "K"], hodlDirectCardRanks = ["A", "2", "3", "4", "5", "6", "7", "8"], hodlCardSuits = [{ code: "S", symbol: "♠", label: "Spades", red: false }, { code: "H", symbol: "♥", label: "Hearts", red: true }, { code: "C", symbol: "♣", label: "Clubs", red: false }, { code: "D", symbol: "♦", label: "Diamonds", red: true }], hodlCardSuit = "", hodlCardRank = "", hodlCardMethod = "hashed", hodlSeedMethod = "words", hodlSeedZeroIndexed = false, hodlCardColemanSymbols = false, Ne = "dice", ge = "coldcard", Pt = 24, hodlEntropyFormat = "hex", hodlDiceCoinPositions = [], ft = "", re = null, Ge = false, hodlWalletDatBirthday = "genesis", Zs = W("#modes"), at = W("#form"), dr = W("#out");
+var hodlManualCalculationsOpen = false;
 hodlKeyModes.forEach((e) => {
   let t = document.createElement("button"), active = e === Ne;
   t.type = "button";
@@ -3910,6 +3911,7 @@ function hodlUpdateDirectCards() {
     reshuffle.innerHTML = instruction ? `<strong>${instruction}</strong>` : "";
   }
   hodlRenderDiceWordGrid(document.getElementById("dice-words"), parsed.words, parsed.config.words, !parsed.complete);
+  hodlRenderManualCalculations("cards-manual-calculations", "cards", input.value, parsed.config.words);
   let status = parsed.complete ? `${parsed.entries.length} of ${parsed.steps.length} rank draws entered \xB7 checksum-valid ${parsed.config.words}-word seed ready to derive` : `${parsed.entries.length} of ${parsed.steps.length} rank draws entered \xB7 ${hodlDirectCardStepStatus(parsed)}`;
   if (parsed.invalidEntries.length) status += ` \xB7 ${parsed.invalidEntries.length} invalid rank${parsed.invalidEntries.length === 1 ? "" : "s"} highlighted`;
   if (parsed.extraEntries.length) status += ` \xB7 ${parsed.extraEntries.length} extra card${parsed.extraEntries.length === 1 ? "" : "s"} highlighted`;
@@ -4873,6 +4875,81 @@ function hodlNumberBasePreviewWords(value, format, targetWords = Pt) {
 function hodlBinaryPreviewWords(value, targetWords = Pt) {
   return hodlNumberBasePreviewWords(value, "bin", targetWords);
 }
+function hodlNumberBaseCalculationRows(value, format, targetWords = Pt) {
+  let bits = hodlNumberBaseBits(value, format, targetWords), words = hodlNumberBasePreviewWords(value, format, targetWords), groups = bits.match(/.{11}/g) || [];
+  if (words.length > groups.length) {
+    let finalIndex = Ae.indexOf(words[groups.length]);
+    if (finalIndex >= 0) groups.push(finalIndex.toString(2).padStart(11, "0"));
+  }
+  return groups.map((group, index) => {
+    let terms = Array.from(group, (bit, bitIndex) => ({ bit, place: 2 ** (10 - bitIndex), value: bit === "1" ? 2 ** (10 - bitIndex) : 0 }));
+    return { number: index + 1, terms, index: Number.parseInt(group, 2), word: words[index] || "" };
+  });
+}
+function hodlBinaryCalculationRows(value, targetWords = Pt) {
+  return hodlNumberBaseCalculationRows(value, "bin", targetWords);
+}
+function hodlNumberBaseBinaryConversionMarkup(value, meta) {
+  if (meta.id === "bin") return "";
+  let values = [...meta.alphabet].map((character, index) => `<span class="number-base-conversion-cell"><strong>${character}</strong><b>→</b><span>${index.toString(2).padStart(meta.bitsPerDigit, "0")}</span></span>`).join("");
+  return `<div class="number-base-binary-conversion"><p class="label">${meta.shortLabel} digit values</p><p class="muted">Each ${meta.shortLabel} digit uses the binary value shown below before the 11-bit BIP39 calculations.</p><div class="number-base-conversion-list">${values}</div></div>`;
+}
+function hodlManualCalculationMarkup(method, value, targetWords = Pt) {
+  let config = hodlSeedConfig(targetWords), cards = method === "cards" ? hodlParseDirectCards(value, targetWords) : null, dplus = method === "dplus" ? hodlDPlusRolls(value, targetWords) : null, rows = [];
+  if (cards) cards.wordSlots.forEach((word, index) => {
+    let group = cards.values.slice(index * 4, index * 4 + 4);
+    if (group.length === 4 && group.every((entry) => entry !== null)) {
+      let indexValue = (((group[0] * 8) + group[1]) * 8 + group[2]) * 4 + group[3], stages = [{ label: "Draw 1", face: cards.ranks[index * 4], value: group[0], multiplier: 256 }, { label: "Draw 2", face: cards.ranks[index * 4 + 1], value: group[1], multiplier: 32 }, { label: "Draw 3", face: cards.ranks[index * 4 + 2], value: group[2], multiplier: 4 }, { label: "Draw 4", face: cards.ranks[index * 4 + 3], value: group[3], multiplier: 1 }];
+      rows.push({ number: index + 1, values: group, stages, formula: `(((${group[0]} × 8 + ${group[1]}) × 8 + ${group[2]}) × 4 + ${group[3]})`, index: indexValue, word });
+    }
+  });
+  if (dplus) dplus.groups.forEach((group, index) => {
+    if (!group.valid) return;
+    let values = [Number(group.faces[0]) - 1, hodlDPlusD16Value(group.faces[1]), hodlDPlusD16Value(group.faces[2])], stages = [{ label: "D8", face: group.faces[0], value: values[0], multiplier: 256 }, { label: "D16", face: group.faces[1], value: values[1], multiplier: 16 }, { label: "D16", face: group.faces[2], value: values[2], multiplier: 1 }], indexValue = values[0] * 256 + values[1] * 16 + values[2];
+    rows.push({ number: index + 1, values: group.faces, stages, formula: `${values[0]} × 256 + ${values[1]} × 16 + ${values[2]}`, index: indexValue, word: group.word });
+  });
+  if (method === "bitbox") {
+    let faces = [...String(value)].filter((face) => /^[1-6]$/.test(face)), position = 0;
+    for (let number = 1; number <= config.partialWords; number++) {
+      let dice = [];
+      while (dice.length < 5 && position < faces.length) {
+        let face = Number(faces[position++]);
+        if (face <= 4) dice.push(face - 1);
+      }
+      if (dice.length < 5 || position >= faces.length) break;
+      let coinFace = faces[position++], coin = Number(coinFace) <= 3 ? 0 : 1, indexValue = dice.reduce((total, value) => total * 4 + value, 0) * 2 + coin, stages = dice.map((value, index) => ({ label: `Die ${index + 1}`, face: value + 1, value, multiplier: [512, 128, 32, 8, 2][index] }));
+      stages.push({ label: "Coin bit", face: coinFace, value: coin, multiplier: 1 });
+      rows.push({ number, values: [...dice, coin], stages, formula: `(((((${dice[0]} × 4 + ${dice[1]}) × 4 + ${dice[2]}) × 4 + ${dice[3]}) × 4 + ${dice[4]}) × 2 + ${coin}`, index: indexValue, word: Ae[indexValue] });
+    }
+  }
+  if (!rows.length) return "";
+  let title = method === "cards" ? "Direct card calculations" : method === "dplus" ? "D++ calculations" : "BitBox diceware calculations", note = method === "cards" ? "Ranks are mapped to zero-based values (A=0 through 8=7), then combined with radices 8, 8, 8, and 4." : method === "dplus" ? "D8 contributes 8 values and each hexadecimal D16 contributes 16 values, giving 8 × 16 × 16 = 2048 possible indices." : "Each D4 contributes one base-4 value and the final die contributes the coin bit, giving 4⁵ × 2 = 2048 possible indices.";
+  return `<div class="manual-calculation-panel"><p class="label">${title}</p><p class="muted">${note}</p><div class="manual-calculation-list">${rows.map((row) => method === "dplus" || method === "cards" || method === "bitbox" ? `<div class="manual-calculation-row dplus-calculation-row"><div class="manual-calculation-heading"><span>Word ${row.number}</span><strong>${row.word || "incomplete"}</strong></div><div class="dplus-calculation-stages">${row.stages.map((stage) => `<div class="dplus-calculation-stage"><span>${stage.label}</span><strong>${stage.face}</strong><small>&rarr; ${stage.value} &times; ${stage.multiplier}</small><b>= ${stage.value * stage.multiplier}</b></div>`).join("")}</div><div class="dplus-calculation-sum"><span>${row.stages.map((stage) => stage.value * stage.multiplier).join(" + ")}</span><b>= BIP39 index ${row.index} &middot; word number ${row.index + 1}</b></div></div>` : `<div class="manual-calculation-row"><span>Word ${row.number}</span><strong>${row.word || "incomplete"}</strong><code>${row.formula}</code><b>BIP39 index ${row.index} · word number ${row.index + 1}</b></div>`).join("")}</div></div>`;
+}
+function hodlRenderManualCalculations(id, method, value, targetWords = Pt) {
+  let panel = document.getElementById(id);
+  if (!panel) return;
+  let markup = hodlManualCalculationsOpen ? hodlManualCalculationMarkup(method, value, targetWords) : "";
+  panel.hidden = !markup;
+  panel.innerHTML = markup;
+}
+function hodlRenderNumberBaseCalculations(value, format = "bin", targetWords = Pt) {
+  let panel = document.getElementById("number-base-calculations"), toggle = document.getElementById("show-number-base-calculations");
+  if (!panel || !toggle) return;
+  let meta = hodlEntropyFormatConfig(format, targetWords), rows = toggle.checked ? hodlNumberBaseCalculationRows(value, meta.id, targetWords) : [], conversion = toggle.checked ? hodlNumberBaseBinaryConversionMarkup(value, meta) : "";
+  panel.hidden = !toggle.checked || !rows.length && !conversion;
+  if (!rows.length) {
+    panel.innerHTML = conversion;
+    return;
+  }
+  panel.innerHTML = `<p class="label">${meta.label} calculations</p><p class="muted">Each 11-bit group is interpreted as a big-endian binary integer. Multiply each bit by its bit weight, then sum the contributions to get the zero-based BIP39 index. The corresponding word number is the index plus 1.</p><div class="number-base-calculation-list">${rows.map((row) => `<div class="number-base-calculation" data-calculation-word="${row.number}"><div class="number-base-calculation-title"><span>Word ${row.number}</span><strong>${row.word || "incomplete"}</strong></div><div class="number-base-calculation-row"><span class="number-base-calculation-label">Bit weight</span><div class="number-base-calculation-powers">${row.terms.map((term) => `<span>${term.place}</span>`).join("")}</div></div><div class="number-base-calculation-row"><span class="number-base-calculation-label">Bit</span><div class="number-base-calculation-bits">${row.terms.map((term) => `<span>${term.bit}</span>`).join("")}</div></div><div class="number-base-calculation-row"><span class="number-base-calculation-label">Contribution</span><div class="number-base-calculation-products">${row.terms.map((term) => `<span>${term.value}</span>`).join("")}</div></div><div class="number-base-calculation-sum"><span>${row.terms.map((term) => term.value).join(" + ")} <b>=</b></span><span>BIP39 index <strong>${row.index}</strong></span><span>word number <strong>${row.index + 1}</strong></span></div></div>`).join("")}</div>`;
+  let list = panel.querySelector(".number-base-calculation-list");
+  if (list && conversion) {
+    let wrapper = document.createElement("div");
+    wrapper.innerHTML = conversion;
+    panel.insertBefore(wrapper.firstElementChild, list);
+  }
+}
 function hodlHexPreviewWords(value, targetWords = Pt) {
   return hodlNumberBasePreviewWords(value, "hex", targetWords);
 }
@@ -5025,6 +5102,7 @@ function hodlUpdateEntropyInput(input, format, targetWords = Pt, syncContext = "
     meta.className = "muted" + (analysis.ready ? " ok" : analysis.invalidRanges.length ? " err" : "");
   }
   hodlRenderDiceWordGrid(wordsBox, words, config.words, false);
+  hodlRenderNumberBaseCalculations(input.value, definition.id, config.words);
   let entropyPad = input.closest("#form")?.querySelector(".entropy-keypad");
   if (entropyPad) entropyPad.classList.toggle("coin-phase", coinPhase);
   input.closest("#form")?.querySelectorAll("[data-entropy-digit]").forEach((button) => {
@@ -5177,6 +5255,7 @@ function hodlRenderKeyForm() {
       <div class="dice-input-shell"><pre class="dice-input-highlight" id="dice-highlight" aria-hidden="true"></pre><textarea id="dice" placeholder="${dicePlaceholder}" aria-describedby="dice-help dice-meta"></textarea></div>
       ${hodlSeedMetaRowMarkup("dice-meta", true)}
       ${dicePad}
+      ${ge === "bitbox" || ge === "dplus" ? `<label class="seed-autocomplete-toggle manual-calculations-toggle"><input type="checkbox" id="show-manual-calculations" ${hodlManualCalculationsOpen ? "checked" : ""} /><span><strong>Show calculations</strong> <span class="seed-autocomplete-note">(show how direct word selection produces each BIP39 index)</span></span></label><div id="dice-manual-calculations" class="manual-calculations-container" hidden></div>` : ""}
       ${hodlSeedCopyRowMarkup(hodlDiceFairnessToggleMarkup(hodlKeys[hodlActiveKey]?.showDiceFairness))}
       <aside id="dice-fairness" class="dice-fairness" hidden role="status" aria-live="polite"></aside>
       <div id="dice-words" class="dice-word-grid" aria-label="${config.words} seed-word slots"></div><div id="last-words" class="row" style="margin-top:8px"></div>`;
@@ -5184,6 +5263,11 @@ function hodlRenderKeyForm() {
     input.dataset.previousValue = input.value;
     let fairnessToggle = document.getElementById("dice-fairness-toggle");
     if (fairnessToggle) fairnessToggle.onclick = () => hodlSetDiceFairnessOpen(!hodlDiceFairnessIsOpen());
+    let manualToggle = document.getElementById("show-manual-calculations");
+    if (manualToggle) manualToggle.onchange = () => {
+      hodlManualCalculationsOpen = manualToggle.checked;
+      hodlUpdateDice();
+    };
     hodlBindKeypadPointer(at.querySelectorAll("[data-d]"), () => input);
     at.querySelectorAll("[data-d]").forEach((button) => {
       button.onclick = () => hodlInsertDiceControl(input, button);
@@ -5209,6 +5293,7 @@ function hodlRenderKeyForm() {
           }
         }
         ge = radio.value;
+        hodlManualCalculationsOpen = false;
         if (state) {
           state.diceMethod = ge;
           ft = ge === "dplus" ? state.dplusLastWord || "" : ge === "bitbox" ? state.lastWord || "" : "";
@@ -5251,6 +5336,7 @@ function hodlRenderKeyForm() {
       <div class="card-controls-row"><button class="card-undo-button seed-keyboard-delete" id="card-undo" type="button" aria-label="Undo last card" title="Undo last card" disabled><svg viewBox="0 0 24 18" aria-hidden="true" focusable="false"><path d="M9 2h11a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H9L2 9l7-7Z"/><path d="m12 6 6 6m0-6-6 6"/></svg></button><label class="seed-autocomplete-toggle card-visibility-toggle"><input type="checkbox" id="show-cards" aria-controls="dealt-cards" ${showCards ? "checked" : ""} /><span>Show cards</span></label></div>
       <aside class="cards-reshuffle" id="cards-reshuffle" hidden></aside>
       <div class="dealt-cards" id="dealt-cards" aria-live="polite"${showCards ? "" : " hidden"}></div>
+      ${direct ? `<label class="seed-autocomplete-toggle manual-calculations-toggle"><input type="checkbox" id="show-manual-calculations" ${hodlManualCalculationsOpen ? "checked" : ""} /><span><strong>Show calculations</strong> <span class="seed-autocomplete-note">(show how direct card selection produces each BIP39 index)</span></span></label><div id="cards-manual-calculations" class="manual-calculations-container" hidden></div>` : ""}
       ${hodlSeedCopyRowMarkup()}
       <div id="dice-words" class="dice-word-grid" aria-label="${config.words} seed-word slots"></div>
     `;
@@ -5271,6 +5357,7 @@ function hodlRenderKeyForm() {
           state.cardMethod = radio.value;
         }
         hodlCardMethod = radio.value;
+        hodlManualCalculationsOpen = false;
         hodlInvalidateLiveKeyResult();
         hodlRenderKeyForm();
         hodlRestoreFormFields(state);
@@ -5304,6 +5391,11 @@ function hodlRenderKeyForm() {
       if (state) state.showCards = visible;
       if (dealt) dealt.hidden = !visible;
     };
+    let manualToggle = document.getElementById("show-manual-calculations");
+    if (manualToggle) manualToggle.onchange = () => {
+      hodlManualCalculationsOpen = manualToggle.checked;
+      hodlUpdateDirectCards();
+    };
     let colemanToggle = document.getElementById("cards-ian-coleman");
     if (colemanToggle) colemanToggle.onchange = () => {
       hodlCardColemanSymbols = colemanToggle.checked;
@@ -5335,6 +5427,7 @@ function hodlRenderKeyForm() {
       <p class="label">Number base</p>
       <div class="choice-grid entropy-format-grid">${formatChoices}</div>
       <div class="number-base-sync-row"><label class="seed-autocomplete-toggle number-base-sync-toggle"><input type="checkbox" id="sync-number-bases" ${syncEnabled ? "checked" : ""} /><span><strong>Sync number bases</strong> <span class="seed-autocomplete-note">(fill every format after complete valid entropy is entered)</span></span></label><span class="number-base-sync-status" id="number-base-sync-status" aria-live="polite" hidden>${hodlCopiedIconMarkup()}<span>Synced</span></span></div>
+      ${["bin", "base4", "base8", "hex"].includes(format.id) ? `<label class="seed-autocomplete-toggle number-base-calculations-toggle"><input type="checkbox" id="show-number-base-calculations" ${state?.showNumberBaseCalculations ? "checked" : ""} /><span><strong>Show calculations</strong> <span class="seed-autocomplete-note">(show how each BIP39 word number is calculated)</span></span></label>` : ""}
       <p class="label" id="entropy-input-label">${format.label} entropy for a ${config.words}-word seed</p>
       <p class="muted" id="entropy-input-help">Each complete ${format.shortLabel} character contributes ${format.bitsPerDigit} bit${format.bitsPerDigit === 1 ? "" : "s"}${format.binaryRemainder ? "" : " except for a mixed-radix final character when needed"}. Seed-word cards fill as enough bits arrive; the checksum-derived final word appears when all ${format.digits} characters are entered.${format.id === "bin" ? " Spaces are added every 11 bits." : ""}${remainderHelp} No generator \u2014 enter entropy you already created.</p>
       ${base64Tools}
@@ -5342,6 +5435,7 @@ function hodlRenderKeyForm() {
       ${hodlSeedMetaRowMarkup("entropy-meta", true)}
       ${base64Keyboard}
       ${entropyPad}
+      <div id="number-base-calculations" class="number-base-calculations-panel" hidden></div>
       ${hodlSeedCopyRowMarkup()}
       <div id="entropy-words" class="dice-word-grid" aria-label="${config.words} seed-word slots"></div>`;
     at.querySelectorAll('input[name="entropy-format"]').forEach((radio) => {
@@ -5365,6 +5459,12 @@ function hodlRenderKeyForm() {
       let input = document.getElementById(inputId);
       if (input) hodlUpdateEntropyInput(input, format.id);
       if (!syncToggle.checked) hodlSetNumberBaseSyncStatus(false);
+    };
+    let calculationsToggle = document.getElementById("show-number-base-calculations");
+    if (calculationsToggle) calculationsToggle.onchange = () => {
+      if (state) state.showNumberBaseCalculations = calculationsToggle.checked;
+      let input = document.getElementById(inputId);
+      if (input) hodlRenderNumberBaseCalculations(input.value, format.id, config.words);
     };
     hodlBindKeyFields();
     let entropyInput = document.getElementById(inputId);
@@ -5671,6 +5771,7 @@ function hodlUpdateDice() {
     if (result.finalWord) displayWords.push(result.finalWord);
     else if (selectedFinal) displayWords.push(selectedFinal);
     hodlRenderDiceWordGrid(wordsBox, displayWords, config.words, false);
+    hodlRenderManualCalculations("dice-manual-calculations", "dplus", input.value, config.words);
     hodlRenderLastWordPicker(picker, selectingFinal ? result.candidates : [], selectedFinal, (word) => {
       ft = word;
       let state = hodlKeys[hodlActiveKey];
@@ -5701,6 +5802,7 @@ function hodlUpdateDice() {
     if (result.waiting === "last-word" && last && !last.error && ft) displayWords.push(ft);
     W("#dice-meta").textContent = status + invalidStatus;
     hodlRenderDiceWordGrid(wordsBox, displayWords, config.words, false);
+    hodlRenderManualCalculations("dice-manual-calculations", "bitbox", input.value, config.words);
     hodlRenderLastWordPicker(picker, last && !last.error ? last.candidates : [], ft, (word) => {
       ft = word;
       let state = hodlKeys[hodlActiveKey];
@@ -8927,6 +9029,8 @@ function hodlRestoreFormFields(state) {
   });
   let syncNumberBases = document.getElementById("sync-number-bases");
   if (syncNumberBases) syncNumberBases.checked = Boolean(state.syncNumberBases);
+  let showNumberBaseCalculations = document.getElementById("show-number-base-calculations");
+  if (showNumberBaseCalculations) showNumberBaseCalculations.checked = Boolean(state.showNumberBaseCalculations);
   let seedAutocomplete = document.getElementById("seed-autocomplete");
   if (seedAutocomplete) seedAutocomplete.checked = Boolean(state.seedAutocomplete);
   let brainLab = document.getElementById("brain-lab");
@@ -9154,6 +9258,8 @@ function hodlCaptureKey() {
   state.entropyFormat = hodlEntropyFormat;
   let syncNumberBases = document.getElementById("sync-number-bases");
   if (syncNumberBases) state.syncNumberBases = syncNumberBases.checked;
+  let showNumberBaseCalculations = document.getElementById("show-number-base-calculations");
+  if (showNumberBaseCalculations) state.showNumberBaseCalculations = showNumberBaseCalculations.checked;
   let seedAutocomplete = document.getElementById("seed-autocomplete");
   if (seedAutocomplete) state.seedAutocomplete = seedAutocomplete.checked;
   let passphraseBip39Words = document.getElementById("passphrase-bip39-words");

--- a/test/number-bases.test.mjs
+++ b/test/number-bases.test.mjs
@@ -27,7 +27,7 @@ function loadVariable(name, nextName) {
 
 const api = new Function(
   "M",
-  `var Pt=24;
+  `var Pt=24; var Ae=Array.from({length:2048},(_,index)=>String(index));
 ${loadVariable("hodlSeedLengths", "hodlEntropyFormats")}
 ${loadVariable("hodlEntropyFormats", "hodlBip39WordSet")}
 ${loadSlice("hodlSeedConfig")}
@@ -38,12 +38,17 @@ ${loadSlice("hodlFilterNumberBase")}
 ${loadSlice("hodlEntropyDigitEntries")}
 ${loadSlice("hodlEntropyDigits")}
 ${loadSlice("hodlNumberBaseBits")}
+${loadSlice("hodlNumberBasePreviewWords")}
+${loadSlice("hodlBinaryPreviewWords")}
+${loadSlice("hodlNumberBaseCalculationRows")}
+${loadSlice("hodlBinaryCalculationRows")}
+${loadSlice("hodlNumberBaseBinaryConversionMarkup")}
 ${loadSlice("hodlNumberBaseValueFromBytes")}
 ${loadSlice("hodlBinaryDigits")}
 ${loadSlice("hodlGroupedBinary")}
 ${loadSlice("hodlAnalyzeEntropyInput")}
 ${loadSlice("hodlNumberBaseEntropy")}
-return {hodlEntropyFormats,hodlEntropyFormatConfig,hodlFilterNumberBase,hodlAnalyzeEntropyInput,hodlNumberBaseEntropy,hodlNumberBaseValueFromBytes};`,
+return {hodlEntropyFormats,hodlEntropyFormatConfig,hodlFilterNumberBase,hodlAnalyzeEntropyInput,hodlNumberBaseEntropy,hodlNumberBaseValueFromBytes,hodlNumberBaseCalculationRows,hodlBinaryCalculationRows,hodlNumberBaseBinaryConversionMarkup};`,
 )({ encode: (bytes) => Buffer.from(bytes).toString("hex") });
 
 const hexToBits = (hex) => [...hex].map((digit) => Number.parseInt(digit, 16).toString(2).padStart(4, "0")).join("");
@@ -135,6 +140,25 @@ test("complete entropy can be synchronized into every number base", () => {
       assert.equal(api.hodlNumberBaseEntropy(value, format, words).hex, hex, `${words} words, ${format}`);
     }
   }
+});
+
+test("binary calculation rows expose BIP39 place values and word numbers", () => {
+  const rows = api.hodlBinaryCalculationRows("00000000001", 12);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].index, 1);
+  assert.deepEqual(rows[0].terms.map(({ place, bit, value }) => [place, bit, value]), [[1024, "0", 0], [512, "0", 0], [256, "0", 0], [128, "0", 0], [64, "0", 0], [32, "0", 0], [16, "0", 0], [8, "0", 0], [4, "0", 0], [2, "0", 0], [1, "1", 1]]);
+});
+
+test("Base 4 calculation rows use the same normalized 11-bit BIP39 mapping", () => {
+  const rows = api.hodlNumberBaseCalculationRows("333333", "base4", 12);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].index, 2047);
+  assert.deepEqual(rows[0].terms.map(({ place, bit, value }) => [place, bit, value]), [[1024, "1", 1024], [512, "1", 512], [256, "1", 256], [128, "1", 128], [64, "1", 64], [32, "1", 32], [16, "1", 16], [8, "1", 8], [4, "1", 4], [2, "1", 2], [1, "1", 1]]);
+});
+
+test("hex conversion displays each source digit and its binary value", () => {
+  const markup = api.hodlNumberBaseBinaryConversionMarkup("A", api.hodlEntropyFormatConfig("hex", 12));
+  assert.match(markup, />A<\/strong><b>\u2192<\/b><span>1010<\/span>/);
 });
 
 test("Crockford Base32 normalizes its documented aliases", () => {

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -185,6 +185,8 @@ test("direct dice and card methods expose manual BIP39 calculations before copyi
   assert.match(appSource, /dplus-calculation-stages/);
   assert.match(appSource, /dplus-calculation-stage.*stage\.face/);
   assert.match(css, /\.manual-calculation-row \{/);
+  assert.match(css, /\.dplus-calculation-stages \{[^}]*grid-template-columns: repeat\(6, minmax\(0, 1fr\)\)/);
+  assert.match(css, /\.dplus-calculation-stage span \{ grid-column: 1 \/ -1; color: var\(--muted\)/);
   assert.match(css, /\.dplus-calculation-stage \{/);
 });
 

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -163,12 +163,29 @@ test("entropy progress messages sit directly below their inputs and above keypad
   assert.match(app, /<textarea id="key"[^>]*><\/textarea><\/div><p class="muted" id="private-key-meta"[^>]*><\/p>/);
 });
 
-test("seed phrase copy controls sit immediately above every numbered word grid", () => {
-  assert.match(appSource, /\$\{dicePad\}\s*\$\{hodlSeedCopyRowMarkup\(hodlDiceFairnessToggleMarkup\([\s\S]*?\)\)\}\s*<aside id="dice-fairness"[\s\S]*?<\/aside>\s*<div id="dice-words"/);
-  assert.match(appSource, /<div class="dealt-cards"[^>]*><\/div>\s*\$\{hodlSeedCopyRowMarkup\(\)\}\s*<div id="dice-words"/);
-  assert.match(appSource, /\$\{entropyPad\}\s*\$\{hodlSeedCopyRowMarkup\(\)\}\s*<div id="entropy-words"/);
+test("seed phrase calculations and copy controls precede every numbered word grid", () => {
+  assert.match(appSource, /\$\{dicePad\}[\s\S]*?manual-calculations-container[\s\S]*?\$\{hodlSeedCopyRowMarkup\(hodlDiceFairnessToggleMarkup\([\s\S]*?\)\)\}[\s\S]*?<div id="dice-words"/);
+  assert.match(appSource, /<div class="dealt-cards"[^>]*><\/div>[\s\S]*?manual-calculations-container[\s\S]*?\$\{hodlSeedCopyRowMarkup\(\)\}\s*<div id="dice-words"/);
+  assert.match(appSource, /\$\{entropyPad\}\s*<div id="number-base-calculations"[^>]*><\/div>\s*\$\{hodlSeedCopyRowMarkup\(\)\}\s*<div id="entropy-words"/);
   assert.match(appSource, /<\/div>\$\{hodlSeedCopyRowMarkup\(\)\}<div id="seed-number-words"/);
   assert.match(appSource, /function hodlSeedMetaRowMarkup\(metaId, live = false\) \{\s*return `<div class="seed-word-meta"><p[^`]+<\/p><\/div>`;\s*\}/);
+});
+
+test("direct dice and card methods expose manual BIP39 calculations before copying", () => {
+  assert.match(appSource, /id="show-manual-calculations"/);
+  assert.match(appSource, /id="dice-manual-calculations" class="manual-calculations-container"/);
+  assert.match(appSource, /id="cards-manual-calculations" class="manual-calculations-container"/);
+  assert.match(appSource, /function hodlManualCalculationMarkup\(method, value, targetWords = Pt\)/);
+  assert.match(appSource, /hodlRenderManualCalculations\("dice-manual-calculations",\s*"dplus"/);
+  assert.match(appSource, /hodlRenderManualCalculations\("dice-manual-calculations",\s*"bitbox"/);
+  assert.match(appSource, /hodlRenderManualCalculations\("cards-manual-calculations",\s*"cards"/);
+  assert.match(appSource, /D8 contributes 8 values and each hexadecimal D16 contributes 16 values/);
+  assert.match(appSource, /Each D4 contributes one base-4 value and the final die contributes the coin bit/);
+  assert.match(appSource, /Ranks are mapped to zero-based values/);
+  assert.match(appSource, /dplus-calculation-stages/);
+  assert.match(appSource, /dplus-calculation-stage.*stage\.face/);
+  assert.match(css, /\.manual-calculation-row \{/);
+  assert.match(css, /\.dplus-calculation-stage \{/);
 });
 
 test("Seed phrase offers one-based or zero-based BIP39 word-number entry", () => {
@@ -215,11 +232,15 @@ test("Number bases offers exact Base 2, 4, 8, 16, Crockford Base32, and Base64-a
   assert.match(app, /function hodlNumberBasePreviewWords\(value,format,targetWords=Pt\)/);
   assert.match(app, /function hodlNumberBaseValueFromBytes\(bytes,format,targetWords=Pt\)/);
   assert.match(app, /id="sync-number-bases"/);
+  assert.match(app, /id="show-number-base-calculations"/);
+  assert.match(app, /function hodlBinaryCalculationRows\(value,targetWords=Pt\)/);
+  assert.match(app, /id="number-base-calculations" class="number-base-calculations-panel"/);
   assert.match(app, /id="number-base-sync-status"[^>]*hidden>\$\{hodlCopiedIconMarkup\(\)\}<span>Synced<\/span>/);
   assert.match(app, /syncNumberBases:!1/);
   assert.match(app, /entropyFormat:"bin"/);
   assert.ok(app.includes('function hodlNormalizeEntropyFormat(format){return Object.hasOwn(hodlEntropyFormats,String(format??""))?String(format):"bin"}'));
   assert.match(css, /\.number-base-sync-status \{[\s\S]*?color: var\(--ok\)/);
+  assert.match(css, /\.number-base-calculation-list \{/);
   assert.match(app, /fields:\{[^}]*base4:"",base8:"",base32:"",base64:""/);
   assert.match(app, /function hodlBase64KeyboardMarkup\(\)\{return hodlKeyboardMarkup\(!0,"Base64 entropy","base64-keyboard"\)\}/);
   assert.match(app, /function hodlBindBase64Keyboard\(input\)/);


### PR DESCRIPTION
## Summary

Adds optional educational calculation views for manually generated BIP39 entropy.

### Included

- Binary and number-base calculation displays
- Hexadecimal-to-binary conversion reference
- D++ staged calculation breakdown
- BitBox diceware calculation breakdown
- Direct card calculation breakdown
- BIP39 index and word-number explanations
- Compact responsive mobile layouts
- Improved calculation styling and spacing
- Copy controls remain below the calculation panels

### Notes

- Hashed dice and hashed card methods are unchanged.
- Final checksum words remain selected from the valid BIP39 candidate list.
- No new dependencies or network requests were added.

## Testing

- `npm run build`
- Focused tests: 76/76 passing