### PR TITLE
Allow one-way global sync from hashed inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,11 @@ Official website: [entropylab.online](https://entropylab.online)
   wallet looks empty, repair it with `rescanblockchain 0` in Bitcoin Core.
   Generated database files match Bitcoin Core's own record layout
   byte-for-byte (verified against Bitcoin Core v28.3.0).
-- An optional **Sync non-hashed input methods** checkbox (off by default) keeps
+- An optional **Sync entropy across methods** checkbox (off by default) keeps
   direct dice, card, number-base, seed-word, and private-key representations in
   sync while input is entered. Each destination waits for enough bits to emit
-  its next complete character. The control remains visible but unavailable for
-  hashed input methods.
+  its next complete character. Hashed inputs update the non-hashed methods in
+  one direction; edits to non-hashed methods never overwrite hashed inputs.
 - SLIP-132 extended-key display is a prefix swap only (same payload, new
   version bytes and checksum). Import/derive shows the key as pasted, the
   Bitcoin Core xprv/xpub or tprv/tpub, and the descriptor (script in the

--- a/llms.txt
+++ b/llms.txt
@@ -13,7 +13,7 @@ EntropyLab is a single HTML file with no runtime dependencies. It is designed to
 - Edits PSBT v0 files field by field (bip174.org-style): every global/input/output key-value pair decoded and editable, structured transaction fields, and rust-bitcoin-validated re-serialization. A mempool.space-style flow diagram (clickable input/output/transaction boxes joined by bezier connectors, inline output amounts) doubles as the editing surface. Never signs.
 - Derives BIP-85 child entropy from a BIP32 root: English BIP-39, WIF, XPRV, HEX, and Base64/Base85 passwords.
 - Derives BIP-352 Silent Payment addresses, labeled codes, and BIP-392 descriptors; computes sender taproot outputs and verifies pasted outputs offline. Does not scan the chain.
-- Optional global entropy sync keeps direct dice, cards, number bases, BIP39 words/numbers, and private-key encodings aligned live. It stays visible but is unavailable for hashed input methods. Off by default.
+- Optional global entropy sync keeps direct dice, cards, number bases, BIP39 words/numbers, and private-key encodings aligned live. Hashed inputs update those methods in one direction and are never overwritten by non-hashed edits. Off by default.
 - SLIP-132 display is prefix-swap only. Shows as-pasted, Bitcoin Core xpub/xprv (or tpub/tprv), and descriptor. SLIP form only when path/script match. No Taproot prefix. Testnet t/u/v/U/V.
 - Exports a Bitcoin Core wallet.dat (watch-only by default) with all derived descriptors imported.
 - Runs startup sanity checks on the host browser and refuses to render if they fail.

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -5045,11 +5045,14 @@ function hodlGlobalSyncBitBoxBits(value, targetWords = Pt) {
   return bits.slice(0, config.bits);
 }
 function hodlGlobalSyncCurrentBits(targetWords = Pt) {
-  if (hodlGlobalSyncIsHashedMode()) return null;
-  let value = hodlGlobalSyncCurrentValue(), config = hodlSeedConfig(targetWords);
+  let value = hodlGlobalSyncCurrentValue(), config = hodlSeedConfig(targetWords), hashed = hodlGlobalSyncIsHashedMode();
   if (!String(value).length) return "";
   try {
     if (Ne === "dice") {
+      if (hashed) {
+        let entropy = hodlDiceEntropy(value, ge, config.words);
+        return entropy.ok ? hodlBitsFromBytes(entropy.bytes) : null;
+      }
       if (ge === "dplus") {
         let parsed = hodlDPlusRolls(value, config.words);
         if (parsed.complete) return hodlBitsFromBytes(Er([...parsed.wordSlots, parsed.finalWord].join(" "), Ae));
@@ -5063,6 +5066,10 @@ function hodlGlobalSyncCurrentBits(targetWords = Pt) {
       return hodlGlobalSyncBitBoxBits(value, config.words);
     }
     if (Ne === "cards") {
+      if (hodlCardMethod === "hashed") {
+        let entropy = hodlCardsEntropy(value, config.words, hodlCardColemanSymbols);
+        return entropy.ok ? hodlBitsFromBytes(entropy.bytes) : null;
+      }
       let parsed = hodlParseDirectCards(value, config.words);
       if (parsed.complete) return hodlBitsFromBytes(Er([...parsed.wordSlots, parsed.finalWord].join(" "), Ae));
       return hodlGlobalSyncDirectCardBits(value, config.words);
@@ -5086,6 +5093,10 @@ function hodlGlobalSyncCurrentBits(targetWords = Pt) {
       if (mnemonic) return Pn(mnemonic, Ae) ? hodlBitsFromBytes(Er(mnemonic, Ae)) : null;
       return hodlGlobalSyncWordBits(words);
     }
+    if (Ne === "brain-lab") {
+      let entropy = hodlBrainLabEntropy(value);
+      return entropy.ok ? hodlBitsFromBytes(entropy.bytes) : null;
+    }
     let kind = hodlNormalizePrivateKeyKind(document.querySelector('input[name="kk"]:checked')?.value || "wif", value);
     if (kind === "hex-key") {
       let bits = "";
@@ -5096,7 +5107,8 @@ function hodlGlobalSyncCurrentBits(targetWords = Pt) {
       return bits;
     }
     if (kind === "wif") return hodlBitsFromBytes(Ls(value.trim()).priv);
-    return null;
+    if (kind === "minikey") return hodlBitsFromBytes(Ns(value.trim()));
+    return hodlBitsFromBytes(hodlBrainWalletPrivateKey(value, hodlBrainWalletTrimEnabled()));
   } catch {
     return null;
   }
@@ -5206,7 +5218,11 @@ function hodlApplyGlobalSync(bits, sourceId = hodlGlobalSyncSourceId()) {
 }
 function hodlGlobalSyncFromCurrentInput() {
   let state = hodlKeys[hodlActiveKey];
-  if (!state?.globalSync || hodlGlobalSyncIsHashedMode()) {
+  if (!state?.globalSync) {
+    hodlRenderGlobalSyncControl();
+    return false;
+  }
+  if (hodlGlobalSyncIsHashedMode() && !String(hodlGlobalSyncCurrentValue()).length) {
     hodlRenderGlobalSyncControl();
     return false;
   }
@@ -5220,15 +5236,13 @@ function hodlGlobalSyncFromCurrentInput() {
   hodlRenderGlobalSyncControl();
   return true;
 }
-function hodlGlobalSyncControlMarkup(hashed, state) {
-  let detail = hashed ? "Unavailable for hashed input methods." : "Only non-hashed input methods are synchronized. A destination waits for enough bits to emit its next complete character.";
-  return `<div class="global-sync-row"><label class="seed-autocomplete-toggle global-sync-toggle"><input type="checkbox" id="global-entropy-sync" ${state?.globalSync ? "checked" : ""} ${hashed ? "disabled" : ""} /><span><strong>Sync non-hashed input methods</strong> <span class="seed-autocomplete-note">(${detail})</span></span></label><span class="global-sync-status" id="global-sync-status" aria-live="polite" ${!hashed && state?.globalSync && state?.globalSyncBitCount ? "" : "hidden"}>${hodlCopiedIconMarkup()}<span>${state?.globalSyncBitCount || 0} bits synced</span></span></div>`;
+function hodlGlobalSyncControlMarkup(state) {
+  return `<div class="global-sync-row"><label class="seed-autocomplete-toggle global-sync-toggle"><input type="checkbox" id="global-entropy-sync" ${state?.globalSync ? "checked" : ""} /><span><strong>Sync entropy across methods</strong> <span class="seed-autocomplete-note">(Keeps non-hashed methods synchronized. Hashed inputs update them one way and are never overwritten.)</span></span></label><span class="global-sync-status" id="global-sync-status" aria-live="polite" ${state?.globalSync && state?.globalSyncBitCount ? "" : "hidden"}>${hodlCopiedIconMarkup()}<span>${state?.globalSyncBitCount || 0} bits synced</span></span></div>`;
 }
 function hodlRenderGlobalSyncControl() {
   let host = document.getElementById("global-sync-host"), state = hodlKeys[hodlActiveKey];
   if (!host || !state) return;
-  let hashed = hodlGlobalSyncIsHashedMode();
-  host.innerHTML = hodlGlobalSyncControlMarkup(hashed, state);
+  host.innerHTML = hodlGlobalSyncControlMarkup(state);
   let toggle = document.getElementById("global-entropy-sync");
   if (toggle) toggle.onchange = () => {
     state.globalSync = toggle.checked;

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -512,12 +512,13 @@
     input(preservedBase32, "");
   });
 
-  await test("global entropy sync follows partial direct input and excludes hashed input", async () => {
+  await test("global entropy sync follows partial direct input and supports one-way hashed input", async () => {
     document.querySelector('[data-seed-words="12"]').click();
     await chooseMode("Number bases");
     document.querySelector('input[name="entropy-format"][value="bin"]').click();
     const binary = await until(() => document.getElementById("bin"), "global-sync binary input");
     const directToggle = document.getElementById("global-entropy-sync");
+    const syncLabel = directToggle.closest("label").textContent;
     if (!directToggle.checked) directToggle.click();
     input(binary, "000");
     assert(document.getElementById("global-sync-status").textContent.includes("3 bits synced"), "Partial direct entropy did not sync immediately");
@@ -563,18 +564,27 @@
 
     await chooseMode("Dice rolls");
     document.querySelector('input[name="dm"][value="coldcard"]').click();
-    const hashedToggle = document.getElementById("global-entropy-sync");
+    let hashedToggle = document.getElementById("global-entropy-sync");
     assert(hashedToggle.closest("#global-sync-host"), "The global sync control moved away from the method button bar for a hashed input");
-    assert(hashedToggle.disabled && hashedToggle.checked, "A hashed input method did not preserve the enabled non-hashed sync preference while showing it as unavailable");
-    assert(hashedToggle.closest("label").textContent.includes("non-hashed"), "The global sync label did not explain its non-hashed scope");
+    assert(!hashedToggle.disabled && hashedToggle.checked, "The global sync checkbox was unavailable for a hashed input method");
+    equal(hashedToggle.closest("label").textContent, syncLabel, "The global sync label changed for a hashed input method");
+    hashedToggle.click();
+    hashedToggle = document.getElementById("global-entropy-sync");
+    assert(!hashedToggle.checked, "The global sync checkbox could not be turned off for a hashed input method");
+    hashedToggle.click();
+    hashedToggle = document.getElementById("global-entropy-sync");
+    assert(hashedToggle.checked, "The global sync checkbox could not be turned on for a hashed input method");
     const hashedDice = document.getElementById("dice");
     input(hashedDice, "1");
-    assert(document.getElementById("global-entropy-sync").disabled, "Entering hashed input enabled global sync");
     await chooseMode("Number bases");
     document.querySelector('input[name="entropy-format"][value="hex"]').click();
-    equal(document.getElementById("hex").value, wifHex, "A hashed input changed the last non-hashed synchronized entropy");
+    const hashedHex = document.getElementById("hex");
+    assert(hashedHex.value.length === 32 && hashedHex.value !== wifHex, "A hashed input did not publish its entropy to a non-hashed method");
+    input(hashedHex, "0".repeat(32));
+    await chooseMode("Dice rolls");
+    equal(document.getElementById("dice").value, "1", "A non-hashed edit overwrote the hashed dice transcript");
+    equal(document.getElementById("global-entropy-sync").closest("label").textContent, syncLabel, "The global sync label changed after a one-way hashed sync");
     const cleanupToggle = document.getElementById("global-entropy-sync");
-    assert(!cleanupToggle.disabled && cleanupToggle.checked, "The non-hashed sync preference did not resume after leaving a hashed method");
     if (cleanupToggle.checked) cleanupToggle.click();
     document.getElementById("wipe").click();
   });

--- a/test/global-sync.test.mjs
+++ b/test/global-sync.test.mjs
@@ -55,22 +55,30 @@ test("global sync replaces the old workspace and number-base-only sync features"
   assert.doesNotMatch(app, /global-sync-hash-host/);
   assert.match(app, /id="global-entropy-sync"/);
   assert.match(app, /globalSync: false/);
-  assert.match(app, /Sync non-hashed input methods/);
-  assert.match(app, /A destination waits for enough bits to emit its next complete character/);
+  assert.match(app, /Sync entropy across methods/);
+  assert.match(app, /Hashed inputs update them one way and are never overwritten/);
   assert.doesNotMatch(app, /workspace-sync|WorkspaceSync|Sync this key to other workspaces/);
   assert.doesNotMatch(app, /sync-number-bases|syncNumberBases|numberBaseSync/);
 });
 
-test("hashed methods keep the global control visible but cannot publish entropy", () => {
+test("hashed methods publish one way without being overwritten", () => {
   const classify = loadSlice("hodlGlobalSyncIsHashedMode");
   assert.match(classify, /ge === "coldcard" \|\| ge === "coleman"/);
   assert.match(classify, /hodlCardMethod === "hashed"/);
   assert.match(classify, /kind === "minikey" \|\| kind === "brain"/);
-  assert.match(loadSlice("hodlGlobalSyncCurrentBits"), /if \(hodlGlobalSyncIsHashedMode\(\)\) return null/);
-  assert.match(loadSlice("hodlGlobalSyncFromCurrentInput"), /!state\?\.globalSync \|\| hodlGlobalSyncIsHashedMode\(\)/);
+  const current = loadSlice("hodlGlobalSyncCurrentBits");
+  assert.match(current, /hodlDiceEntropy\(value, ge, config\.words\)/);
+  assert.match(current, /hodlCardsEntropy\(value, config\.words, hodlCardColemanSymbols\)/);
+  assert.match(current, /hodlBrainLabEntropy\(value\)/);
+  const apply = loadSlice("hodlApplyGlobalSync");
+  assert.doesNotMatch(apply, /fields\.dice\s*=/);
+  assert.doesNotMatch(apply, /fields\.cards\s*=/);
+  assert.doesNotMatch(apply, /privateKeys\.minikey\s*=/);
+  assert.doesNotMatch(apply, /privateKeys\.brain\s*=/);
   const render = loadSlice("hodlRenderGlobalSyncControl");
   assert.match(render, /document\.getElementById\("global-sync-host"\)/);
   assert.doesNotMatch(render, /global-sync-hash-host/);
+  assert.doesNotMatch(loadSlice("hodlGlobalSyncControlMarkup"), /disabled/);
 });
 
 test("BitBox direct input is isolated from hashed dice input", () => {


### PR DESCRIPTION
## Summary
- keep the global entropy-sync checkbox enabled and identically labeled for every input method
- let hashed inputs publish their derived entropy one way to non-hashed methods
- prevent edits to non-hashed methods from overwriting hashed dice, cards, Mini Key, Brain Wallet, or Brain Lab inputs
- preserve existing non-hashed data when sync is enabled from an empty hashed input
- update documentation and regression coverage for the one-way behavior

## Verification
- `node --test test/global-sync.test.mjs test/ui-defaults.test.mjs test/ci-completeness.test.mjs` (75 passed)
- `npm run build`
- `npm run verify`
- `npm run test:browser` (52 Chrome integration checks passed; Firefox and Edge unavailable locally)
- `npm test` (763 passed, 2 unavailable-browser skips)
