### PR TITLE
FIX: Make the online warning permanent

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -655,10 +655,10 @@ td { border-top: 1px solid var(--border); padding: 8px; vertical-align: top; fon
   border-color: var(--danger); background: color-mix(in oklab, var(--danger) 14%, var(--surface));
 }
 .online-warning a { font-weight: 700; white-space: nowrap; }
-/* Every banner that can be dismissed is a row: the message takes the slack,
-   the control column does not. The noscript notice carries no control and
-   stays a plain block, but its label is wrapped like the others so it takes
-   the same treatment. */
+/* The banners are rows: the message takes the slack, a control column (only
+   the beta banner carries one) does not. The noscript notice carries no
+   control and stays a plain block, but its label is wrapped like the others
+   so it takes the same treatment. */
 #beta-warning, #online-warning { display: flex; align-items: flex-start; gap: 12px; }
 /* The author display wins over the UA [hidden] rule, so restate it. */
 #beta-warning[hidden], #online-warning[hidden] { display: none; }
@@ -674,7 +674,7 @@ td { border-top: 1px solid var(--border); padding: 8px; vertical-align: top; fon
   display: block; margin-bottom: 4px; line-height: 1; text-transform: uppercase;
   color: var(--danger-bright);
 }
-.beta-warning-dismiss, .online-warning-dismiss {
+.beta-warning-dismiss {
   /* Negative margins pull the control out of the banner padding so it sits
      up in the corner rather than level with the first line of text. */
   flex: none; display: grid; place-items: center; width: 32px; height: 32px;
@@ -684,9 +684,9 @@ td { border-top: 1px solid var(--border); padding: 8px; vertical-align: top; fon
 /* White reads against the dark banner, but the light theme tints the same
    banner pale, so the glyph takes the theme's near-black foreground there.
    Both explicit light and system-light land on this attribute. */
-:root[data-theme="light"] :is(.beta-warning-dismiss, .online-warning-dismiss) { color: var(--fg); }
-.beta-warning-dismiss:hover, .online-warning-dismiss:hover { background: color-mix(in oklab, var(--danger) 20%, transparent); }
-.beta-warning-dismiss:focus-visible, .online-warning-dismiss:focus-visible { outline: 2px solid var(--danger); outline-offset: 2px; }
+:root[data-theme="light"] .beta-warning-dismiss { color: var(--fg); }
+.beta-warning-dismiss:hover { background: color-mix(in oklab, var(--danger) 20%, transparent); }
+.beta-warning-dismiss:focus-visible { outline: 2px solid var(--danger); outline-offset: 2px; }
 .disclaimer-overlay {
   position: fixed; inset: 0; z-index: 200; display: grid; place-items: center;
   padding: 24px; box-sizing: border-box; background: rgb(0 0 0 / 55%);

--- a/src/index.html
+++ b/src/index.html
@@ -26,7 +26,6 @@
     </noscript>
     <aside class="online-warning no-print" id="online-warning" role="alert" hidden>
       <div class="online-warning-text"><strong>Online version</strong> Do not enter seed phrases, private keys, or other wallet secrets on an internet-connected device. <a href="entropylab.html" download="entropylab.html">Download EntropyLab</a> and run the HTML file offline on a trusted, air-gapped computer.</div>
-      <button type="button" class="online-warning-dismiss" id="online-warning-dismiss" aria-label="Dismiss the online version warning"><svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M18 6 6 18M6 6l12 12"/></svg></button>
     </aside>
     <!-- TODO: This copy is being kept for the network-detected modal that will
          replace the banner. Verbatim, with the lead-in as the modal's title:

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -532,7 +532,6 @@ ec.innerHTML = `
     </aside>
     <aside class="online-warning no-print" id="online-warning" role="alert" hidden>
       <div class="online-warning-text"><strong>Online version</strong> Do not enter seed phrases, private keys, or other wallet secrets on an internet-connected device. <a href="entropylab.html" download="entropylab.html">Download EntropyLab</a> and run the HTML file offline on a trusted, air-gapped computer.</div>
-      <button type="button" class="online-warning-dismiss" id="online-warning-dismiss" aria-label="Dismiss the online version warning"><svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M18 6 6 18M6 6l12 12"/></svg></button>
     </aside>
     <!-- TODO: This copy is being kept for the network-detected modal that will
          replace the banner. Verbatim, with the lead-in as the modal's title:

--- a/src/js/online.js
+++ b/src/js/online.js
@@ -6,26 +6,8 @@
   ) && new URLSearchParams(location.search).get("online-preview") === "1";
   if (!isHostedOnline && !isLocalPreview) return;
 
-  const banner = document.getElementById("online-warning");
-  if (!banner) return;
-  // This unit owns the banner's visibility, so a dismissal is checked here
-  // rather than hidden again afterwards: the row is never revealed at all.
-  // Keyed to the build version, the same store the beta banner and the
-  // disclaimer use, so a new release warns again. Without storage the
-  // warning simply returns, which is the safe direction for this one.
-  const KEY = "entropylab-online-warning-dismissed";
-  const VERSION = "{{VERSION}}";
-  try {
-    if (localStorage.getItem(KEY) === VERSION) return;
-  } catch (e) {}
-  banner.removeAttribute("hidden");
-  const dismiss = document.getElementById("online-warning-dismiss");
-  if (dismiss) dismiss.onclick = () => {
-    try {
-      localStorage.setItem(KEY, VERSION);
-    } catch (e) {}
-    banner.hidden = true;
-  };
+  // The hosted site always warns: the banner cannot be dismissed.
+  document.getElementById("online-warning")?.removeAttribute("hidden");
 })();
 
 function hodlFormatRecoverySheet(text) {

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -138,10 +138,10 @@
     // Parked with the rest of the banners; restore them and this asserts the
     // hosted build lights the warning up again.
     assert(!warning || !warning.hidden, "Online warning was not displayed");
-    // Titled and dismissible like the beta banner above it.
+    // Titled like the beta banner above it, but permanent: no dismiss control.
     const label = warning.querySelector(".online-warning-text strong");
-    const dismiss = document.getElementById("online-warning-dismiss");
-    assert(label && dismiss, "Online warning is missing its label wrapper or dismiss control");
+    assert(label, "Online warning is missing its label wrapper");
+    assert(!document.getElementById("online-warning-dismiss"), "Online warning must not carry a dismiss control");
     const labelStyle = getComputedStyle(label);
     assert(labelStyle.textTransform === "uppercase", "Online warning label is not uppercase");
     assert(labelStyle.display === "block", "Online warning label does not sit on its own line");
@@ -158,21 +158,11 @@
     if (beta) {
       assert(labelStyle.color === getComputedStyle(beta).color, "The two banner labels are different colours");
     }
-    const box = warning.getBoundingClientRect();
-    const button = dismiss.getBoundingClientRect();
-    assert(Math.abs(button.right - box.right) < 12, "Online dismiss control is not at the banner's right edge");
-    assert(button.top < box.top + box.height / 2, "Online dismiss control is not near the banner's top");
-    try {
-      dismiss.click();
-      assert(getComputedStyle(warning).display === "none", "Online warning survived its dismiss control");
-      assert(
-        localStorage.getItem("entropylab-online-warning-dismissed") === currentVersion.replace(/^v/, ""),
-        "Online dismissal was not persisted against this build's version",
-      );
-    } finally {
-      localStorage.removeItem("entropylab-online-warning-dismissed");
-      warning.hidden = false;
-    }
+    // The warning is permanent, so nothing about it may live in storage.
+    assert(
+      localStorage.getItem("entropylab-online-warning-dismissed") === null,
+      "Online warning must not persist anything in storage",
+    );
     assert(logo, "Header logo is missing");
     assert(
       logo.querySelector("svg.site-logo-dark") && logo.querySelector("svg.site-logo-light") && logo.getBoundingClientRect().width > 0,

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -815,11 +815,11 @@ test("the beta banner carries a dismiss control in a narrow right-hand column", 
   // The banner is a row: the message takes the slack, the control does not.
   assert.match(css, /#beta-warning, #online-warning \{ display: flex; align-items: flex-start; gap: 12px; \}/);
   assert.match(css, /\.beta-warning-text, \.online-warning-text \{ flex: 1; \}/);
-  assert.match(css, /\.beta-warning-dismiss, \.online-warning-dismiss \{[^}]*flex: none;[^}]*\}/s);
+  assert.match(css, /\.beta-warning-dismiss \{[^}]*flex: none;[^}]*\}/s);
   // White on the dark banner, near-black on the light theme's pale one: the
   // glyph must stay legible in both.
-  assert.match(css, /\.beta-warning-dismiss, \.online-warning-dismiss \{[^}]*color: #ffffff;[^}]*\}/s);
-  assert.match(css, /:root\[data-theme="light"\] :is\(\.beta-warning-dismiss, \.online-warning-dismiss\) \{ color: var\(--fg\); \}/);
+  assert.match(css, /\.beta-warning-dismiss \{[^}]*color: #ffffff;[^}]*\}/s);
+  assert.match(css, /:root\[data-theme="light"\] \.beta-warning-dismiss \{ color: var\(--fg\); \}/);
   // The author display would otherwise beat the user agent's [hidden] rule
   // and the dismissed banner would stay on screen.
   assert.match(css, /#beta-warning\[hidden\], #online-warning\[hidden\] \{ display: none; \}/);
@@ -865,13 +865,11 @@ test("the online and noscript warnings are titled like the beta banner", () => {
       /<div class="online-warning-text"><strong>Online version<\/strong> Do not enter seed phrases/,
       "the online warning must carry its label in a wrapper",
     );
-    assert.match(
+    // The hosted-site warning is permanent: no dismiss control anywhere.
+    assert.doesNotMatch(
       markup,
-      /<button type="button" class="online-warning-dismiss" id="online-warning-dismiss" aria-label="Dismiss the online version warning">/,
-    );
-    assert.ok(
-      markup.indexOf('class="online-warning-text"') < markup.indexOf('class="online-warning-dismiss"'),
-      "the dismiss column must follow the warning text",
+      /online-warning-dismiss/,
+      "the online warning must not carry a dismiss control",
     );
   }
   assert.match(template, /<div class="beta-warning-text"><strong>JavaScript is required<\/strong> EntropyLab performs wallet/);
@@ -881,16 +879,11 @@ test("the online and noscript warnings are titled like the beta banner", () => {
   // answer one. It takes the label treatment and nothing else.
   const noscript = template.slice(template.indexOf("<noscript>"), template.indexOf("</noscript>"));
   assert.doesNotMatch(noscript, /-dismiss/, "the noscript notice cannot carry a scripted control");
-  // Dismissal is owned by the unit that reveals the banner, so a dismissed
-  // warning is never shown rather than shown and then hidden.
-  assert.match(online, /const KEY = "entropylab-online-warning-dismissed";/);
-  assert.match(online, /if \(localStorage\.getItem\(KEY\) === VERSION\) return;/);
-  assert.match(online, /localStorage\.setItem\(KEY, VERSION\)/);
-  assert.match(online, /banner\.removeAttribute\("hidden"\)/);
-  assert.ok(
-    online.indexOf("localStorage.getItem(KEY)") < online.indexOf('removeAttribute("hidden")'),
-    "the dismissal must be checked before the banner is revealed",
-  );
+  // The hosted-site warning is permanent: the reveal unit must not read or
+  // write storage, so every visit warns again.
+  assert.match(online, /getElementById\("online-warning"\)\?\.removeAttribute\("hidden"\)/);
+  assert.doesNotMatch(online, /localStorage/, "the online warning must not touch storage");
+  assert.doesNotMatch(css, /\.online-warning-dismiss/);
 });
 
 test("the beta disclaimer gates the page as a modal until accepted", () => {


### PR DESCRIPTION
Makes the online version warning permanent. The banner on the hosted site loses its dismiss control and no longer reads or writes localStorage, so every visit warns about entering secrets on an internet-connected device.

Local copies hide the banner.

All other banners unaffected.

Tests updated in test/ui-defaults.test.mjs and test/browser-suite.html. Build artifacts regenerated.