### PR TITLE
Fix the PSBT inspector's raw-transaction network read

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -8666,7 +8666,9 @@ function hodlRenderPsbt(psbt) {
   return html.join("")
 }
 function hodlRenderRawTx(tx) {
-  let network = hodlSelectedNetwork(document.getElementById("psbt-network")),
+  // psbt-network is a mainnet/testnet select, not a numeric coin-type input,
+  // so hodlSelectedNetwork (which reads coin types) cannot parse it.
+  let network = document.getElementById("psbt-network")?.value === "testnet" ? "testnet" : "mainnet",
     html = [],
     map = hodlSessionOwnership(network),
     signatures = extractEcdsaSignatures(tx),

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -1020,10 +1020,10 @@
     await until(() => !document.getElementById("calc-card").hidden, "key workspace");
   });
 
-  await test("PSBT inspector renders a BIP-174 vector", async () => {
+  await test("PSBT inspector renders a BIP-174 vector and a BIP143 raw transaction", async () => {
     // Regression: the inspector used to hand the mainnet/testnet select to a
-    // coin-type reader, so every parseable PSBT failed with "Coin type must
-    // be a whole number".
+    // coin-type reader, so every parseable PSBT and raw transaction failed
+    // with "Coin type must be a whole number".
     const vector = "cHNidP8BAKACAAAAAqsJSaCMWvfEm4IS9Bfi8Vqz9cM9zxU4IagTn4d6W3vkAAAAAAD+////qwlJoIxa98SbghL0F+LxWrP1wz3PFTghqBOfh3pbe+QBAAAAAP7///8CYDvqCwAAAAAZdqkUdopAu9dAy+gdmI5x3ipNXHE5ax2IrI4kAAAAAAAAGXapFG9GILVT+glechue4O/p+gOcykWXiKwAAAAAAAEHakcwRAIgR1lmF5fAGwNrJZKJSGhiGDR9iYZLcZ4ff89X0eURZYcCIFMJ6r9Wqk2Ikf/REf3xM286KdqGbX+EhtdVRs7tr5MZASEDXNxh/HupccC1AaZGoqg7ECy0OIEhfKaC3Ibi1z+ogpIAAQEgAOH1BQAAAAAXqRQ1RebjO4MsRwUPJNPuuTycA5SLx4cBBBYAFIXRNTfy4mVAWjTbr6nj3aAfuCMIAAAA";
     document.querySelector('#workspace [data-workspace="psbt"]').click();
     const box = await until(() => document.getElementById("psbt-text"), "PSBT input");
@@ -1036,6 +1036,32 @@
     assert(out.includes("1.99900000"), "decoded output amount missing");
     assert(out.includes("Signature policy: SIGHASH_ALL"), "sighash policy missing");
     assert(out.includes("r values:"), "finalized signature was not inspected");
+    // BIP143 "Native P2WPKH" signed transaction (witness-carrying) — the raw
+    // transaction path reads the same network select.
+    const rawTx =
+      "01000000000102fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f0000000049" +
+      "4830450221008b9d1dc26ba6a9cb62127b02742fa9d754cd3bebf337f7a55d114c8e5cdd30be022040529b194ba3f9281a99f2b1c0a19c0489bc22ede944ccf4ecbab4cc618ef3ed01eeffffff" +
+      "ef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a0100000000ffffffff" +
+      "02202cb206000000001976a9148280b37df378db99f66f85c95a783a76ac7a6d5988ac" +
+      "9093510d000000001976a9143bde42dbee7e4dbe6a21b2d50ce2f0167faa815988ac" +
+      "000247304402203609e17b84f6a7d30c80bfa610b5b4542f32a8a0d5447a12fb1366d7f01cc44a0220573a954c4518331561406f90300e8f3358f51928d43c212a8caed02de67eebee01" +
+      "21025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee635711000000";
+    input(box, rawTx);
+    document.getElementById("psbt-go").click();
+    await until(() => document.getElementById("psbt-out").textContent.includes("ECDSA nonce check") || document.getElementById("psbt-error").textContent, "raw transaction report");
+    equal(document.getElementById("psbt-error").textContent, "", "inspector rejected a valid raw transaction");
+    const rawOut = document.getElementById("psbt-out").textContent;
+    assert(rawOut.includes("Raw Bitcoin transaction."), "raw transaction banner missing");
+    assert(rawOut.includes("Where this transaction sends bitcoin"), "raw transaction outputs section missing");
+    assert(rawOut.includes("1Cu32FVupVCgHkMMRJdYJugxwo2Aprgk7H"), "mainnet output address missing");
+    assert(rawOut.includes("r values:"), "raw transaction signatures were not inspected");
+    // The testnet option must reach the render as well.
+    const network = document.getElementById("psbt-network");
+    input(network, "testnet");
+    document.getElementById("psbt-go").click();
+    await until(() => document.getElementById("psbt-out").textContent.includes("msQzKJatdWdw4rpy8sbv8puHoncseekYCf") || document.getElementById("psbt-error").textContent, "testnet raw transaction report");
+    equal(document.getElementById("psbt-error").textContent, "", "inspector rejected the testnet selection");
+    input(network, "mainnet");
     input(box, "");
     document.getElementById("psbt-wipe").click();
     document.querySelector('#workspace [data-workspace="calc"]').click();


### PR DESCRIPTION
## What

`hodlRenderRawTx` still passed `#psbt-network` — a mainnet/testnet `<select>` — to `hodlSelectedNetwork`, which demands a numeric coin type (`/^\d+$/`) and throws on anything else. 0464c61 fixed this for `hodlRenderPsbt` but missed the raw-transaction callsite, so pasting any raw transaction into the inspector failed with *"Coin type must be a whole number from 0 to 2,147,483,647."* and every defensive check on that path (output/destination review, ECDSA nonce-reuse and sighash warnings, inscription hints) never ran.

## Fix

Mirror 0464c61's callsite pattern in `hodlRenderRawTx` — read the select directly, one line plus the same explanatory comment. `hodlSelectedNetwork` itself is unchanged; its other callers all pass the numeric coin-type inputs it is built for.

## Test

Extended the existing DOM-level regression test (now *"PSBT inspector renders a BIP-174 vector and a BIP143 raw transaction"*): pastes the signed BIP143 native-P2WPKH transaction, asserts the inspector renders the outputs, the mainnet address, and the r-value report with no error — then selects testnet and asserts the render follows (testnet address, still no error). Before the fix this fails with the coin-type error; the source-sliced `psbt-*.test.mjs` suites can't catch this because none of them drive the DOM.

## Commands run

- `npm run build`
- `npm test` (601 pass, 1 skipped)
- `npm run test:browser` (Firefox + Chrome; Edge absent, skipped)
- `npm run verify`