### PR TITLE
Fix exact WASM allocation ownership

### DIFF
--- a/entropylab-wasm/src/lib.rs
+++ b/entropylab-wasm/src/lib.rs
@@ -44,15 +44,18 @@ fn ctx() -> &'static Secp256k1<secp256k1::All> {
     CONTEXT.get_or_init(Secp256k1::new)
 }
 
-/// Allocates `len` bytes of linear memory for JS to fill. Pair with
-/// `secp_free`.
+/// Allocates `len` zero-filled bytes of linear memory for JS to fill. Pair
+/// with `secp_free`. The box owns exactly `len` bytes, so the deallocation
+/// layout is reproducible from `len` alone.
 #[no_mangle]
 pub extern "C" fn secp_alloc(len: usize) -> *mut u8 {
     Box::into_raw(vec![0u8; len].into_boxed_slice()) as *mut u8
 }
 
 /// # Safety
-/// `ptr`/`len` must come from `secp_alloc`.
+/// `ptr` must come from `secp_alloc` and `len` must be exactly the length
+/// passed there: the box is reconstructed from `len` alone, so any other
+/// length deallocates with the wrong layout.
 #[no_mangle]
 pub unsafe extern "C" fn secp_free(ptr: *mut u8, len: usize) {
     // Zero the buffer before deallocation: inputs can carry private keys,
@@ -1089,4 +1092,33 @@ pub unsafe extern "C" fn el_sighash_segwit_v0(
     let digest = bitcoin_hashes::sha256d::Hash::hash(&buf).to_byte_array();
     std::ptr::copy_nonoverlapping(digest.as_ptr(), out, 32);
     32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The allocator pair must round-trip exact sizes, including zero length:
+    // secp_free reconstructs a Box<[u8]> whose layout comes from `len` alone,
+    // so a capacity mismatch corrupts the host allocator. The wasm suite
+    // (test/wipe-wasm.test.mjs) pins this behavior in the artifact; this test
+    // makes the same lifecycle checkable on the host — `cargo test`, or
+    // `cargo +nightly miri test` for a UB-checked run.
+    #[test]
+    fn alloc_free_round_trips_exact_sizes() {
+        for len in [0usize, 1, 2, 15, 16, 31, 32, 255, 256, 4096] {
+            for cycle in 0..8u8 {
+                let ptr = secp_alloc(len);
+                assert!(!ptr.is_null());
+                unsafe {
+                    for i in 0..len {
+                        // A recycled block must never expose stale bytes.
+                        assert_eq!(ptr.add(i).read(), 0);
+                        ptr.add(i).write_volatile(cycle ^ i as u8);
+                    }
+                    secp_free(ptr, len);
+                }
+            }
+        }
+    }
 }

--- a/entropylab-wasm/src/lib.rs
+++ b/entropylab-wasm/src/lib.rs
@@ -48,10 +48,7 @@ fn ctx() -> &'static Secp256k1<secp256k1::All> {
 /// `secp_free`.
 #[no_mangle]
 pub extern "C" fn secp_alloc(len: usize) -> *mut u8 {
-    let mut buf = Vec::<u8>::with_capacity(len);
-    let ptr = buf.as_mut_ptr();
-    std::mem::forget(buf);
-    ptr
+    Box::into_raw(vec![0u8; len].into_boxed_slice()) as *mut u8
 }
 
 /// # Safety
@@ -62,7 +59,8 @@ pub unsafe extern "C" fn secp_free(ptr: *mut u8, len: usize) {
     // seeds, mnemonics, or passphrases, and freed linear memory must not
     // retain them for a later allocation to expose.
     wipe(ptr, len);
-    drop(Vec::from_raw_parts(ptr, 0, len));
+    let slice = std::ptr::slice_from_raw_parts_mut(ptr, len);
+    drop(Box::from_raw(slice));
 }
 
 /// Overwrites `len` bytes at `ptr` with zeroes. Volatile stores plus a
@@ -1092,4 +1090,3 @@ pub unsafe extern "C" fn el_sighash_segwit_v0(
     std::ptr::copy_nonoverlapping(digest.as_ptr(), out, 32);
     32
 }
-

--- a/psbt-wasm/src/lib.rs
+++ b/psbt-wasm/src/lib.rs
@@ -53,15 +53,18 @@ fn clear_error() {
     LAST_ERROR.with(|slot| slot.borrow_mut().clear());
 }
 
-/// Allocates `len` bytes of linear memory for JS to fill. Pair with
-/// `psbt_free`.
+/// Allocates `len` zero-filled bytes of linear memory for JS to fill. Pair
+/// with `psbt_free`. The box owns exactly `len` bytes, so the deallocation
+/// layout is reproducible from `len` alone.
 #[no_mangle]
 pub extern "C" fn psbt_alloc(len: usize) -> *mut u8 {
     Box::into_raw(vec![0u8; len].into_boxed_slice()) as *mut u8
 }
 
 /// # Safety
-/// `ptr`/`len` must come from `psbt_alloc`.
+/// `ptr` must come from `psbt_alloc` and `len` must be exactly the length
+/// passed there: the box is reconstructed from `len` alone, so any other
+/// length deallocates with the wrong layout.
 #[no_mangle]
 pub unsafe extern "C" fn psbt_free(ptr: *mut u8, len: usize) {
     // Zero the buffer before deallocation. The boundary is watch-only by
@@ -912,4 +915,33 @@ fn build(json_bytes: &[u8]) -> Result<Vec<u8>, String> {
     // witness-carrying unsigned transactions and count mismatches.
     Psbt::deserialize(&out).map_err(|e| format!("rebuilt PSBT does not parse: {e}"))?;
     Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The allocator pair must round-trip exact sizes, including zero length:
+    // psbt_free reconstructs a Box<[u8]> whose layout comes from `len` alone,
+    // so a capacity mismatch corrupts the host allocator. The wasm suite
+    // (test/wipe-wasm.test.mjs) pins this behavior in the artifact; this test
+    // makes the same lifecycle checkable on the host — `cargo test`, or
+    // `cargo +nightly miri test` for a UB-checked run.
+    #[test]
+    fn alloc_free_round_trips_exact_sizes() {
+        for len in [0usize, 1, 2, 15, 16, 31, 32, 255, 256, 4096] {
+            for cycle in 0..8u8 {
+                let ptr = psbt_alloc(len);
+                assert!(!ptr.is_null());
+                unsafe {
+                    for i in 0..len {
+                        // A recycled block must never expose stale bytes.
+                        assert_eq!(ptr.add(i).read(), 0);
+                        ptr.add(i).write_volatile(cycle ^ i as u8);
+                    }
+                    psbt_free(ptr, len);
+                }
+            }
+        }
+    }
 }

--- a/psbt-wasm/src/lib.rs
+++ b/psbt-wasm/src/lib.rs
@@ -57,10 +57,7 @@ fn clear_error() {
 /// `psbt_free`.
 #[no_mangle]
 pub extern "C" fn psbt_alloc(len: usize) -> *mut u8 {
-    let mut buf = Vec::<u8>::with_capacity(len);
-    let ptr = buf.as_mut_ptr();
-    std::mem::forget(buf);
-    ptr
+    Box::into_raw(vec![0u8; len].into_boxed_slice()) as *mut u8
 }
 
 /// # Safety
@@ -71,7 +68,8 @@ pub unsafe extern "C" fn psbt_free(ptr: *mut u8, len: usize) {
     // design, but a pasted PSBT can carry xprvs in proprietary fields; freed
     // linear memory must not retain it for a later allocation to expose.
     wipe(ptr, len);
-    drop(Vec::from_raw_parts(ptr, 0, len));
+    let slice = std::ptr::slice_from_raw_parts_mut(ptr, len);
+    drop(Box::from_raw(slice));
 }
 
 /// Overwrites `len` bytes at `ptr` with zeroes. Volatile stores plus a

--- a/test/wipe-wasm.test.mjs
+++ b/test/wipe-wasm.test.mjs
@@ -18,6 +18,9 @@ const read = (file) => readFileSync(join(root, file), "utf8");
 // Distinctive fixed patterns; nothing here is anyone's key.
 const pattern = (size, seed) => new Uint8Array(size).map((_, i) => (i * seed + seed) & 0xff);
 const wasmMemoryContains = (bytes) => Buffer.from(heap().buffer).indexOf(Buffer.from(bytes)) !== -1;
+const psbtBinary = new Uint8Array(Buffer.from(PSBT_WASM_B64, "base64"));
+const psbtWasm = new WebAssembly.Instance(new WebAssembly.Module(psbtBinary), {}).exports;
+const psbtHeap = () => new Uint8Array(psbtWasm.memory.buffer);
 
 test("secp_free zeroes the linear-memory buffer before deallocating it", () => {
   const wasm = wasmExports();
@@ -29,14 +32,30 @@ test("secp_free zeroes the linear-memory buffer before deallocating it", () => {
 });
 
 test("psbt_free zeroes the linear-memory buffer before deallocating it", () => {
-  const binary = new Uint8Array(Buffer.from(PSBT_WASM_B64, "base64"));
-  const wasm = new WebAssembly.Instance(new WebAssembly.Module(binary), {}).exports;
-  const psbtHeap = () => new Uint8Array(wasm.memory.buffer);
   const secret = pattern(96, 13);
-  const ptr = wasm.psbt_alloc(secret.length);
+  const ptr = psbtWasm.psbt_alloc(secret.length);
   psbtHeap().set(secret, ptr);
-  wasm.psbt_free(ptr, secret.length);
+  psbtWasm.psbt_free(ptr, secret.length);
   assert.deepEqual([...psbtHeap().slice(ptr, ptr + secret.length)], new Array(secret.length).fill(0));
+});
+
+test("both WASM allocators support exact-size repeated and zero-length lifecycles", () => {
+  const allocators = [
+    { alloc: wasmExports().secp_alloc, free: wasmExports().secp_free, memory: heap },
+    { alloc: psbtWasm.psbt_alloc, free: psbtWasm.psbt_free, memory: psbtHeap },
+  ];
+  for (const { alloc, free, memory } of allocators) {
+    for (const size of [0, 1, 2, 15, 16, 31, 32, 255, 256, 4096]) {
+      for (let cycle = 0; cycle < 8; cycle++) {
+        const ptr = alloc(size);
+        assert.ok(Number.isInteger(ptr) && ptr >= 0);
+        const marker = pattern(size, cycle + 3);
+        memory().set(marker, ptr);
+        free(ptr, size);
+        assert.deepEqual(memory().slice(ptr, ptr + size), new Uint8Array(size));
+      }
+    }
+  }
 });
 
 test("a private key is absent from linear memory once public-key derivation returns", () => {
@@ -102,6 +121,16 @@ test("the Rust free functions wipe before deallocating (source guard)", () => {
     read("psbt-wasm/src/lib.rs"),
     /fn psbt_free\(ptr: \*mut u8, len: usize\) \{\s*(?:\/\/[^\n]*\n\s*(?:\/\/[^\n]*\n\s*)*)?wipe\(ptr, len\);/,
   );
+});
+
+test("the Rust allocators reconstruct the exact boxed-slice layout", () => {
+  for (const file of ["entropylab-wasm/src/lib.rs", "psbt-wasm/src/lib.rs"]) {
+    const source = read(file);
+    assert.match(source, /vec!\[0u8; len\]\.into_boxed_slice\(\)/);
+    assert.match(source, /slice_from_raw_parts_mut\(ptr, len\)/);
+    assert.doesNotMatch(source, /Vec::<u8>::with_capacity\(len\)/);
+    assert.doesNotMatch(source, /Vec::from_raw_parts\(ptr, 0, len\)/);
+  }
 });
 
 test("the JS facades wipe their secret byte buffers (source guard)", () => {


### PR DESCRIPTION
## Summary

- allocate both WASM input buffers as exact-length boxed slices
- reconstruct the same boxed-slice layout after securely wiping the buffer
- cover repeated allocation/free cycles, boundary sizes, and zero-length allocations
- add source guards against reintroducing capacity-based `Vec` reconstruction

Closes #188.

## Validation

- `npm run build:wasm` (workspace-local Rust 1.95.0 and Clang)
- rebuilt-WASM suites: 41/41 passed
- `npm run build`
- `npm test`: 722/723 passed locally; only snap-confined Firefox could not start because its runtime directories are read-only in the sandbox
- Chrome browser integration: 49/49 passed
- `git diff --check`

Generated WASM/base64 and HTML artifacts were rebuilt and tested locally, then left out of the source commit per the repository artifact workflow.