### PR TITLE
Share one on-screen keyboard between the seed and passphrase boxes

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -4573,7 +4573,10 @@ function hodlBindSeedKeyboardDelete(getInput, button, applyDelete = hodlApplySee
 function hodlBindSeedKeyboard(input, targetWords = Pt) {
   let toggle = document.getElementById("seed-keyboard-toggle"), keyboard = document.getElementById("seed-keyboard"), modeButton = keyboard?.querySelector("[data-seed-keyboard-mode]"), passphrase = document.getElementById("pass");
   if (!toggle || !keyboard || !input) return;
-  let activeInput = input, isPassphrase = () => Boolean(passphrase && activeInput === passphrase), refresh = () => {
+  let activeInput = input, passphraseField = () => document.getElementById("pass") || passphrase, isPassphrase = () => {
+    let field = passphraseField();
+    return Boolean(field && activeInput === field);
+  }, refresh = () => {
     if (isPassphrase()) hodlUpdatePassphraseKeyboardKeys(activeInput, "seed-keyboard");
     else hodlUpdateSeedKeyboardKeys(input, targetWords);
   };
@@ -4603,10 +4606,18 @@ function hodlBindSeedKeyboard(input, targetWords = Pt) {
     refresh();
   };
   input.onfocus = () => activate(input);
-  if (passphrase) passphrase.addEventListener("focus", () => activate(passphrase));
-  [input, ...passphrase ? [passphrase] : []].forEach((field) => {
-    ["input", "click", "keyup", "select"].forEach((type) => field.addEventListener(type, () => activate(field)));
-  });
+  // Delegated so the passphrase field is found whenever it renders, and stored on
+  // the keyboard so re-binding replaces the handler rather than stacking another.
+  // Typing and clicking retarget as well as focus, because a headless browser
+  // does not always deliver focus events to a document that is not foremost.
+  let activityEvents = ["focusin", "input", "click", "keyup", "select"];
+  if (keyboard.hodlKeyboardActivity) activityEvents.forEach((type) => document.removeEventListener(type, keyboard.hodlKeyboardActivity));
+  keyboard.hodlKeyboardActivity = (event) => {
+    let field = passphraseField();
+    if (field && event.target === field) activate(field);
+    else if (event.target === input) activate(input);
+  };
+  activityEvents.forEach((type) => document.addEventListener(type, keyboard.hodlKeyboardActivity));
   activate(input);
 }
 function hodlBindPassphraseKeyboard(inputId = "pass", toggleId = "passphrase-keyboard-toggle", inputName = "passphrase", keyboardId = "passphrase-keyboard") {
@@ -4670,10 +4681,15 @@ function hodlBindBase64Keyboard(input) {
   refresh();
 }
 function hodlRenderPassphraseKeyboard() {
-  let host = document.getElementById("passphrase-keyboard-host"), toggleHost = document.getElementById("passphrase-keyboard-toggle-host"), privateKey = Ne === "key", passphrase = !privateKey, enabled = passphrase || privateKey;
+  let host = document.getElementById("passphrase-keyboard-host"), toggleHost = document.getElementById("passphrase-keyboard-toggle-host"), privateKey = Ne === "key", passphrase = !privateKey;
+  // The seed keyboard already follows focus between the seed box and the
+  // passphrase box, so where it exists it serves both and a second on-screen
+  // keyboard would only stack another copy under the first.
+  let shared = passphrase && Boolean(document.getElementById("seed-keyboard")),
+    enabled = !shared;
   if (toggleHost) {
     toggleHost.hidden = !passphrase;
-    toggleHost.innerHTML = passphrase ? hodlPassphraseKeyboardToggleMarkup() + hodlPassphraseBip39ToggleMarkup() : "";
+    toggleHost.innerHTML = passphrase ? (shared ? "" : hodlPassphraseKeyboardToggleMarkup()) + hodlPassphraseBip39ToggleMarkup() : "";
   }
   if (!host) return;
   host.hidden = !enabled;

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -368,7 +368,11 @@ test("seed phrase mode has a lowercase Jade-style on-screen keyboard", () => {
   assert.match(app, /hodlKeyboardMarkup\(!0,"private key","private-keyboard",!0\)/);
   assert.doesNotMatch(app, /hodlKeyboardMarkup\(!0\)/);
   assert.match(app, /function hodlRenderPassphraseKeyboard\(\)/);
-  assert.match(app, /privateKey=Ne==="key",passphrase=!privateKey,enabled=passphrase\|\|privateKey/);
+  assert.match(app, /privateKey=Ne==="key",passphrase=!privateKey/);
+  // Where the seed keyboard exists it already follows focus into the passphrase
+  // box, so no second on-screen keyboard is rendered underneath it.
+  assert.match(app, /shared=passphrase&&!!document\.getElementById\("seed-keyboard"\),enabled=!shared/);
+  assert.match(app, /passphrase\?\(shared\?"":hodlPassphraseKeyboardToggleMarkup\(\)\)\+hodlPassphraseBip39ToggleMarkup\(\)/);
   assert.match(app, /hodlPassphraseKeyboardToggleMarkup\(\)/);
   assert.match(app, /function hodlPassphraseBip39ToggleMarkup\(checked=hodlPassphraseBip39Enabled\(\)\)/);
   assert.match(app, /function hodlAnalyzeBip39Passphrase\(value,activeCaret=null\)/);


### PR DESCRIPTION
The seed keyboard already follows focus between the seed box and the passphrase box, so rendering the passphrase keyboard alongside it stacked a second identical keyboard underneath the first. Where a seed keyboard exists, the passphrase now uses it, and only its own toggle is dropped — the BIP39 words option still renders wherever a passphrase field does.

Following focus was also unreliable. The binder captured `#pass` once, but that element is not always in the document when the keyboard binds, and a captured node can be left detached by a later render, so the keyboard never retargeted and the passphrase keys stayed disabled. The field is now resolved on demand, preferring the live element, and focus is watched through the document so a field that renders later is still picked up. The handler is stored on the keyboard so re-binding replaces it rather than stacking another.

### Verified in the browser

| Focus | Keyboard label | Character-mode key | Keys go to |
| --- | --- | --- | --- |
| seed box | lowercase seed phrase keyboard | disabled | seed box |
| passphrase box | lower **passphrase** keyboard | enabled | passphrase box |
| back to seed box | lowercase seed phrase keyboard | disabled | seed box |

Neither box receives the other's keys, and only one `[data-on-screen-keyboard]` element is present in seed mode.

`npm run test:ci` 511/511, `npm run verify` clean. No change to the built artifact in this branch.
