### PR TITLE
Add Brain wallet — lab: SHA-256 text as 256-bit BIP39 entropy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,13 @@ Official website: [entropylab.online](https://entropylab.online)
 - Accepts dice rolls, coin flips, hexadecimal entropy, BIP39 seed phrases,
   extended keys, WIF keys, raw private keys, and Casascius mini private keys.
   All five BIP39 phrase lengths (12, 15, 18, 21, and 24 words) are supported
-  for every entropy entry method.
+  for every entropy entry method. A separate **Brain wallet — lab** mode hashes
+  exact UTF-8 text with SHA-256 and uses the 32-byte digest as 256-bit BIP39
+  entropy (24 words). That is not a BIP39 passphrase, not a Bitcoin Core hdseed
+  or address-key backup, and not the private-key brain-wallet path (which treats
+  the same hash as a secp256k1 scalar). Strength is the entropy of the text, not
+  the word count. Derive Wallet is required; the lab does not preview the
+  mnemonic while typing.
 - Derives BIP39 seeds, BIP32 extended keys, wallet fingerprints, addresses,
   and Bitcoin Core-compatible descriptors. Each master fingerprint is shown
   next to its deterministic [LifeHash](https://lifehash.info) icon so two

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -83,6 +83,12 @@ material. Its security posture rests on the following model:
   supplied entropy and says to use it only for testing. Users who intend to
   secure funds must meet the displayed roll/card recommendation and verify
   their procedure independently.
+- Brain wallet — lab hashes the exact UTF-8 text with unsalted SHA-256 and
+  treats the digest as BIP39 entropy. Guessable text is stolen coins. A valid
+  24-word mnemonic from that hash is not the same wallet as hashing the text
+  as a Bitcoin Core private key, and it is not a backup of a Core hdseed or
+  address key. The private-key brain-wallet mode remains a separate scalar
+  path.
 - BIP-85 children are a deterministic transformation of the parent BIP32 root,
   not newly generated entropy. A BIP-39 passphrase, when present, is part of
   that root (the same rule COLDCARD uses). Anyone who has the parent seed,

--- a/llms.txt
+++ b/llms.txt
@@ -6,7 +6,7 @@ EntropyLab is a single HTML file with no runtime dependencies. It is designed to
 
 ## What it does
 
-- Accepts dice rolls, coin flips, playing cards, hexadecimal entropy, BIP39 seed phrases (12–24 words), extended keys, WIF keys, raw private keys, and Casascius mini keys.
+- Accepts dice rolls, coin flips, playing cards, hexadecimal entropy, BIP39 seed phrases (12–24 words), extended keys, WIF keys, raw private keys, Casascius mini keys, and a lab brain-wallet mode (SHA-256 of exact UTF-8 text as 256-bit BIP39 entropy → 24 words; not a BIP39 passphrase, not a Core-key backup, and not the private-key scalar brain-wallet path).
 - Derives BIP39 seeds, BIP32 extended keys, master fingerprints, addresses, and Bitcoin Core-compatible descriptors for legacy, nested SegWit, native SegWit, and Taproot; mainnet and testnet.
 - Builds multisignature wallets, including watch-only multisig from extended public keys alone.
 - Inspects PSBT v0 and raw signed transactions: amounts, fees (PSBT claims), repeated ECDSA nonces, optional anti-exfil transcript checks, inscription envelopes in taproot witnesses (detector only — does not number sats or create inscriptions), session-key output ownership (change vs not yours), and OP_RETURN data-carrier outputs (detector only — does not create them).

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -269,6 +269,12 @@ label.field { display: block; margin-top: var(--space-component); font-size: 14p
 .choice:has(input:disabled) { cursor: not-allowed; opacity: 0.52; }
 .choice-grid { display: grid; gap: var(--space-control); margin-top: var(--space-control); }
 .choice-grid .choice { margin-top: 0; }
+details.lab-entropy { margin-top: var(--space-section); }
+details.lab-entropy > summary {
+  cursor: pointer; font-weight: 600; color: var(--fg);
+}
+details.lab-entropy .wallet-result-messages { margin-top: var(--space-control); }
+#brain-lab { font-family: var(--mono); letter-spacing: 0; }
 @media (min-width: 720px) {
   .choice-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .choice-grid.three-up { grid-template-columns: repeat(3, minmax(0, 1fr)); }

--- a/src/index.html
+++ b/src/index.html
@@ -50,7 +50,7 @@
     </section>
     <section class="card no-print" id="calc-card" role="tabpanel" hidden>
       <div class="key-panel-head">
-        <div class="row segmented-control" id="modes"><button class="tab active" aria-pressed="true">Dice rolls</button><button class="tab" aria-pressed="false">Cards</button><button class="tab" aria-pressed="false">Number bases</button><button class="tab" aria-pressed="false">Seed phrase</button><button class="tab" aria-pressed="false">Private key</button></div>
+        <div class="row segmented-control" id="modes"><button class="tab active" aria-pressed="true">Dice rolls</button><button class="tab" aria-pressed="false">Cards</button><button class="tab" aria-pressed="false">Number bases</button><button class="tab" aria-pressed="false">Seed phrase</button><button class="tab" aria-pressed="false">Private key</button><button class="tab" aria-pressed="false">Brain wallet — lab</button></div>
         <button class="btn delete-key" id="delete-key" type="button" aria-label="Delete current key" disabled>Delete Key</button>
       </div>
       <section class="seed-length-control" id="seed-length" aria-labelledby="seed-length-label">

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -511,6 +511,17 @@ function hodlBrainWalletPassphrase(value, trimBoundaryWhitespace = false) {
 function hodlBrainWalletPrivateKey(value, trimBoundaryWhitespace = false) {
   return Z(new TextEncoder().encode(hodlBrainWalletPassphrase(value, trimBoundaryWhitespace)));
 }
+function hodlBrainLabEntropy(value) {
+  let text = String(value ?? ""), notes = [], warnings = [];
+  if (!text.length) return { ok: false, error: "Enter the brain-wallet lab text.", notes, warnings };
+  let bytes = Z(new TextEncoder().encode(text)), hex = M.encode(bytes);
+  notes.push("SHA-256 of the exact UTF-8 text is 32 bytes of BIP39 entropy (256 bits → 24 words).");
+  warnings.push("Lab only. Strength is the entropy of this text, not the 24-word count.");
+  warnings.push("SHA-256(text) is unsalted and fast. Anyone who can guess the text recovers the wallet.");
+  warnings.push("This is not a BIP39 passphrase, and it is not a Bitcoin Core hdseed or address-key backup.");
+  warnings.push("A valid mnemonic does not mean it is the same wallet as hashing the text as a Core private key.");
+  return { ok: true, bytes, hex, bits: 256, sourceBits: 256, method: "brain-lab", notes, warnings };
+}
 function Io(e, t, r, trimBrainWallet = false) {
   let n = [], o = [], i, s = null, c = t, a = r === "brain" ? hodlBrainWalletPassphrase(e, trimBrainWallet) : e.trim();
   if (r === "brain") {
@@ -993,13 +1004,13 @@ ec.innerHTML = `
   </div>
 `;
 if (/^(www\.)?entropylab\.online$/i.test(location.hostname)) document.getElementById("online-warning")?.removeAttribute("hidden");
-var hodlKeyModes = ["dice", "cards", "hex", "seed", "key"], hodlCardRanks = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "T", "J", "Q", "K"], hodlDirectCardRanks = ["A", "2", "3", "4", "5", "6", "7", "8"], hodlCardSuits = [{ code: "S", symbol: "\u2660", label: "Spades", red: false }, { code: "H", symbol: "\u2665", label: "Hearts", red: true }, { code: "C", symbol: "\u2663", label: "Clubs", red: false }, { code: "D", symbol: "\u2666", label: "Diamonds", red: true }], hodlCardSuit = "", hodlCardRank = "", hodlCardMethod = "hashed", hodlSeedMethod = "words", hodlSeedZeroIndexed = false, hodlCardColemanSymbols = false, Ne = "dice", ge = "coldcard", Pt = 24, hodlEntropyFormat = "hex", hodlDiceCoinPositions = [], ft = "", re = null, Ge = false, hodlWalletDatBirthday = "genesis", Zs = W("#modes"), at = W("#form"), dr = W("#out");
+var hodlKeyModes = ["dice", "cards", "hex", "seed", "key", "brain-lab"], hodlBrainLabAck = false, hodlCardRanks = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "T", "J", "Q", "K"], hodlDirectCardRanks = ["A", "2", "3", "4", "5", "6", "7", "8"], hodlCardSuits = [{ code: "S", symbol: "\u2660", label: "Spades", red: false }, { code: "H", symbol: "\u2665", label: "Hearts", red: true }, { code: "C", symbol: "\u2663", label: "Clubs", red: false }, { code: "D", symbol: "\u2666", label: "Diamonds", red: true }], hodlCardSuit = "", hodlCardRank = "", hodlCardMethod = "hashed", hodlSeedMethod = "words", hodlSeedZeroIndexed = false, hodlCardColemanSymbols = false, Ne = "dice", ge = "coldcard", Pt = 24, hodlEntropyFormat = "hex", hodlDiceCoinPositions = [], ft = "", re = null, Ge = false, hodlWalletDatBirthday = "genesis", Zs = W("#modes"), at = W("#form"), dr = W("#out");
 hodlKeyModes.forEach((e) => {
   let t = document.createElement("button"), active = e === Ne;
   t.type = "button";
   t.className = "tab" + (active ? " active" : "");
   t.setAttribute("aria-pressed", String(active));
-  t.textContent = e === "dice" ? "Dice rolls" : e === "cards" ? "Cards" : e === "hex" ? "Number bases" : e === "seed" ? "Seed phrase" : "Private key";
+  t.textContent = e === "dice" ? "Dice rolls" : e === "cards" ? "Cards" : e === "hex" ? "Number bases" : e === "seed" ? "Seed phrase" : e === "brain-lab" ? "Brain wallet — lab" : "Private key";
   t.onclick = () => hodlSetMode(e);
   Zs.appendChild(t);
 });
@@ -2555,7 +2566,7 @@ function hodlUpdateKeyModeControls() {
   let singleKey = Ne === "key", settings = document.getElementById("key-settings");
   ["passphrase-field", "master-fingerprint-preview", "script-type-field", "derivation-path-field", "derivation-advanced"].forEach((id) => {
     let element = document.getElementById(id);
-    if (element) element.hidden = singleKey;
+    if (element) element.hidden = singleKey || (id === "master-fingerprint-preview" && Ne === "brain-lab");
   });
   settings?.classList.toggle("single-key-mode", singleKey);
 }
@@ -5015,7 +5026,7 @@ function hodlUpdateSeedLengthControl() {
   let section = document.getElementById("seed-length");
   if (!section) return;
   let config = hodlSeedConfig();
-  section.hidden = Ne === "key";
+  section.hidden = Ne === "key" || Ne === "brain-lab";
   section.querySelectorAll("[data-seed-words]").forEach((button) => {
     let active = Number(button.dataset.seedWords) === config.words;
     button.classList.toggle("active", active);
@@ -5475,6 +5486,64 @@ function hodlRenderKeyForm() {
     update();
     return;
   }
+  if (Ne === "brain-lab") {
+    let state = hodlKeys[hodlActiveKey], acked = Boolean(hodlBrainLabAck);
+    at.innerHTML = `
+      <details class="lab-entropy" id="brain-lab-details" ${acked ? "" : "open"}>
+        <summary>Brain wallet — lab</summary>
+        <div class="wallet-result-messages" role="alert">
+          <h3>Lab warning — read before first use</h3>
+          <ul>
+            <li class="is-warning">Strength is the entropy of this text, not the 24-word count.</li>
+            <li class="is-warning">SHA-256(text) is unsalted and fast. Guessable phrases are stolen coins.</li>
+            <li class="is-warning">This is not a BIP39 passphrase.</li>
+            <li class="is-warning">This is not a Bitcoin Core hdseed or address-key backup of the same wallet.</li>
+            <li class="is-warning">A valid mnemonic does not mean it is the same Core wallet as hashing the text as a private-key scalar.</li>
+          </ul>
+        </div>
+        <label class="choice"><input type="checkbox" id="brain-lab-ack" ${acked ? "checked" : ""} /><span><strong>I understand</strong><span class="desc">Required once this session, in page memory only. Derive is still required.</span></span></label>
+      </details>
+      <p class="label" id="brain-lab-label">Lab text</p>
+      <p class="muted" id="brain-lab-help">UTF-8 text is hashed with SHA-256. The 32-byte digest is BIP39 entropy for a 24-word seed. Nothing is derived until you press Derive Wallet.</p>
+      <textarea id="brain-lab" placeholder="Exact text. Whitespace is significant." ${acked ? "" : "disabled"} aria-labelledby="brain-lab-label" aria-describedby="brain-lab-help brain-lab-hex"></textarea>
+      <p class="muted" id="brain-lab-hex" aria-live="polite">SHA-256 hex appears here. 24 words appear only after Derive Wallet.</p>`;
+    let ack = document.getElementById("brain-lab-ack"), input = document.getElementById("brain-lab"), hex = document.getElementById("brain-lab-hex");
+    let renderHex = () => {
+      if (!hodlBrainLabAck) {
+        hex.textContent = "Acknowledge the lab warning, then enter text. Derive Wallet is still required.";
+        hex.className = "muted";
+        return;
+      }
+      let value = input.value;
+      if (!value.length) {
+        hex.textContent = "SHA-256 hex appears here. 24 words appear only after Derive Wallet.";
+        hex.className = "muted";
+        return;
+      }
+      let entropy = hodlBrainLabEntropy(value);
+      hex.textContent = entropy.ok ? `SHA-256 (256-bit BIP39 entropy): ${entropy.hex}` : entropy.error;
+      hex.className = "muted " + (entropy.ok ? "ok" : "err");
+    };
+    ack.onchange = () => {
+      hodlBrainLabAck = ack.checked;
+      input.disabled = !hodlBrainLabAck;
+      renderHex();
+      hodlSyncKeyClearButton();
+      hodlSyncDeriveButton();
+    };
+    input.oninput = () => {
+      if (state) state.fields.brainLab = input.value;
+      renderHex();
+      hodlSyncKeyClearButton();
+      hodlSyncDeriveButton();
+    };
+    if (state?.fields.brainLab) input.value = state.fields.brainLab;
+    hodlBindKeyFields();
+    hodlRenderPassphraseKeyboard();
+    renderHex();
+    hodlSyncDeriveButton();
+    return;
+  }
   at.innerHTML = `
     <p class="label">Private key format</p>
     <div class="choice-grid">
@@ -5832,6 +5901,10 @@ function hodlCanDeriveCurrentKey() {
       }
       return hodlValidateTargetMnemonic(value, Pt).ok;
     }
+    if (Ne === "brain-lab") {
+      if (!hodlBrainLabAck) return false;
+      return hodlBrainLabEntropy(document.getElementById("brain-lab")?.value).ok;
+    }
     return hodlPrivateKeyInputIsValid();
   } catch {
     return false;
@@ -5896,6 +5969,7 @@ function hodlFingerprintMnemonic() {
       let validation = hodlValidateTargetMnemonic(value, Pt);
       return validation.ok ? validation.words.join(" ") : null;
     }
+    if (Ne === "brain-lab") return null;
   } catch {
   }
   return null;
@@ -5933,7 +6007,7 @@ function hodlRenderMasterFingerprintPreview(revision = hodlMasterFingerprintRevi
   if (revision !== hodlMasterFingerprintRevision) return;
   let preview = document.getElementById("master-fingerprint-preview"), baseCard = document.getElementById("base-master-fingerprint-card"), base = document.getElementById("base-master-fingerprint"), baseImage = document.getElementById("base-master-fingerprint-lifehash"), arrow = document.getElementById("master-fingerprint-arrow"), derivedCard = document.getElementById("passphrase-master-fingerprint-card"), derived = document.getElementById("passphrase-master-fingerprint"), derivedImage = document.getElementById("passphrase-master-fingerprint-lifehash"), pass = document.getElementById("pass");
   if (!preview || !baseCard || !base || !arrow || !derivedCard || !derived || !pass) return;
-  if (Ne === "key") {
+  if (Ne === "key" || Ne === "brain-lab") {
     preview.hidden = true;
     return;
   }
@@ -6089,6 +6163,11 @@ async function hodlCalculateKey(progress) {
         if (!validation.ok) throw new Error(validation.error);
         re = await hodlMnemonicWalletWithProgress(validation.words.join(" "), passphrase, network, count, void 0, account, addressStart, progress, purpose, coinType, hardening, branchStart, branchRange, derivationPlan);
       }
+    } else if (Ne === "brain-lab") {
+      if (!hodlBrainLabAck) throw new Error("Acknowledge the lab warning before deriving.");
+      let entropy = hodlBrainLabEntropy(document.getElementById("brain-lab")?.value);
+      if (!entropy.ok) throw new Error(entropy.error);
+      re = await hodlEntropyWalletWithProgress(entropy, passphrase, network, count, account, addressStart, progress, purpose, coinType, hardening, branchStart, branchRange, derivationPlan);
     } else {
       let value = document.getElementById("key").value, kind = hodlNormalizePrivateKeyKind(document.querySelector("input[name=kk]:checked")?.value, value);
       let trimBrainWallet = hodlBrainWalletTrimEnabled();
@@ -8782,7 +8861,7 @@ function hodlPrivateKeyValues(fields) {
 }
 function hodlNewKeyState(name, keyId, keyNumber) {
   let id = keyId ?? hodlNextKeyId++, number = keyNumber ?? hodlNextKeyNumber++;
-  return { id, number, color: hodlKeyColor(id), name: name || hodlDefaultKeyName(number), mode: "dice", diceMethod: "coldcard", cardMethod: "hashed", seedMethod: "words", seedZeroIndexed: false, cardColemanSymbols: false, entropyFormat: "bin", syncNumberBases: false, numberBaseSyncSource: "", numberBasesSynced: false, seedAutocomplete: true, passphraseBip39Words: false, passphraseAutocomplete: true, brainWalletTrim: false, showCards: false, showDiceFairness: false, targetWords: 24, diceCoinPositions: [], lastWord: "", dplusLastWord: "", result: null, reveal: false, accountId: "bip84", error: "", fields: { pass: "", script: "bip84", derivationPath: "m/84'/0'/0'/0/0", derivationAccountPath: "m/84'/0'/0'", purpose: "84'", purposeHarden: true, coinType: "0'", coinTypeHarden: true, network: "mainnet", account: "0'", accountHarden: true, branchStart: "0", branchHarden: false, branchRange: "1", addressStart: "0", addressHarden: false, addressRange: "1", dice: "", dplusDice: "", hex: "", bin: "", base4: "", base8: "", base32: "", base64: "", cards: "", directCards: "", seed: "", seedNumbers: "", key: "", keyKind: "wif", privateKeys: { wif: "", "hex-key": "", minikey: "", brain: "" } } };
+  return { id, number, color: hodlKeyColor(id), name: name || hodlDefaultKeyName(number), mode: "dice", diceMethod: "coldcard", cardMethod: "hashed", seedMethod: "words", seedZeroIndexed: false, cardColemanSymbols: false, entropyFormat: "bin", syncNumberBases: false, numberBaseSyncSource: "", numberBasesSynced: false, seedAutocomplete: true, passphraseBip39Words: false, passphraseAutocomplete: true, brainWalletTrim: false, showCards: false, showDiceFairness: false, targetWords: 24, diceCoinPositions: [], lastWord: "", dplusLastWord: "", result: null, reveal: false, accountId: "bip84", error: "", fields: { pass: "", script: "bip84", derivationPath: "m/84'/0'/0'/0/0", derivationAccountPath: "m/84'/0'/0'", purpose: "84'", purposeHarden: true, coinType: "0'", coinTypeHarden: true, network: "mainnet", account: "0'", accountHarden: true, branchStart: "0", branchHarden: false, branchRange: "1", addressStart: "0", addressHarden: false, addressRange: "1", dice: "", dplusDice: "", hex: "", bin: "", base4: "", base8: "", base32: "", base64: "", cards: "", directCards: "", seed: "", seedNumbers: "", brainLab: "", key: "", keyKind: "wif", privateKeys: { wif: "", "hex-key": "", minikey: "", brain: "" } } };
 }
 function hodlRestoreFormFields(state) {
   if (!state) return;
@@ -8795,6 +8874,11 @@ function hodlRestoreFormFields(state) {
   if (syncNumberBases) syncNumberBases.checked = Boolean(state.syncNumberBases);
   let seedAutocomplete = document.getElementById("seed-autocomplete");
   if (seedAutocomplete) seedAutocomplete.checked = Boolean(state.seedAutocomplete);
+  let brainLab = document.getElementById("brain-lab");
+  if (brainLab) {
+    brainLab.value = state.fields.brainLab || "";
+    brainLab.dispatchEvent(new Event("input"));
+  }
   ["dice", "hex", "bin", "base4", "base8", "base32", "base64", "seed", "seed-numbers", "key", "cards", "direct-cards"].forEach(id => {
     let el = document.getElementById(id);
     if (el) {
@@ -8832,7 +8916,7 @@ function hodlSetMode(mode) {
 function hodlKeyStateNeedsClear(state) {
   if (!state) return false;
   let fields = state.fields || {}, privateKeys = hodlPrivateKeyValues(fields), hasText = (id) => String(fields[id] ?? "").length > 0;
-  return String(state.mode ?? "dice") !== "dice" || String(state.diceMethod ?? "coldcard") !== "coldcard" || String(state.cardMethod ?? "hashed") !== "hashed" || String(state.seedMethod ?? "words") !== "words" || Boolean(state.seedZeroIndexed) || Boolean(state.cardColemanSymbols) || String(state.entropyFormat ?? "bin") !== "bin" || Boolean(state.syncNumberBases) || state.seedAutocomplete === false || Boolean(state.passphraseBip39Words) || state.passphraseAutocomplete === false || Boolean(state.brainWalletTrim) || Boolean(state.showCards) || Boolean(state.showDiceFairness) || Number(state.targetWords ?? 24) !== 24 || Array.isArray(state.diceCoinPositions) && state.diceCoinPositions.length > 0 || String(state.lastWord ?? "").length > 0 || String(state.dplusLastWord ?? "").length > 0 || Boolean(state.result) || Boolean(state.reveal) || String(state.error ?? "").length > 0 || String(state.accountId ?? "bip84") !== "bip84" || String(fields.script ?? "bip84") !== "bip84" || String(fields.derivationPath ?? "m/84'/0'/0'/0/0") !== "m/84'/0'/0'/0/0" || String(fields.purpose ?? "84'") !== "84'" || fields.purposeHarden === false || String(fields.coinType ?? (fields.network === "testnet" ? "1'" : "0'")) !== "0'" || fields.coinTypeHarden === false || String(fields.account ?? "0'") !== "0'" || fields.accountHarden === false || String(fields.branchStart ?? "0") !== "0" || Boolean(fields.branchHarden) || String(fields.branchRange ?? "1") !== "1" || String(fields.addressStart ?? "0") !== "0" || Boolean(fields.addressHarden) || String(fields.addressRange ?? fields.count ?? "1") !== "1" || hodlNormalizePrivateKeyKind(fields.keyKind, privateKeys[fields.keyKind] || "") !== "wif" || ["pass", "dice", "dplusDice", "hex", "bin", "base4", "base8", "base32", "base64", "cards", "directCards", "seed", "seedNumbers", "key"].some(hasText) || hodlPrivateKeyKinds.some((kind) => privateKeys[kind].length > 0);
+  return String(state.mode ?? "dice") !== "dice" || String(state.diceMethod ?? "coldcard") !== "coldcard" || String(state.cardMethod ?? "hashed") !== "hashed" || String(state.seedMethod ?? "words") !== "words" || Boolean(state.seedZeroIndexed) || Boolean(state.cardColemanSymbols) || String(state.entropyFormat ?? "bin") !== "bin" || Boolean(state.syncNumberBases) || state.seedAutocomplete === false || Boolean(state.passphraseBip39Words) || state.passphraseAutocomplete === false || Boolean(state.brainWalletTrim) || Boolean(state.showCards) || Boolean(state.showDiceFairness) || Number(state.targetWords ?? 24) !== 24 || Array.isArray(state.diceCoinPositions) && state.diceCoinPositions.length > 0 || String(state.lastWord ?? "").length > 0 || String(state.dplusLastWord ?? "").length > 0 || Boolean(state.result) || Boolean(state.reveal) || String(state.error ?? "").length > 0 || String(state.accountId ?? "bip84") !== "bip84" || String(fields.script ?? "bip84") !== "bip84" || String(fields.derivationPath ?? "m/84'/0'/0'/0/0") !== "m/84'/0'/0'/0/0" || String(fields.purpose ?? "84'") !== "84'" || fields.purposeHarden === false || String(fields.coinType ?? (fields.network === "testnet" ? "1'" : "0'")) !== "0'" || fields.coinTypeHarden === false || String(fields.account ?? "0'") !== "0'" || fields.accountHarden === false || String(fields.branchStart ?? "0") !== "0" || Boolean(fields.branchHarden) || String(fields.branchRange ?? "1") !== "1" || String(fields.addressStart ?? "0") !== "0" || Boolean(fields.addressHarden) || String(fields.addressRange ?? fields.count ?? "1") !== "1" || hodlNormalizePrivateKeyKind(fields.keyKind, privateKeys[fields.keyKind] || "") !== "wif" || ["pass", "dice", "dplusDice", "hex", "bin", "base4", "base8", "base32", "base64", "cards", "directCards", "seed", "seedNumbers", "brainLab", "key"].some(hasText) || hodlPrivateKeyKinds.some((kind) => privateKeys[kind].length > 0);
 }
 function hodlSyncKeyClearButton(capture = false) {
   if (capture) hodlCaptureKey();
@@ -8888,6 +8972,8 @@ function hodlCaptureKey() {
   if (directCards) state.fields.directCards = directCards.value;
   let seedNumbers = document.getElementById("seed-numbers");
   if (seedNumbers) state.fields.seedNumbers = seedNumbers.value;
+  let brainLabField = document.getElementById("brain-lab");
+  if (brainLabField) state.fields.brainLab = brainLabField.value;
   state.fields.coinType = document.getElementById("network")?.value || "0";
   state.fields.derivationAccountPath = document.getElementById("derivation-path")?.dataset.accountPath || state.fields.derivationAccountPath || "m/84'/0'/0'";
   let hardening = hodlReadHardening();

--- a/test/brain-wallet.test.mjs
+++ b/test/brain-wallet.test.mjs
@@ -54,3 +54,47 @@ test("exact mode accepts whitespace while trim mode rejects an empty result", ()
   assert.throws(() => helpers.hodlBrainWalletPassphrase(" \t\n", true), /leaves an empty brain-wallet recovery passphrase/);
   assert.throws(() => helpers.hodlBrainWalletPassphrase(""), /Enter the brain-wallet recovery passphrase/);
 });
+
+const lab = new Function(
+  "Z",
+  "M",
+  `${loadSlice("hodlBrainLabEntropy")};return { hodlBrainLabEntropy };`,
+)(Z, { encode: (bytes) => Buffer.from(bytes).toString("hex") });
+
+test("brain-wallet lab hashes exact UTF-8 text as 256-bit BIP39 entropy", () => {
+  const text = " recovery phrase \t\n";
+  const expected = createHash("sha256").update(text, "utf8").digest("hex");
+  const result = lab.hodlBrainLabEntropy(text);
+  assert.equal(result.ok, true);
+  assert.equal(result.hex, expected);
+  assert.equal(result.bits, 256);
+  assert.equal(result.sourceBits, 256);
+  assert.equal(result.method, "brain-lab");
+  assert.equal(result.bytes.length, 32);
+  assert.match(result.notes.join(" "), /24 words/);
+  assert.match(result.warnings.join(" "), /entropy of this text, not the 24-word count/);
+  assert.match(result.warnings.join(" "), /unsalted and fast/);
+  assert.match(result.warnings.join(" "), /not a BIP39 passphrase/);
+  assert.match(result.warnings.join(" "), /not a Bitcoin Core hdseed/);
+  assert.match(result.warnings.join(" "), /not mean it is the same wallet/);
+});
+
+test("brain-wallet lab rejects empty text and keeps private-key hashing separate", () => {
+  assert.equal(lab.hodlBrainLabEntropy("").ok, false);
+  const text = "correct horse battery staple";
+  const labHex = lab.hodlBrainLabEntropy(text).hex;
+  const scalarHex = Buffer.from(helpers.hodlBrainWalletPrivateKey(text)).toString("hex");
+  assert.equal(labHex, scalarHex);
+  assert.equal(app.includes('Ne === "brain-lab"'), true);
+  assert.match(app, /function hodlBrainWalletPrivateKey\(/);
+  assert.match(app, /function hodlBrainLabEntropy\(/);
+});
+
+test("brain-lab has no silent fingerprint or mnemonic preview path", () => {
+  assert.match(app, /hodlKeyModes = \["dice", "cards", "hex", "seed", "key", "brain-lab"\]/);
+  assert.match(app, /Brain wallet — lab/);
+  assert.match(loadSlice("hodlFingerprintMnemonic"), /if \(Ne === "brain-lab"\) return null;/);
+  assert.match(app, /24 words appear only after Derive Wallet/);
+  assert.match(app, /Acknowledge the lab warning before deriving/);
+  assert.doesNotMatch(loadSlice("hodlBrainLabEntropy"), /localStorage/);
+});


### PR DESCRIPTION
Hashes exact UTF-8 text with SHA-256 and uses the 32-byte digest as 256-bit BIP39 entropy (24 words).

- Private-key brain wallets remain a separate scalar path.
- Not a BIP39 passphrase, not a Bitcoin Core hdseed or address-key backup.
- Derive Wallet is required. The mnemonic is not previewed while typing.
- Strength is the entropy of the text, not the word count. Guessable text is stolen coins.
- Session ack stays in page RAM.

Run: `node --test test/brain-wallet.test.mjs`