### PR TITLE
Move workspace tabs into a hamburger dropdown menu at every width

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -767,16 +767,10 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .hint.bad { color: var(--danger); }
 .hint.ok { color: var(--ok); }
 .hint:empty, .err:empty { display: none; }
-/* The pitch-to-tool seam now lands on the shell that holds the workspace
-   switcher and the tool together. */
-.tool-shell { margin-top: var(--space-lede); }
-/* Grid items refuse to shrink below their content without this; the address
-   tables inside are wider than any narrow column. */
-.tool-content { min-width: 0; }
-/* The workspace switcher is a videogame-style settings menu: a sticky
-   sidebar beside the tool on wide screens, a hamburger dropdown above it on
-   narrow ones. */
-.workspace { position: relative; margin: 0 0 4px; }
+/* The workspace switcher is a videogame-style settings menu at every width:
+   a hamburger bar above the tool that drops the menu down over it. The
+   pitch-to-tool seam lands on it, as it did on the tab strip before. */
+.workspace { position: relative; margin: var(--space-lede) 0 4px; }
 .workspace-menu-toggle {
   display: flex; align-items: center; gap: 10px; width: 100%; min-height: 44px;
   padding: 0 14px; border: 1px solid var(--border); border-radius: 12px;
@@ -791,8 +785,8 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .workspace-menu-chevron { color: var(--accent); transition: transform 120ms ease; }
 .workspace.is-open .workspace-menu-chevron { transform: rotate(180deg); }
 @media (prefers-reduced-motion: reduce) { .workspace-menu-chevron { transition: none; } }
-/* Narrow screens: the menu is a dropdown panel under the toggle, closed
-   until it is asked for. */
+/* The menu is a dropdown panel under the toggle, closed until it is asked
+   for. */
 .workspace-menu {
   position: absolute; top: calc(100% + 6px); left: 0; right: 0; z-index: 60;
   display: none; gap: 4px; padding: 8px;
@@ -811,18 +805,6 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 }
 .workspace-menu .tab:focus-visible {
   outline: 2px solid color-mix(in oklab, var(--selection-accent) 72%, var(--fg)); outline-offset: 2px;
-}
-/* Wide screens: header and page widen by exactly the sidebar's footprint, so
-   the content column keeps its 1000px-line measure and the centered pair —
-   not the viewport edge — carries the menu. */
-@media (min-width: 1024px) {
-  .site-header-inner, .wrap { max-width: 1260px; }
-  .tool-shell { display: grid; grid-template-columns: 232px minmax(0, 1fr); gap: 0 28px; align-items: start; }
-  /* Sticky, so the menu stays beside the tool down the longest result page.
-     The 14px aligns its top edge with the Keys / Multisigs tab strip. */
-  .workspace { position: sticky; top: calc(var(--site-header-height) + 12px); margin: 14px 0 0; }
-  .workspace-menu-toggle { display: none; }
-  .workspace-menu { position: static; display: grid; box-shadow: none; }
 }
 .segmented-control {
   display: flex; align-items: stretch; flex-wrap: wrap; gap: 0; max-width: 100%; isolation: isolate;

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -767,7 +767,63 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .hint.bad { color: var(--danger); }
 .hint.ok { color: var(--ok); }
 .hint:empty, .err:empty { display: none; }
-#workspace { margin: var(--space-lede) 0 4px; } /* the pitch ends here and the tool begins */
+/* The pitch-to-tool seam now lands on the shell that holds the workspace
+   switcher and the tool together. */
+.tool-shell { margin-top: var(--space-lede); }
+/* Grid items refuse to shrink below their content without this; the address
+   tables inside are wider than any narrow column. */
+.tool-content { min-width: 0; }
+/* The workspace switcher is a videogame-style settings menu: a sticky
+   sidebar beside the tool on wide screens, a hamburger dropdown above it on
+   narrow ones. */
+.workspace { position: relative; margin: 0 0 4px; }
+.workspace-menu-toggle {
+  display: flex; align-items: center; gap: 10px; width: 100%; min-height: 44px;
+  padding: 0 14px; border: 1px solid var(--border); border-radius: 12px;
+  background: var(--surface); color: var(--fg); font-weight: 600; text-align: left;
+}
+.workspace-menu-toggle:hover { border-color: var(--faint); }
+.workspace-menu-toggle:focus-visible { outline: 2px solid var(--selection-accent); outline-offset: 2px; }
+.workspace-menu-toggle svg { flex: 0 0 auto; }
+.workspace-menu-current {
+  flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.workspace-menu-chevron { color: var(--accent); transition: transform 120ms ease; }
+.workspace.is-open .workspace-menu-chevron { transform: rotate(180deg); }
+@media (prefers-reduced-motion: reduce) { .workspace-menu-chevron { transition: none; } }
+/* Narrow screens: the menu is a dropdown panel under the toggle, closed
+   until it is asked for. */
+.workspace-menu {
+  position: absolute; top: calc(100% + 6px); left: 0; right: 0; z-index: 60;
+  display: none; gap: 4px; padding: 8px;
+  border: 1px solid var(--border); border-radius: 14px; background: var(--surface);
+  box-shadow: 0 16px 36px rgb(0 0 0 / 55%);
+}
+.workspace.is-open .workspace-menu { display: grid; }
+.workspace-menu .tab {
+  display: flex; align-items: center; margin: 0; border: 1px solid transparent;
+  border-radius: 10px; background: transparent; color: var(--muted);
+  text-align: left; white-space: nowrap;
+}
+.workspace-menu .tab:not(.active):hover { background: color-mix(in oklab, var(--surface-2) 70%, transparent); color: var(--fg); }
+.workspace-menu .tab:is(.active, [aria-pressed="true"]) {
+  background: var(--selection-accent); border-color: var(--selection-accent); color: var(--selection-fg); font-weight: 600;
+}
+.workspace-menu .tab:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--selection-accent) 72%, var(--fg)); outline-offset: 2px;
+}
+/* Wide screens: header and page widen by exactly the sidebar's footprint, so
+   the content column keeps its 1000px-line measure and the centered pair —
+   not the viewport edge — carries the menu. */
+@media (min-width: 1024px) {
+  .site-header-inner, .wrap { max-width: 1260px; }
+  .tool-shell { display: grid; grid-template-columns: 232px minmax(0, 1fr); gap: 0 28px; align-items: start; }
+  /* Sticky, so the menu stays beside the tool down the longest result page.
+     The 14px aligns its top edge with the Keys / Multisigs tab strip. */
+  .workspace { position: sticky; top: calc(var(--site-header-height) + 12px); margin: 14px 0 0; }
+  .workspace-menu-toggle { display: none; }
+  .workspace-menu { position: static; display: grid; box-shadow: none; }
+}
 .segmented-control {
   display: flex; align-items: stretch; flex-wrap: wrap; gap: 0; max-width: 100%; isolation: isolate;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -44,9 +44,7 @@
         <li>Keep your private keys offline.</li>
       </ul>
     </section>
-    <div class="tool-shell">
     <nav class="workspace no-print" id="workspace"><button type="button" class="workspace-menu-toggle" id="workspace-menu-toggle" aria-expanded="false" aria-controls="workspace-menu"><svg class="workspace-menu-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true" focusable="false"><path d="M4 7h16M4 12h16M4 17h16"/></svg><span class="workspace-menu-current" id="workspace-menu-current">Key Derivation</span><svg class="workspace-menu-chevron" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="m6 9 6 6 6-6"/></svg></button><div class="workspace-menu" id="workspace-menu" role="group" aria-label="Workspace"><button class="tab active" aria-pressed="true">Key Derivation</button><button class="tab" aria-pressed="false">BIP-85</button><button class="tab" aria-pressed="false">Multi Signature</button><button class="tab" aria-pressed="false">Silent Payments</button><button class="tab" aria-pressed="false">PSBT / Nonce</button></div></nav>
-    <div class="tool-content">
     <section class="key-manager no-print" id="key-manager">
       <div class="key-manager-head"><h2>Keys</h2></div>
       <div class="key-tab-strip"><div class="key-tabs" id="key-tabs" role="tablist" aria-label="Keys"></div><div class="add-item-control"><button class="add-key" id="add-key" type="button" aria-label="Add key" aria-describedby="add-key-tooltip">+</button><span class="add-item-tooltip" id="add-key-tooltip" role="tooltip">Add another key</span></div></div>
@@ -453,8 +451,6 @@ words, pick one of the checksum words.</span></span>
       <p class="muted">Session keys remain in this page only and are never intentionally stored or sent. Memory clearing is best-effort because browsers may retain internal copies; close the page before reconnecting the computer.</p>
     </section>
     <div id="out"></div>
-    </div>
-    </div>
     <section class="card muted sources">
       <h3 class="sources-heading">Sources</h3>
       <p>Ian Coleman BIP39: <a href="https://github.com/iancoleman/bip39" target="_blank" rel="noopener noreferrer">github.com/iancoleman/bip39</a> — pull <code>bip39-standalone.html</code> from Releases, or <code>src/js/index.js</code>, <code>entropy.js</code>, <code>jsbip39.js</code>, <code>wordlist_english.js</code>.</p>

--- a/src/index.html
+++ b/src/index.html
@@ -44,7 +44,9 @@
         <li>Keep your private keys offline.</li>
       </ul>
     </section>
-    <div class="row no-print segmented-control" id="workspace"><button class="tab active" aria-pressed="true">Key Derivation</button><button class="tab" aria-pressed="false">BIP-85</button><button class="tab" aria-pressed="false">Multi Signature</button><button class="tab" aria-pressed="false">Silent Payments</button><button class="tab" aria-pressed="false">PSBT / Nonce</button></div>
+    <div class="tool-shell">
+    <nav class="workspace no-print" id="workspace"><button type="button" class="workspace-menu-toggle" id="workspace-menu-toggle" aria-expanded="false" aria-controls="workspace-menu"><svg class="workspace-menu-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true" focusable="false"><path d="M4 7h16M4 12h16M4 17h16"/></svg><span class="workspace-menu-current" id="workspace-menu-current">Key Derivation</span><svg class="workspace-menu-chevron" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="m6 9 6 6 6-6"/></svg></button><div class="workspace-menu" id="workspace-menu" role="group" aria-label="Workspace"><button class="tab active" aria-pressed="true">Key Derivation</button><button class="tab" aria-pressed="false">BIP-85</button><button class="tab" aria-pressed="false">Multi Signature</button><button class="tab" aria-pressed="false">Silent Payments</button><button class="tab" aria-pressed="false">PSBT / Nonce</button></div></nav>
+    <div class="tool-content">
     <section class="key-manager no-print" id="key-manager">
       <div class="key-manager-head"><h2>Keys</h2></div>
       <div class="key-tab-strip"><div class="key-tabs" id="key-tabs" role="tablist" aria-label="Keys"></div><div class="add-item-control"><button class="add-key" id="add-key" type="button" aria-label="Add key" aria-describedby="add-key-tooltip">+</button><span class="add-item-tooltip" id="add-key-tooltip" role="tooltip">Add another key</span></div></div>
@@ -451,6 +453,8 @@ words, pick one of the checksum words.</span></span>
       <p class="muted">Session keys remain in this page only and are never intentionally stored or sent. Memory clearing is best-effort because browsers may retain internal copies; close the page before reconnecting the computer.</p>
     </section>
     <div id="out"></div>
+    </div>
+    </div>
     <section class="card muted sources">
       <h3 class="sources-heading">Sources</h3>
       <p>Ian Coleman BIP39: <a href="https://github.com/iancoleman/bip39" target="_blank" rel="noopener noreferrer">github.com/iancoleman/bip39</a> — pull <code>bip39-standalone.html</code> from Releases, or <code>src/js/index.js</code>, <code>entropy.js</code>, <code>jsbip39.js</code>, <code>wordlist_english.js</code>.</p>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -555,7 +555,9 @@ ec.innerHTML = `
         <li>Keep your private keys offline.</li>
       </ul>
     </section>
-    <div class="row no-print segmented-control" id="workspace" role="group" aria-label="Workspace"></div>
+    <div class="tool-shell">
+    <nav class="workspace no-print" id="workspace"></nav>
+    <div class="tool-content">
     <section class="key-manager no-print" id="key-manager">
       <div class="key-manager-head"><h2>Keys</h2></div>
       <div class="key-tab-strip"><div class="key-tabs" id="key-tabs" role="tablist" aria-label="Keys"></div><div class="add-item-control"><button class="add-key" id="add-key" type="button" aria-label="Add key" aria-describedby="add-key-tooltip">+</button><span class="add-item-tooltip" id="add-key-tooltip" role="tooltip">Add another key</span></div></div>
@@ -930,6 +932,8 @@ ec.innerHTML = `
       <p class="muted">Session keys remain in this page only and are never intentionally stored or sent. Memory clearing is best-effort because browsers may retain internal copies; close the page before reconnecting the computer.</p>
     </section>
     <div id="out"></div>
+    </div>
+    </div>
     <section class="card muted sources">
       <h3 class="sources-heading">Sources</h3>
       <p>Ian Coleman BIP39: <a href="https://github.com/iancoleman/bip39" target="_blank" rel="noopener noreferrer">github.com/iancoleman/bip39</a> \u2014 pull <code>bip39-standalone.html</code> from Releases, or <code>src/js/index.js</code>, <code>entropy.js</code>, <code>jsbip39.js</code>, <code>wordlist_english.js</code>.</p>
@@ -9485,11 +9489,12 @@ function hodlShowWorkspace(id) {
   if (hodlWorkspace === "calc") hodlCaptureKey();
   else if (hodlWorkspace === "msig") hodlCaptureMsig();
   hodlWorkspace = id;
-  [...W("#workspace").children].forEach((button) => {
+  [...W("#workspace-menu").children].forEach((button) => {
     let active = button.dataset.workspace === id;
     button.classList.toggle("active", active);
     button.setAttribute("aria-pressed", String(active));
   });
+  W("#workspace-menu-current").textContent = hodlWorkspaceTabs.find(([tab]) => tab === id)?.[1] ?? "";
   document.getElementById("key-manager").hidden = id !== "calc";
   document.getElementById("msig-manager").hidden = id !== "msig";
   document.getElementById("calc-card").hidden = true;
@@ -9588,19 +9593,56 @@ function hodlSeedInitialManagers() {
     hodlActiveMsig = 0;
   }
 }
+var hodlWorkspaceTabs = [["calc", "Key Derivation"], ["bip85", "BIP-85"], ["msig", "Multi Signature"], ["sp", "Silent Payments"], ["psbt", "PSBT / Nonce"]];
+// The switcher reads as a videogame settings menu: a sticky sidebar beside
+// the tool on wide screens, and a hamburger dropdown above it on narrow
+// ones. The is-open class only matters in the dropdown layout; the sidebar
+// ignores it, and crossing back to the wide layout clears it.
+function hodlSetWorkspaceMenuOpen(open) {
+  W("#workspace").classList.toggle("is-open", open);
+  W("#workspace-menu-toggle").setAttribute("aria-expanded", String(open));
+}
 function hodlInitWorkspace() {
   let box = W("#workspace");
   box.innerHTML = "";
-  [["calc", "Key Derivation"], ["bip85", "BIP-85"], ["msig", "Multi Signature"], ["sp", "Silent Payments"], ["psbt", "PSBT / Nonce"]].forEach(([id, label]) => {
+  let toggle = document.createElement("button");
+  toggle.type = "button";
+  toggle.className = "workspace-menu-toggle";
+  toggle.id = "workspace-menu-toggle";
+  toggle.setAttribute("aria-expanded", "false");
+  toggle.setAttribute("aria-controls", "workspace-menu");
+  toggle.innerHTML = `<svg class="workspace-menu-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true" focusable="false"><path d="M4 7h16M4 12h16M4 17h16"/></svg><span class="workspace-menu-current" id="workspace-menu-current"></span><svg class="workspace-menu-chevron" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="m6 9 6 6 6-6"/></svg>`;
+  toggle.onclick = () => hodlSetWorkspaceMenuOpen(!box.classList.contains("is-open"));
+  let menu = document.createElement("div");
+  menu.className = "workspace-menu";
+  menu.id = "workspace-menu";
+  menu.setAttribute("role", "group");
+  menu.setAttribute("aria-label", "Workspace");
+  hodlWorkspaceTabs.forEach(([id, label]) => {
     let button = document.createElement("button"), active = hodlWorkspace === id;
     button.type = "button";
     button.className = "tab" + (active ? " active" : "");
     button.dataset.workspace = id;
     button.setAttribute("aria-pressed", String(active));
     button.textContent = label;
-    button.onclick = () => hodlShowWorkspace(id);
-    box.appendChild(button);
+    button.onclick = () => {
+      hodlShowWorkspace(id);
+      hodlSetWorkspaceMenuOpen(false);
+    };
+    menu.appendChild(button);
   });
+  box.append(toggle, menu);
+  W("#workspace-menu-current").textContent = hodlWorkspaceTabs.find(([id]) => id === hodlWorkspace)?.[1] ?? "";
+  document.addEventListener("click", (event) => {
+    if (box.classList.contains("is-open") && !event.target.closest("#workspace")) hodlSetWorkspaceMenuOpen(false);
+  });
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && box.classList.contains("is-open")) {
+      hodlSetWorkspaceMenuOpen(false);
+      toggle.focus();
+    }
+  });
+  matchMedia("(min-width: 1024px)").addEventListener("change", () => hodlSetWorkspaceMenuOpen(false));
   hodlInitMsig();
   hodlInitPsbt();
   hodlInitBip85();

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -555,9 +555,7 @@ ec.innerHTML = `
         <li>Keep your private keys offline.</li>
       </ul>
     </section>
-    <div class="tool-shell">
     <nav class="workspace no-print" id="workspace"></nav>
-    <div class="tool-content">
     <section class="key-manager no-print" id="key-manager">
       <div class="key-manager-head"><h2>Keys</h2></div>
       <div class="key-tab-strip"><div class="key-tabs" id="key-tabs" role="tablist" aria-label="Keys"></div><div class="add-item-control"><button class="add-key" id="add-key" type="button" aria-label="Add key" aria-describedby="add-key-tooltip">+</button><span class="add-item-tooltip" id="add-key-tooltip" role="tooltip">Add another key</span></div></div>
@@ -932,8 +930,6 @@ ec.innerHTML = `
       <p class="muted">Session keys remain in this page only and are never intentionally stored or sent. Memory clearing is best-effort because browsers may retain internal copies; close the page before reconnecting the computer.</p>
     </section>
     <div id="out"></div>
-    </div>
-    </div>
     <section class="card muted sources">
       <h3 class="sources-heading">Sources</h3>
       <p>Ian Coleman BIP39: <a href="https://github.com/iancoleman/bip39" target="_blank" rel="noopener noreferrer">github.com/iancoleman/bip39</a> \u2014 pull <code>bip39-standalone.html</code> from Releases, or <code>src/js/index.js</code>, <code>entropy.js</code>, <code>jsbip39.js</code>, <code>wordlist_english.js</code>.</p>
@@ -9594,10 +9590,9 @@ function hodlSeedInitialManagers() {
   }
 }
 var hodlWorkspaceTabs = [["calc", "Key Derivation"], ["bip85", "BIP-85"], ["msig", "Multi Signature"], ["sp", "Silent Payments"], ["psbt", "PSBT / Nonce"]];
-// The switcher reads as a videogame settings menu: a sticky sidebar beside
-// the tool on wide screens, and a hamburger dropdown above it on narrow
-// ones. The is-open class only matters in the dropdown layout; the sidebar
-// ignores it, and crossing back to the wide layout clears it.
+// The switcher reads as a videogame settings menu at every width: a
+// hamburger bar that drops the menu down over the tool. The is-open class
+// opens and closes the dropdown.
 function hodlSetWorkspaceMenuOpen(open) {
   W("#workspace").classList.toggle("is-open", open);
   W("#workspace-menu-toggle").setAttribute("aria-expanded", String(open));
@@ -9642,7 +9637,6 @@ function hodlInitWorkspace() {
       toggle.focus();
     }
   });
-  matchMedia("(min-width: 1024px)").addEventListener("change", () => hodlSetWorkspaceMenuOpen(false));
   hodlInitMsig();
   hodlInitPsbt();
   hodlInitBip85();

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -1019,9 +1019,8 @@ test("the seam into the tool is wider than the page's other major seams", () => 
   assert.match(css, /--space-lede: 48px;/);
   // The pitch-to-tool seam is the page's widest; the closing Sources card keeps
   // the ordinary major one. Both collapse with a neighbouring card's 16px, so
-  // the larger value wins rather than the two adding up. The seam lives on the
-  // shell that now groups the workspace switcher with the tool it switches.
-  assert.match(css, /\.tool-shell \{ margin-top: var\(--space-lede\); \}/);
+  // the larger value wins rather than the two adding up.
+  assert.match(css, /\.workspace \{ position: relative; margin: var\(--space-lede\) 0 4px; \}/);
   assert.match(css, /\.sources \{ margin-top: var\(--space-major\); \}/);
   for (const markup of [template, app]) {
     assert.match(markup, /<section class="card muted sources">/);
@@ -1194,34 +1193,25 @@ test("Silent Payments sits between Multi Signature and PSBT / Nonce", () => {
   assert.match(css, /#sp-card\[hidden\]/);
 });
 
-test("the workspace switcher is a sticky sidebar on wide screens and a hamburger dropdown on narrow ones", () => {
-  // The switcher and the sections it switches are grouped in one shell so the
-  // wide layout can place the menu in its own column beside the tool.
-  for (const markup of [template, appSource]) {
-    assert.match(markup, /<div class="tool-shell">/);
-    assert.match(markup, /<div class="tool-content">/);
-  }
-  // The switcher is a nav now, and no longer one of the segmented controls.
+test("the workspace switcher is a hamburger dropdown menu at every width", () => {
+  // The switcher is a nav holding a hamburger toggle and the menu it
+  // controls; it is no longer one of the segmented controls.
   assert.match(template, /<nav class="workspace no-print" id="workspace">/);
   assert.match(appSource, /<nav class="workspace no-print" id="workspace"><\/nav>/);
   assert.doesNotMatch(template, /segmented-control" id="workspace"/);
-  // The hamburger toggle is wired to the menu it opens, and names the current
+  // The toggle is wired to the menu it opens, and names the current
   // workspace in the collapsed bar.
   assert.match(template, /<button type="button" class="workspace-menu-toggle" id="workspace-menu-toggle" aria-expanded="false" aria-controls="workspace-menu">/);
   assert.match(template, /<span class="workspace-menu-current" id="workspace-menu-current">Key Derivation<\/span>/);
   assert.match(template, /<div class="workspace-menu" id="workspace-menu" role="group" aria-label="Workspace">/);
-  // Narrow screens: the menu hides until toggled; wide screens: it is always
-  // shown as the sidebar and the toggle is gone. One breakpoint owns both.
-  assert.match(css, /\.workspace-menu \{[^}]*display: none;/s);
+  // The menu hides until toggled. There is no wide-screen sidebar layout:
+  // the same dropdown serves every width and the page keeps its single
+  // 1000px measure.
+  assert.match(css, /\.workspace-menu \{[^}]*position: absolute;[^}]*display: none;/s);
   assert.match(css, /\.workspace\.is-open \.workspace-menu \{ display: grid; \}/);
-  assert.match(css, /@media \(min-width: 1024px\) \{[\s\S]*?\.workspace-menu-toggle \{ display: none; \}/);
-  assert.match(css, /@media \(min-width: 1024px\) \{[\s\S]*?\.workspace-menu \{ position: static; display: grid; box-shadow: none; \}/);
-  assert.match(appSource, /matchMedia\("\(min-width: 1024px\)"\)/);
-  // The sidebar rides along beside the tool instead of docking to the
-  // viewport edge: the centered page simply widens by the menu's footprint.
-  assert.match(css, /@media \(min-width: 1024px\) \{[\s\S]*?\.site-header-inner, \.wrap \{ max-width: 1260px; \}/);
-  assert.match(css, /\.tool-shell \{[^}]*grid-template-columns: 232px minmax\(0, 1fr\);/s);
-  assert.match(css, /@media \(min-width: 1024px\) \{[\s\S]*?\.workspace \{ position: sticky; top: calc\(var\(--site-header-height\) \+ 12px\);/);
+  assert.doesNotMatch(css, /min-width: 1024px|max-width: 1260px|tool-shell|tool-content/);
+  assert.doesNotMatch(appSource, /matchMedia\("\(min-width: 1024px\)"\)/);
+  assert.doesNotMatch(`${template}${appSource}`, /tool-shell|tool-content/);
   // Menu entries keep the app's orange active state.
   assert.match(css, /\.workspace-menu \.tab:is\(\.active, \[aria-pressed="true"\]\) \{[^}]*background: var\(--selection-accent\);/s);
   // Runtime: the toggle flips aria-expanded with the open class, picking an

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -1019,8 +1019,9 @@ test("the seam into the tool is wider than the page's other major seams", () => 
   assert.match(css, /--space-lede: 48px;/);
   // The pitch-to-tool seam is the page's widest; the closing Sources card keeps
   // the ordinary major one. Both collapse with a neighbouring card's 16px, so
-  // the larger value wins rather than the two adding up.
-  assert.match(css, /#workspace \{ margin: var\(--space-lede\) 0 4px; \}/);
+  // the larger value wins rather than the two adding up. The seam lives on the
+  // shell that now groups the workspace switcher with the tool it switches.
+  assert.match(css, /\.tool-shell \{ margin-top: var\(--space-lede\); \}/);
   assert.match(css, /\.sources \{ margin-top: var\(--space-major\); \}/);
   for (const markup of [template, app]) {
     assert.match(markup, /<section class="card muted sources">/);
@@ -1191,4 +1192,47 @@ test("Silent Payments sits between Multi Signature and PSBT / Nonce", () => {
     assert.match(markup, /BIP-352/);
   }
   assert.match(css, /#sp-card\[hidden\]/);
+});
+
+test("the workspace switcher is a sticky sidebar on wide screens and a hamburger dropdown on narrow ones", () => {
+  // The switcher and the sections it switches are grouped in one shell so the
+  // wide layout can place the menu in its own column beside the tool.
+  for (const markup of [template, appSource]) {
+    assert.match(markup, /<div class="tool-shell">/);
+    assert.match(markup, /<div class="tool-content">/);
+  }
+  // The switcher is a nav now, and no longer one of the segmented controls.
+  assert.match(template, /<nav class="workspace no-print" id="workspace">/);
+  assert.match(appSource, /<nav class="workspace no-print" id="workspace"><\/nav>/);
+  assert.doesNotMatch(template, /segmented-control" id="workspace"/);
+  // The hamburger toggle is wired to the menu it opens, and names the current
+  // workspace in the collapsed bar.
+  assert.match(template, /<button type="button" class="workspace-menu-toggle" id="workspace-menu-toggle" aria-expanded="false" aria-controls="workspace-menu">/);
+  assert.match(template, /<span class="workspace-menu-current" id="workspace-menu-current">Key Derivation<\/span>/);
+  assert.match(template, /<div class="workspace-menu" id="workspace-menu" role="group" aria-label="Workspace">/);
+  // Narrow screens: the menu hides until toggled; wide screens: it is always
+  // shown as the sidebar and the toggle is gone. One breakpoint owns both.
+  assert.match(css, /\.workspace-menu \{[^}]*display: none;/s);
+  assert.match(css, /\.workspace\.is-open \.workspace-menu \{ display: grid; \}/);
+  assert.match(css, /@media \(min-width: 1024px\) \{[\s\S]*?\.workspace-menu-toggle \{ display: none; \}/);
+  assert.match(css, /@media \(min-width: 1024px\) \{[\s\S]*?\.workspace-menu \{ position: static; display: grid; box-shadow: none; \}/);
+  assert.match(appSource, /matchMedia\("\(min-width: 1024px\)"\)/);
+  // The sidebar rides along beside the tool instead of docking to the
+  // viewport edge: the centered page simply widens by the menu's footprint.
+  assert.match(css, /@media \(min-width: 1024px\) \{[\s\S]*?\.site-header-inner, \.wrap \{ max-width: 1260px; \}/);
+  assert.match(css, /\.tool-shell \{[^}]*grid-template-columns: 232px minmax\(0, 1fr\);/s);
+  assert.match(css, /@media \(min-width: 1024px\) \{[\s\S]*?\.workspace \{ position: sticky; top: calc\(var\(--site-header-height\) \+ 12px\);/);
+  // Menu entries keep the app's orange active state.
+  assert.match(css, /\.workspace-menu \.tab:is\(\.active, \[aria-pressed="true"\]\) \{[^}]*background: var\(--selection-accent\);/s);
+  // Runtime: the toggle flips aria-expanded with the open class, picking an
+  // entry closes the dropdown, and the collapsed bar tracks the workspace.
+  assert.match(appSource, /function hodlSetWorkspaceMenuOpen\(open\) \{/);
+  assert.match(appSource, /W\("#workspace"\)\.classList\.toggle\("is-open", open\);/);
+  assert.match(appSource, /W\("#workspace-menu-toggle"\)\.setAttribute\("aria-expanded", String\(open\)\);/);
+  assert.match(appSource, /hodlShowWorkspace\(id\);\s*hodlSetWorkspaceMenuOpen\(false\);/);
+  assert.match(appSource, /\[\.\.\.W\("#workspace-menu"\)\.children\]\.forEach/);
+  assert.match(appSource, /W\("#workspace-menu-current"\)\.textContent = hodlWorkspaceTabs\.find/);
+  // Clicking outside or pressing Escape closes the dropdown.
+  assert.match(appSource, /!event\.target\.closest\("#workspace"\)\) hodlSetWorkspaceMenuOpen\(false\);/);
+  assert.match(appSource, /event\.key === "Escape" && box\.classList\.contains\("is-open"\)/);
 });


### PR DESCRIPTION
## What

Moves the workspace switcher (Key Derivation · BIP-85 · Multi Signature · Silent Payments · PSBT / Nonce) out of the horizontal segmented tab strip and into a videogame-style menu: a hamburger bar above the tool that drops the full menu down over it — **the same component at every width, desktop and mobile alike.**

- The bar names the current workspace and carries a chevron that flips while the menu is open.
- The dropdown lists all five workspaces with the active one in the app's orange; picking an entry — or clicking outside, or pressing Escape — closes it, and the bar tracks the active workspace.
- The page keeps its single centered 1000px measure; nothing docks to a screen edge and nothing widens on desktop.

(First revision had a sticky sidebar at ≥1024px with a 1260px page; review feedback asked for the width reverted and the mobile hamburger menu used everywhere.)

## Why

The horizontal strip wrapped awkwardly and spent vertical space phones don't have. One menu component for all platforms keeps the behavior identical everywhere, reads as a settings selector, and frees the most vertical room on every screen.

## How

- `src/index.html` and the runtime template in `src/js/app.js`: the strip becomes a `<nav class="workspace">` holding the hamburger toggle (`aria-expanded` / `aria-controls`, current-workspace label) and the `.workspace-menu` list. The entry buttons are unchanged (`data-workspace`, `aria-pressed`, `.active`), so all workspace behavior and the browser suite's selectors keep working.
- `src/css/styles.css`: the menu is an absolute dropdown panel under the bar, hidden until `.is-open`; no breakpoint anywhere. The pitch-to-tool lede seam moves with the element (`#workspace` → `.workspace`). The chevron transition honors `prefers-reduced-motion`.
- `test/ui-defaults.test.mjs`: the seam assertion moves with the seam; a new test covers the nav/toggle/menu structure, the ARIA wiring, the open/close runtime paths, and that no wide-screen layout or page widening exists.

The generated `entropylab.html` is intentionally not committed; CI rebuilds it.

## Screenshots

**Desktop — closed and open:**

![Desktop menu closed](https://gist.githubusercontent.com/portlandhodl/d90cfbf11310f3b9ff4fbe7e66c38711/raw/entropylab-menu-desktop-closed.png)
![Desktop menu open](https://gist.githubusercontent.com/portlandhodl/d90cfbf11310f3b9ff4fbe7e66c38711/raw/entropylab-menu-desktop-open.png)

**Mobile — closed and open:**

![Mobile menu closed](https://gist.githubusercontent.com/portlandhodl/d90cfbf11310f3b9ff4fbe7e66c38711/raw/entropylab-menu-mobile-closed.png)
![Mobile menu open](https://gist.githubusercontent.com/portlandhodl/d90cfbf11310f3b9ff4fbe7e66c38711/raw/entropylab-menu-mobile-open.png)

## Commands run

- `npm run build`
- `npm test` — 498 passing, including the headless Firefox hosted and offline suites
