### PR TITLE
Apply psbted-actions in the runtime template so editor buttons stay text-sized

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -967,7 +967,7 @@ ec.innerHTML = `
       <label class="field">PSBT v0 (base64 or hex)
         <textarea id="psbted-text" placeholder="cHNidP8B..." spellcheck="false" autocomplete="off" autocapitalize="off"></textarea>
       </label>
-      <div class="row psbt-actions">
+      <div class="row psbt-actions psbted-actions">
         <button class="btn primary" id="psbted-load" type="button">Load PSBT</button>
         <button class="btn secondary" id="psbted-wipe" type="button">Clear editor</button>
         <label class="field psbted-network-field">Address network

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -1226,7 +1226,12 @@ test("PSBT Editor tab follows PSBT / Nonce and wires the rust-bitcoin editor", (
     assert.match(markup, /id="psbted-out"/);
     assert.match(markup, /id="psbted-error"/);
     assert.match(markup, /rust-bitcoin compiled to WebAssembly/);
+    // The row must carry psbted-actions in both markups, or the flex stretch
+    // pulls the Load/Clear buttons up to the network field's full height.
+    assert.match(markup, /<div class="row psbt-actions psbted-actions">/);
   }
+  assert.match(css, /\.psbted-actions \{ align-items: flex-end; \}/);
+  assert.match(css, /\.psbted-actions \.btn \{ min-height: 0; padding: 6px 10px; \}/);
   assert.match(appSource, /import \{ initPsbtEditor \} from "\.\/psbt-editor\.js"/);
   assert.match(appSource, /initPsbtEditor\(\)/);
   assert.match(css, /#psbted-card\[hidden\]/);


### PR DESCRIPTION
## Problem

In the PSBT Editor tab, the **Load PSBT** / **Clear editor** buttons render ~95px tall — the flex action row's default `align-items: stretch` pulls them up to the full height of the "Address network" field (label + 44px custom select).

## Root cause

6b13b0e added the `.psbted-actions` CSS rules (`align-items: flex-end`; `min-height: 0; padding: 6px 10px` on the buttons) and applied the class in `src/index.html`, but missed the second copy of the markup in `src/js/app.js` — the runtime template that replaces the static markup via `innerHTML`. The rules therefore never matched in the live app.

## Fix

- `src/js/app.js`: add `psbted-actions` to the editor's action row in the runtime template.
- `test/ui-defaults.test.mjs`: assert both markup copies (`src/index.html` and the `app.js` template) carry the class, and that the two `.psbted-actions` CSS rules exist, so the duplicated templates can't drift again.

## Verification

Measured in headless Firefox against the built page (PSBT editor open):

| | Before | After |
|---|---|---|
| Button height | 95px | 37px |
| Row alignment | `stretch` | `flex-end` (bottom-aligned with the select) |

`npm run build && npm test` pass.