### PR TITLE
Fold the brain-wallet lab into the private-key brain wallet section

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1005,14 +1005,14 @@ ec.innerHTML = `
   </div>
 `;
 if (/^(www\.)?entropylab\.online$/i.test(location.hostname)) document.getElementById("online-warning")?.removeAttribute("hidden");
-var hodlKeyModes = ["dice", "cards", "hex", "seed", "key", "brain-lab"], hodlBrainLabAck = false, hodlCardRanks = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "T", "J", "Q", "K"], hodlDirectCardRanks = ["A", "2", "3", "4", "5", "6", "7", "8"], hodlCardSuits = [{ code: "S", symbol: "♠", label: "Spades", red: false }, { code: "H", symbol: "♥", label: "Hearts", red: true }, { code: "C", symbol: "♣", label: "Clubs", red: false }, { code: "D", symbol: "♦", label: "Diamonds", red: true }], hodlCardSuit = "", hodlCardRank = "", hodlCardMethod = "hashed", hodlSeedMethod = "words", hodlSeedZeroIndexed = false, hodlCardColemanSymbols = false, Ne = "dice", ge = "coldcard", Pt = 24, hodlEntropyFormat = "hex", hodlDiceCoinPositions = [], ft = "", re = null, Ge = false, hodlWalletDatBirthday = "genesis", Zs = W("#modes"), at = W("#form"), dr = W("#out");
+var hodlKeyModes = ["dice", "cards", "hex", "seed", "key"], hodlBrainLabAck = false, hodlCardRanks = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "T", "J", "Q", "K"], hodlDirectCardRanks = ["A", "2", "3", "4", "5", "6", "7", "8"], hodlCardSuits = [{ code: "S", symbol: "♠", label: "Spades", red: false }, { code: "H", symbol: "♥", label: "Hearts", red: true }, { code: "C", symbol: "♣", label: "Clubs", red: false }, { code: "D", symbol: "♦", label: "Diamonds", red: true }], hodlCardSuit = "", hodlCardRank = "", hodlCardMethod = "hashed", hodlSeedMethod = "words", hodlSeedZeroIndexed = false, hodlCardColemanSymbols = false, Ne = "dice", ge = "coldcard", Pt = 24, hodlEntropyFormat = "hex", hodlDiceCoinPositions = [], ft = "", re = null, Ge = false, hodlWalletDatBirthday = "genesis", Zs = W("#modes"), at = W("#form"), dr = W("#out");
 var hodlManualCalculationsOpen = false;
 hodlKeyModes.forEach((e) => {
   let t = document.createElement("button"), active = e === Ne;
   t.type = "button";
   t.className = "tab" + (active ? " active" : "");
   t.setAttribute("aria-pressed", String(active));
-  t.textContent = e === "dice" ? "Dice rolls" : e === "cards" ? "Cards" : e === "hex" ? "Number bases" : e === "seed" ? "Seed phrase" : e === "brain-lab" ? "Brain wallet — lab" : "Private key";
+  t.textContent = e === "dice" ? "Dice rolls" : e === "cards" ? "Cards" : e === "hex" ? "Number bases" : e === "seed" ? "Seed phrase" : "Private key";
   t.onclick = () => hodlSetMode(e);
   Zs.appendChild(t);
 });
@@ -2621,7 +2621,7 @@ function hodlUpdateKeyModeControls() {
   let singleKey = Ne === "key", settings = document.getElementById("key-settings");
   ["passphrase-field", "master-fingerprint-preview", "script-type-field", "derivation-path-field", "derivation-advanced"].forEach((id) => {
     let element = document.getElementById(id);
-    if (element) element.hidden = singleKey || (id === "master-fingerprint-preview" && Ne === "brain-lab");
+    if (element) element.hidden = singleKey;
   });
   settings?.classList.toggle("single-key-mode", singleKey);
 }
@@ -4224,7 +4224,7 @@ function hodlPassphraseKeyboardToggleMarkup() {
 }
 function hodlPassphraseBip39ToggleMarkup(checked = hodlPassphraseBip39Enabled()) {
   let autocomplete = hodlPassphraseAutocompleteEnabled();
-  return `<div class="passphrase-bip39-options"><label class="seed-autocomplete-toggle passphrase-bip39-toggle"><input type="checkbox" id="passphrase-bip39-words" ${checked ? "checked" : ""} /><span><strong>Build passphrase from BIP39 words</strong> <span class="seed-autocomplete-note">(lowercase words separated by single spaces)</span></span></label><label class="seed-autocomplete-toggle passphrase-autocomplete-toggle" id="passphrase-autocomplete-control"${checked ? "" : " hidden"}><input type="checkbox" id="passphrase-autocomplete" ${autocomplete ? "checked" : ""} /><span><strong>Autocomplete BIP39 words</strong> <span class="seed-autocomplete-note">(when the entered prefix identifies one word)</span></span></label></div>`;
+  return `<div class="passphrase-bip39-options"><label class="seed-autocomplete-toggle passphrase-bip39-toggle"><input type="checkbox" id="passphrase-bip39-words" ${checked ? "checked" : ""} /><span><strong>Build passphrase from BIP39 words</strong> <span class="seed-autocomplete-note">(lowercase words separated by single spaces)</span></span></label><label class="seed-autocomplete-toggle passphrase-autocomplete-toggle" id="passphrase-autocomplete-control"${checked ? "" : " hidden"}><input type="checkbox" id="passphrase-autocomplete" ${autocomplete ? "checked" : ""} /><span><strong>Autocomplete BIP39 words</strong></span></label></div>`;
 }
 function hodlBrainWalletTrimEnabled() {
   return Boolean(document.getElementById("brain-wallet-trim")?.checked);
@@ -4432,12 +4432,79 @@ function hodlPrivateKeyPlaceholder(kind, network = "mainnet") {
   if (kind === "brain") return "Recovery passphrase";
   return network === "testnet" ? "9\u2026 / c\u2026" : "5\u2026 / K\u2026 / L\u2026";
 }
+function hodlBrainWalletText(value, trim = hodlBrainWalletTrimEnabled()) {
+  try {
+    return hodlBrainWalletPassphrase(value, trim);
+  } catch {
+    return "";
+  }
+}
+function hodlBrainWalletOutput() {
+  return document.querySelector('input[name="bo"]:checked')?.value === "hd" ? "hd" : "scalar";
+}
+// The same SHA-256 digest can be used two ways, and they are different wallets:
+// as the private-key scalar, or as 256-bit BIP39 entropy for a 24-word seed.
+// Both live under Brain wallet so the choice is explicit rather than a separate
+// place to land in by accident.
+function hodlBrainOutputMarkup(output = "scalar", acked = Boolean(hodlBrainLabAck)) {
+  let hd = output === "hd";
+  return `<div class="brain-output" id="brain-output" hidden>
+    <p class="label">Brain wallet output</p>
+    <div class="choice-grid">
+      <label class="choice"><input type="radio" name="bo" value="scalar" ${hd ? "" : "checked"} /><span><strong>Single key pair</strong><span class="desc">The digest is the private key. One address, the original brain-wallet behaviour.</span></span></label>
+      <label class="choice"><input type="radio" name="bo" value="hd" ${hd ? "checked" : ""} /><span><strong>HD wallet with seed phrase</strong><span class="desc">The digest is 256-bit BIP39 entropy for a 24-word seed. Not the same wallet as the single key pair.</span></span></label>
+    </div>
+    <div class="wallet-result-messages" id="brain-warning" role="alert">
+      <h3>Brain wallet warning — read before first use</h3>
+      <ul>
+        <li class="is-warning">SHA-256(text) is unsalted and fast. Guessable phrases are stolen coins.</li>
+        <li class="is-warning">Strength is the entropy of this text, nothing more.</li>
+        <li class="is-warning">This is not a BIP39 passphrase.</li>
+        <li class="is-warning">This is not a Bitcoin Core hdseed or address-key backup of the same wallet.</li>
+        <li class="is-warning" data-brain-hd-warning ${hd ? "" : "hidden"}>The 24-word count is not the strength; the text is.</li>
+        <li class="is-warning" data-brain-hd-warning ${hd ? "" : "hidden"}>A valid mnemonic does not mean it is the same wallet as hashing the text as a private-key scalar.</li>
+      </ul>
+    </div>
+    <label class="choice"><input type="checkbox" id="brain-lab-ack" ${acked ? "checked" : ""} /><span><strong>I understand</strong><span class="desc">Required once this session, in page memory only. Derive is still required.</span></span></label>
+    <div id="brain-lab-zone" ${hd ? "" : "hidden"}>
+      <p class="muted" id="brain-lab-help">UTF-8 text is hashed with SHA-256. The 32-byte digest is BIP39 entropy for a 24-word seed. Nothing is derived until you press Derive Wallet.</p>
+      <p class="muted" id="brain-lab-hex" aria-live="polite">SHA-256 hex appears here. 24 words appear only after Derive Wallet.</p>
+    </div>
+  </div>`;
+}
+function hodlSyncBrainOutput() {
+  let zone = document.getElementById("brain-output"), input = document.getElementById("key");
+  if (!zone || !input) return;
+  let kind = hodlNormalizePrivateKeyKind(document.querySelector('input[name="kk"]:checked')?.value, input.value),
+    brain = kind === "brain", output = hodlBrainWalletOutput(), lab = document.getElementById("brain-lab-zone");
+  zone.hidden = !brain;
+  if (lab) lab.hidden = output !== "hd";
+  zone.querySelectorAll("[data-brain-hd-warning]").forEach((item) => {
+    item.hidden = output !== "hd";
+  });
+  let trimControl = document.querySelector("[data-brain-wallet-trim-control]");
+  if (trimControl) trimControl.hidden = !brain;
+  let hex = document.getElementById("brain-lab-hex");
+  if (!hex || !brain || output !== "hd") return;
+  if (!hodlBrainLabAck) {
+    hex.textContent = "Acknowledge the lab warning, then enter text. Derive Wallet is still required.";
+    hex.className = "muted";
+    return;
+  }
+  if (!input.value.length) {
+    hex.textContent = "SHA-256 hex appears here. 24 words appear only after Derive Wallet.";
+    hex.className = "muted";
+    return;
+  }
+  let entropy = hodlBrainLabEntropy(hodlBrainWalletText(input.value));
+  hex.textContent = entropy.ok ? `SHA-256 ${entropy.hex} \xB7 24 words appear only after Derive Wallet.` : entropy.error;
+  hex.className = "muted" + (entropy.ok ? " ok" : " err");
+}
 function hodlUpdatePrivateKeyInputPresentation() {
   let input = document.getElementById("key");
   if (!input) return;
   let kind = hodlNormalizePrivateKeyKind(document.querySelector('input[name="kk"]:checked')?.value, input.value), network = hodlSelectedNetwork(document.getElementById("network"));
-  let trimControl = document.querySelector("[data-brain-wallet-trim-control]");
-  if (trimControl) trimControl.hidden = kind !== "brain";
+  hodlSyncBrainOutput();
   input.placeholder = hodlPrivateKeyPlaceholder(kind, network);
   input.setAttribute("inputmode", kind === "hex-key" ? "text" : "text");
   input.setAttribute("autocapitalize", "off");
@@ -4964,7 +5031,6 @@ function hodlBytesFromBits(bits) {
 function hodlGlobalSyncIsHashedMode() {
   if (Ne === "dice") return ge === "coldcard" || ge === "coleman";
   if (Ne === "cards") return hodlCardMethod === "hashed";
-  if (Ne === "brain-lab") return true;
   if (Ne === "key") {
     let kind = hodlNormalizePrivateKeyKind(document.querySelector('input[name="kk"]:checked')?.value || hodlKeys[hodlActiveKey]?.fields?.keyKind, "");
     return kind === "minikey" || kind === "brain";
@@ -4976,7 +5042,6 @@ function hodlGlobalSyncSourceId() {
   if (Ne === "cards") return `cards:${hodlCardMethod}`;
   if (Ne === "hex") return `number:${hodlEntropyFormat}`;
   if (Ne === "seed") return `seed:${hodlSeedMethod}`;
-  if (Ne === "brain-lab") return "brain-lab";
   let kind = hodlNormalizePrivateKeyKind(document.querySelector('input[name="kk"]:checked')?.value || hodlKeys[hodlActiveKey]?.fields?.keyKind, "");
   return `key:${kind}`;
 }
@@ -4986,7 +5051,6 @@ function hodlGlobalSyncCurrentValue() {
   if (Ne === "cards") return document.getElementById(hodlCardMethod === "direct" ? "direct-cards" : "cards")?.value ?? fields[hodlCardMethod === "direct" ? "directCards" : "cards"] ?? "";
   if (Ne === "hex") return document.getElementById(hodlEntropyFormat)?.value ?? fields[hodlEntropyFormat] ?? "";
   if (Ne === "seed") return document.getElementById(hodlSeedMethod === "numbers" ? "seed-numbers" : "seed")?.value ?? fields[hodlSeedMethod === "numbers" ? "seedNumbers" : "seed"] ?? "";
-  if (Ne === "brain-lab") return document.getElementById("brain-lab")?.value ?? fields.brainLab ?? "";
   let values = hodlPrivateKeyValues(fields), kind = hodlNormalizePrivateKeyKind(document.querySelector('input[name="kk"]:checked')?.value || fields.keyKind, "");
   return document.getElementById("key")?.value ?? values[kind] ?? "";
 }
@@ -5092,10 +5156,6 @@ function hodlGlobalSyncCurrentBits(targetWords = Pt) {
       let mnemonic = words.length === config.words ? words.join(" ") : "";
       if (mnemonic) return Pn(mnemonic, Ae) ? hodlBitsFromBytes(Er(mnemonic, Ae)) : null;
       return hodlGlobalSyncWordBits(words);
-    }
-    if (Ne === "brain-lab") {
-      let entropy = hodlBrainLabEntropy(value);
-      return entropy.ok ? hodlBitsFromBytes(entropy.bytes) : null;
     }
     let kind = hodlNormalizePrivateKeyKind(document.querySelector('input[name="kk"]:checked')?.value || "wif", value);
     if (kind === "hex-key") {
@@ -5418,7 +5478,7 @@ function hodlUpdateSeedLengthControl() {
   let section = document.getElementById("seed-length");
   if (!section) return;
   let config = hodlSeedConfig();
-  section.hidden = Ne === "key" || Ne === "brain-lab";
+  section.hidden = Ne === "key";
   section.querySelectorAll("[data-seed-words]").forEach((button) => {
     let active = Number(button.dataset.seedWords) === config.words;
     button.classList.toggle("active", active);
@@ -5814,7 +5874,7 @@ function hodlRenderKeyForm() {
       update();
       return;
     }
-    at.innerHTML = `${choices}<p class="label">Your ${config.words}-word seed phrase</p><p class="muted" id="seed-help">Enter exactly ${config.words} English BIP39 words. You can also paste an extended key here; the selected phrase length does not apply to extended keys. With ${config.partialWords} compatible diceware words, choose the final checksum word below.</p><div class="seed-entry-tools">${hodlSeedKeyboardToggleMarkup()}<label class="seed-autocomplete-toggle"><input type="checkbox" id="seed-autocomplete" ${autocompleteEnabled ? "checked" : ""} /><span>Autocomplete BIP39 words <span class="seed-autocomplete-note">(fills in once only one word matches: usually 4 letters, or as few as 1 for the final checksum word)</span></span></label></div><div class="dice-input-shell seed-input-shell"><pre class="dice-input-highlight" id="seed-highlight" aria-hidden="true"></pre><textarea id="seed" placeholder="Enter exactly ${config.words} BIP39 words" aria-describedby="seed-help seed-meta" autocomplete="off" spellcheck="false" autocapitalize="off"></textarea></div><p class="muted" id="seed-meta" aria-live="polite"></p>${hodlSeedKeyboardMarkup()}<div id="last-words" class="row" style="margin-top:8px"></div>`;
+    at.innerHTML = `${choices}<p class="label">Your ${config.words}-word seed phrase</p><p class="muted" id="seed-help">Enter exactly ${config.words} English BIP39 words. You can also paste an extended key here; the selected phrase length does not apply to extended keys. With ${config.partialWords} compatible diceware words, choose the final checksum word below.</p><div class="seed-entry-tools">${hodlSeedKeyboardToggleMarkup()}<label class="seed-autocomplete-toggle"><input type="checkbox" id="seed-autocomplete" ${autocompleteEnabled ? "checked" : ""} /><span>Autocomplete BIP39 words</span></label></div><div class="dice-input-shell seed-input-shell"><pre class="dice-input-highlight" id="seed-highlight" aria-hidden="true"></pre><textarea id="seed" placeholder="Enter exactly ${config.words} BIP39 words" aria-describedby="seed-help seed-meta" autocomplete="off" spellcheck="false" autocapitalize="off"></textarea></div><p class="muted" id="seed-meta" aria-live="polite"></p>${hodlSeedKeyboardMarkup()}<div id="last-words" class="row" style="margin-top:8px"></div>`;
     let input = document.getElementById("seed"), update = () => {
       let rawValue = input.value, value = rawValue.trim(), meta = W("#seed-meta"), picker = W("#last-words"), analysis = hodlRenderSeedInputState(input, config.words);
       if (hodlLooksExtendedKey(value)) {
@@ -5893,64 +5953,6 @@ function hodlRenderKeyForm() {
     update();
     return;
   }
-  if (Ne === "brain-lab") {
-    let state = hodlKeys[hodlActiveKey], acked = Boolean(hodlBrainLabAck);
-    at.innerHTML = `
-      <details class="lab-entropy" id="brain-lab-details" ${acked ? "" : "open"}>
-        <summary>Brain wallet — lab</summary>
-        <div class="wallet-result-messages" role="alert">
-          <h3>Lab warning — read before first use</h3>
-          <ul>
-            <li class="is-warning">Strength is the entropy of this text, not the 24-word count.</li>
-            <li class="is-warning">SHA-256(text) is unsalted and fast. Guessable phrases are stolen coins.</li>
-            <li class="is-warning">This is not a BIP39 passphrase.</li>
-            <li class="is-warning">This is not a Bitcoin Core hdseed or address-key backup of the same wallet.</li>
-            <li class="is-warning">A valid mnemonic does not mean it is the same Core wallet as hashing the text as a private-key scalar.</li>
-          </ul>
-        </div>
-        <label class="choice"><input type="checkbox" id="brain-lab-ack" ${acked ? "checked" : ""} /><span><strong>I understand</strong><span class="desc">Required once this session, in page memory only. Derive is still required.</span></span></label>
-      </details>
-      <p class="label" id="brain-lab-label">Lab text</p>
-      <p class="muted" id="brain-lab-help">UTF-8 text is hashed with SHA-256. The 32-byte digest is BIP39 entropy for a 24-word seed. Nothing is derived until you press Derive Wallet.</p>
-      <textarea id="brain-lab" placeholder="Exact text. Whitespace is significant." ${acked ? "" : "disabled"} aria-labelledby="brain-lab-label" aria-describedby="brain-lab-help brain-lab-hex"></textarea>
-      <p class="muted" id="brain-lab-hex" aria-live="polite">SHA-256 hex appears here. 24 words appear only after Derive Wallet.</p>`;
-    let ack = document.getElementById("brain-lab-ack"), input = document.getElementById("brain-lab"), hex = document.getElementById("brain-lab-hex");
-    let renderHex = () => {
-      if (!hodlBrainLabAck) {
-        hex.textContent = "Acknowledge the lab warning, then enter text. Derive Wallet is still required.";
-        hex.className = "muted";
-        return;
-      }
-      let value = input.value;
-      if (!value.length) {
-        hex.textContent = "SHA-256 hex appears here. 24 words appear only after Derive Wallet.";
-        hex.className = "muted";
-        return;
-      }
-      let entropy = hodlBrainLabEntropy(value);
-      hex.textContent = entropy.ok ? `SHA-256 (256-bit BIP39 entropy): ${entropy.hex}` : entropy.error;
-      hex.className = "muted " + (entropy.ok ? "ok" : "err");
-    };
-    ack.onchange = () => {
-      hodlBrainLabAck = ack.checked;
-      input.disabled = !hodlBrainLabAck;
-      renderHex();
-      hodlSyncKeyClearButton();
-      hodlSyncDeriveButton();
-    };
-    input.oninput = () => {
-      if (state) state.fields.brainLab = input.value;
-      renderHex();
-      hodlSyncKeyClearButton();
-      hodlSyncDeriveButton();
-    };
-    if (state?.fields.brainLab) input.value = state.fields.brainLab;
-    hodlBindKeyFields();
-    hodlRenderPassphraseKeyboard();
-    renderHex();
-    hodlSyncDeriveButton();
-    return;
-  }
   at.innerHTML = `
     <p class="label">Private key format</p>
     <div class="choice-grid">
@@ -5959,6 +5961,7 @@ function hodlRenderKeyForm() {
     <label class="choice"><input type="radio" name="kk" value="minikey" /><span><strong>Mini key</strong><span class="desc">Casascius-style short key.</span></span></label>
     <label class="choice"><input type="radio" name="kk" value="brain" /><span><strong>Brain wallet</strong><span class="desc">Unsafe. Use only to recover an old passphrase wallet.</span></span></label>
     </div>
+    ${hodlBrainOutputMarkup(hodlKeys[hodlActiveKey]?.brainWalletOutput || "scalar")}
     <p class="label" id="private-key-input-label">Private key or recovery passphrase</p>
     <p class="muted" id="private-key-input-help">Enter the value matching the selected format. Brain wallets are for recovery only.</p>
     ${hodlPrivateKeyKeyboardToggleMarkup()}
@@ -6232,10 +6235,26 @@ function hodlBindKeyFields() {
       radio.addEventListener("input", change);
       radio.addEventListener("change", change);
     });
+    let refreshBrain = () => {
+      hodlSyncBrainOutput();
+      hodlRenderPrivateKeyInputState(key);
+      hodlSyncKeyClearButton();
+      hodlSyncDeriveButton();
+    };
+    document.querySelectorAll('input[name="bo"]').forEach((radio) => radio.addEventListener("change", () => {
+      if (state) state.brainWalletOutput = hodlBrainWalletOutput();
+      refreshBrain();
+    }));
+    let ack = document.getElementById("brain-lab-ack");
+    if (ack) ack.onchange = () => {
+      hodlBrainLabAck = ack.checked;
+      refreshBrain();
+    };
     document.getElementById("network")?.addEventListener("change", apply);
     let trim = document.getElementById("brain-wallet-trim");
     if (trim) trim.onchange = () => {
       if (state) state.brainWalletTrim = trim.checked;
+      hodlSyncBrainOutput();
       hodlRenderPrivateKeyInputState(key);
       hodlSyncKeyClearButton();
       hodlSyncDeriveButton();
@@ -6310,9 +6329,9 @@ function hodlCanDeriveCurrentKey() {
       }
       return hodlValidateTargetMnemonic(value, Pt).ok;
     }
-    if (Ne === "brain-lab") {
+    if (Ne === "key" && hodlNormalizePrivateKeyKind(document.querySelector('input[name="kk"]:checked')?.value, document.getElementById("key")?.value || "") === "brain") {
       if (!hodlBrainLabAck) return false;
-      return hodlBrainLabEntropy(document.getElementById("brain-lab")?.value).ok;
+      if (hodlBrainWalletOutput() === "hd") return hodlBrainLabEntropy(hodlBrainWalletText(document.getElementById("key")?.value)).ok;
     }
     return hodlPrivateKeyInputIsValid();
   } catch {
@@ -6378,7 +6397,6 @@ function hodlFingerprintMnemonic() {
       let validation = hodlValidateTargetMnemonic(value, Pt);
       return validation.ok ? validation.words.join(" ") : null;
     }
-    if (Ne === "brain-lab") return null;
   } catch {
   }
   return null;
@@ -6416,7 +6434,7 @@ function hodlRenderMasterFingerprintPreview(revision = hodlMasterFingerprintRevi
   if (revision !== hodlMasterFingerprintRevision) return;
   let preview = document.getElementById("master-fingerprint-preview"), baseCard = document.getElementById("base-master-fingerprint-card"), base = document.getElementById("base-master-fingerprint"), baseImage = document.getElementById("base-master-fingerprint-lifehash"), arrow = document.getElementById("master-fingerprint-arrow"), derivedCard = document.getElementById("passphrase-master-fingerprint-card"), derived = document.getElementById("passphrase-master-fingerprint"), derivedImage = document.getElementById("passphrase-master-fingerprint-lifehash"), pass = document.getElementById("pass");
   if (!preview || !baseCard || !base || !arrow || !derivedCard || !derived || !pass) return;
-  if (Ne === "key" || Ne === "brain-lab") {
+  if (Ne === "key") {
     preview.hidden = true;
     return;
   }
@@ -6581,18 +6599,22 @@ async function hodlCalculateKey(progress) {
         if (!validation.ok) throw new Error(validation.error);
         re = await hodlMnemonicWalletWithProgress(validation.words.join(" "), passphrase, network, count, void 0, account, addressStart, progress, purpose, coinType, hardening, branchStart, branchRange, derivationPlan);
       }
-    } else if (Ne === "brain-lab") {
-      if (!hodlBrainLabAck) throw new Error("Acknowledge the lab warning before deriving.");
-      let entropy = hodlBrainLabEntropy(document.getElementById("brain-lab")?.value);
-      if (!entropy.ok) throw new Error(entropy.error);
-      re = await hodlEntropyWalletWithProgress(entropy, passphrase, network, count, account, addressStart, progress, purpose, coinType, hardening, branchStart, branchRange, derivationPlan);
     } else {
       let value = document.getElementById("key").value, kind = hodlNormalizePrivateKeyKind(document.querySelector("input[name=kk]:checked")?.value, value);
-      let trimBrainWallet = hodlBrainWalletTrimEnabled();
-      hodlAssertPrivateKeyKind(value, network, kind, trimBrainWallet);
-      progress.setTotal(1);
-      re = Io(value, network, kind, trimBrainWallet);
-      progress.step();
+      if (kind === "brain" && !hodlBrainLabAck) throw new Error("Acknowledge the lab warning before deriving.");
+      if (kind === "brain" && hodlBrainWalletOutput() === "hd") {
+        // The digest becomes BIP39 entropy rather than the private key itself,
+        // which is a different wallet from the same text.
+        let entropy = hodlBrainLabEntropy(hodlBrainWalletPassphrase(value, hodlBrainWalletTrimEnabled()));
+        if (!entropy.ok) throw new Error(entropy.error);
+        re = await hodlEntropyWalletWithProgress(entropy, passphrase, network, count, account, addressStart, progress, purpose, coinType, hardening, branchStart, branchRange, derivationPlan);
+      } else {
+        let trimBrainWallet = hodlBrainWalletTrimEnabled();
+        hodlAssertPrivateKeyKind(value, network, kind, trimBrainWallet);
+        progress.setTotal(1);
+        re = Io(value, network, kind, trimBrainWallet);
+        progress.step();
+      }
     }
     if (re?.network !== network) throw new Error(`The supplied key is for ${re.network}, but Network is set to ${network}.`);
     Ge = false;
@@ -9279,7 +9301,7 @@ function hodlPrivateKeyValues(fields) {
 }
 function hodlNewKeyState(name, keyId, keyNumber) {
   let id = keyId ?? hodlNextKeyId++, number = keyNumber ?? hodlNextKeyNumber++;
-  return { id, number, color: hodlKeyColor(id), name: name || hodlDefaultKeyName(number), mode: "dice", diceMethod: "coldcard", cardMethod: "hashed", seedMethod: "words", seedZeroIndexed: false, cardColemanSymbols: false, entropyFormat: "bin", globalSync: false, globalSyncSource: "", globalSyncBitCount: 0, seedAutocomplete: true, passphraseBip39Words: false, passphraseAutocomplete: true, brainWalletTrim: false, showCards: false, showDiceFairness: false, targetWords: 24, diceCoinPositions: [], lastWord: "", dplusLastWord: "", result: null, reveal: false, accountId: "bip84", error: "", fields: { pass: "", script: "bip84", derivationPath: "m/84'/0'/0'/0/0", derivationAccountPath: "m/84'/0'/0'", purpose: "84'", purposeHarden: true, coinType: "0'", coinTypeHarden: true, network: "mainnet", account: "0'", accountHarden: true, branchStart: "0", branchHarden: false, branchRange: "1", addressStart: "0", addressHarden: false, addressRange: "1", dice: "", bitboxDice: "", dplusDice: "", hex: "", bin: "", base4: "", base8: "", base32: "", base64: "", cards: "", directCards: "", seed: "", seedNumbers: "", brainLab: "", key: "", keyKind: "wif", privateKeys: { wif: "", "hex-key": "", minikey: "", brain: "" } } };
+  return { id, number, color: hodlKeyColor(id), name: name || hodlDefaultKeyName(number), mode: "dice", diceMethod: "coldcard", cardMethod: "hashed", seedMethod: "words", seedZeroIndexed: false, cardColemanSymbols: false, entropyFormat: "bin", globalSync: false, globalSyncSource: "", globalSyncBitCount: 0, seedAutocomplete: true, passphraseBip39Words: false, brainWalletOutput: "scalar", passphraseAutocomplete: true, brainWalletTrim: false, showCards: false, showDiceFairness: false, targetWords: 24, diceCoinPositions: [], lastWord: "", dplusLastWord: "", result: null, reveal: false, accountId: "bip84", error: "", fields: { pass: "", script: "bip84", derivationPath: "m/84'/0'/0'/0/0", derivationAccountPath: "m/84'/0'/0'", purpose: "84'", purposeHarden: true, coinType: "0'", coinTypeHarden: true, network: "mainnet", account: "0'", accountHarden: true, branchStart: "0", branchHarden: false, branchRange: "1", addressStart: "0", addressHarden: false, addressRange: "1", dice: "", bitboxDice: "", dplusDice: "", hex: "", bin: "", base4: "", base8: "", base32: "", base64: "", cards: "", directCards: "", seed: "", seedNumbers: "", brainLab: "", key: "", keyKind: "wif", privateKeys: { wif: "", "hex-key": "", minikey: "", brain: "" } } };
 }
 function hodlRestoreFormFields(state) {
   if (!state) return;
@@ -9294,11 +9316,10 @@ function hodlRestoreFormFields(state) {
   if (showNumberBaseCalculations) showNumberBaseCalculations.checked = Boolean(state.showNumberBaseCalculations);
   let seedAutocomplete = document.getElementById("seed-autocomplete");
   if (seedAutocomplete) seedAutocomplete.checked = Boolean(state.seedAutocomplete);
-  let brainLab = document.getElementById("brain-lab");
-  if (brainLab) {
-    brainLab.value = state.fields.brainLab || "";
-    brainLab.dispatchEvent(new Event("input"));
-  }
+  document.querySelectorAll('input[name="bo"]').forEach((radio) => {
+    radio.checked = radio.value === (state.brainWalletOutput || "scalar");
+  });
+  hodlSyncBrainOutput();
   ["dice", "hex", "bin", "base4", "base8", "base32", "base64", "seed", "seed-numbers", "key", "cards", "direct-cards"].forEach(id => {
     let el = document.getElementById(id);
     if (el) {
@@ -9394,8 +9415,7 @@ function hodlCaptureKey() {
   if (directCards) state.fields.directCards = directCards.value;
   let seedNumbers = document.getElementById("seed-numbers");
   if (seedNumbers) state.fields.seedNumbers = seedNumbers.value;
-  let brainLabField = document.getElementById("brain-lab");
-  if (brainLabField) state.fields.brainLab = brainLabField.value;
+  if (document.querySelector('input[name="bo"]')) state.brainWalletOutput = hodlBrainWalletOutput();
   state.fields.coinType = document.getElementById("network")?.value || "0";
   state.fields.derivationAccountPath = document.getElementById("derivation-path")?.dataset.accountPath || state.fields.derivationAccountPath || "m/84'/0'/0'";
   let hardening = hodlReadHardening();

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1119,7 +1119,7 @@ function lr() {
       <label class="choice"><input type="radio" name="kk" value="wif" checked /><span><strong>WIF</strong><span class="desc">Bitcoin wallet import format (Base58Check).</span></span></label>
       <label class="choice"><input type="radio" name="kk" value="hex-key" /><span><strong>Private key hex</strong><span class="desc">Raw 32-byte private key as 64 hexadecimal characters.</span></span></label>
       <label class="choice"><input type="radio" name="kk" value="minikey" /><span><strong>Mini key</strong><span class="desc">Casascius-style short key.</span></span></label>
-      <label class="choice"><input type="radio" name="kk" value="brain" /><span><strong>Brain wallet</strong><span class="desc">Unsafe. Use only to recover an old passphrase wallet.</span></span></label>
+      <label class="choice"><input type="radio" name="kk" value="brain" /><span><strong>Brain wallet</strong><span class="desc">Unsafe. SHA-256 of your text, as one private key or a 24-word seed.</span></span></label>
     `;
   hodlBindFields();
 }
@@ -4778,16 +4778,27 @@ function hodlBindSeedKeyboard(input, targetWords = Pt) {
 function hodlBindPassphraseKeyboard(inputId = "pass", toggleId = "passphrase-keyboard-toggle", inputName = "passphrase", keyboardId = "passphrase-keyboard") {
   let toggle = document.getElementById(toggleId), keyboard = document.getElementById(keyboardId), input = document.getElementById(inputId), modeButton = keyboard?.querySelector("[data-seed-keyboard-mode]");
   if (!toggle || !keyboard || !input) return;
-  let privateKey = inputId === "key", refresh = () => privateKey ? hodlUpdatePrivateKeyKeyboardKeys(input, keyboardId) : hodlUpdatePassphraseKeyboardKeys(input, keyboardId);
+  let privateKey = inputId === "key", activeInput = input,
+    // Resolved on demand: the passphrase field is not always in the document
+    // when this binds, and it is only a target while it is actually shown.
+    passphraseTarget = () => {
+      let field = document.getElementById("passphrase-field"), element = document.getElementById("pass");
+      return privateKey && element && field && !field.hidden ? element : null;
+    },
+    onPassphrase = () => {
+      let target = passphraseTarget();
+      return Boolean(target) && activeInput === target;
+    },
+    refresh = () => onPassphrase() ? hodlUpdatePassphraseKeyboardKeys(activeInput, keyboardId) : privateKey ? hodlUpdatePrivateKeyKeyboardKeys(input, keyboardId) : hodlUpdatePassphraseKeyboardKeys(input, keyboardId);
   toggle.onclick = () => {
     hodlSetOnScreenKeyboardOpen(!hodlOnScreenKeyboardOpen);
     refresh();
   };
-  hodlBindKeypadPointer(keyboard.querySelectorAll("button"), () => input);
+  hodlBindKeypadPointer(keyboard.querySelectorAll("button"), () => activeInput);
   keyboard.querySelectorAll("[data-seed-character-key],.seed-keyboard-space").forEach((button) => {
-    button.onclick = () => hodlApplySeedKeyboardKey(input, button.dataset.seedKey || "");
+    button.onclick = () => hodlApplySeedKeyboardKey(activeInput, button.dataset.seedKey || "");
   });
-  keyboard.querySelectorAll("[data-seed-delete]").forEach((button) => hodlBindSeedKeyboardDelete(() => input, button));
+  keyboard.querySelectorAll("[data-seed-delete]").forEach((button) => hodlBindSeedKeyboardDelete(() => activeInput, button));
   if (modeButton) {
     modeButton.disabled = false;
     modeButton.onclick = () => {
@@ -4796,10 +4807,27 @@ function hodlBindPassphraseKeyboard(inputId = "pass", toggleId = "passphrase-key
       refresh();
     };
   }
-  ["input", "focus", "blur", "click", "keyup", "select"].forEach((type) => input.addEventListener(type, refresh));
+  ["input", "focus", "blur", "click", "keyup", "select"].forEach((type) => input.addEventListener(type, () => {
+    activeInput = input;
+    refresh();
+  }));
   if (privateKey) {
     document.querySelectorAll('input[name="kk"]').forEach((radio) => radio.addEventListener("change", refresh));
     document.getElementById("network")?.addEventListener("change", refresh);
+    // Delegated so a passphrase field that renders later is still picked up, and
+    // stored on the keyboard so re-binding replaces the handler.
+    let events = ["focusin", "input", "click", "keyup", "select"];
+    if (keyboard.hodlKeyboardActivity) events.forEach((type) => document.removeEventListener(type, keyboard.hodlKeyboardActivity));
+    keyboard.hodlKeyboardActivity = (event) => {
+      let target = passphraseTarget();
+      if (target && event.target === target) activeInput = target;
+      else if (event.target === input) activeInput = input;
+      else return;
+      // Announce the field it is actually typing into.
+      keyboard.setAttribute("aria-label", `On-screen ${keyboard.dataset.seedKeyboardLayout || "lower"} ${onPassphrase() ? "passphrase" : inputName} keyboard`);
+      refresh();
+    };
+    events.forEach((type) => document.addEventListener(type, keyboard.hodlKeyboardActivity));
   }
   refresh();
 }
@@ -4854,15 +4882,20 @@ function hodlBindBase64Keyboard(input) {
   refresh();
 }
 function hodlRenderPassphraseKeyboard() {
-  let host = document.getElementById("passphrase-keyboard-host"), toggleHost = document.getElementById("passphrase-keyboard-toggle-host"), privateKey = Ne === "key" && !hodlBrainHdActive(), passphrase = !privateKey;
-  // The seed keyboard already follows focus between the seed box and the
-  // passphrase box, so where it exists it serves both and a second on-screen
-  // keyboard would only stack another copy under the first.
+  let host = document.getElementById("passphrase-keyboard-host"), toggleHost = document.getElementById("passphrase-keyboard-toggle-host"),
+    keyMode = Ne === "key", hdBrain = hodlBrainHdActive(),
+    // The HD brain output needs the passphrase controls, but its keyboard is
+    // still the private-key one, which now follows focus into the passphrase.
+    privateKey = keyMode, passphrase = !keyMode || hdBrain;
+  // One on-screen keyboard per section: the seed keyboard already serves both
+  // fields, and in key mode the private-key keyboard does, so neither case adds
+  // a second keyboard or a second toggle.
   let shared = passphrase && Boolean(document.getElementById("seed-keyboard")),
+    ownToggle = passphrase && !shared && !hdBrain,
     enabled = !shared;
   if (toggleHost) {
     toggleHost.hidden = !passphrase;
-    toggleHost.innerHTML = passphrase ? (shared ? "" : hodlPassphraseKeyboardToggleMarkup()) + hodlPassphraseBip39ToggleMarkup() : "";
+    toggleHost.innerHTML = passphrase ? (ownToggle ? hodlPassphraseKeyboardToggleMarkup() : "") + hodlPassphraseBip39ToggleMarkup() : "";
   }
   if (!host) return;
   host.hidden = !enabled;
@@ -5967,7 +6000,7 @@ function hodlRenderKeyForm() {
     <label class="choice"><input type="radio" name="kk" value="wif" checked /><span><strong>WIF</strong><span class="desc">Bitcoin wallet import format (Base58Check).</span></span></label>
     <label class="choice"><input type="radio" name="kk" value="hex-key" /><span><strong>Private key hex</strong><span class="desc">Raw 32-byte private key as 64 hexadecimal characters.</span></span></label>
     <label class="choice"><input type="radio" name="kk" value="minikey" /><span><strong>Mini key</strong><span class="desc">Casascius-style short key.</span></span></label>
-    <label class="choice"><input type="radio" name="kk" value="brain" /><span><strong>Brain wallet</strong><span class="desc">Unsafe. Use only to recover an old passphrase wallet.</span></span></label>
+    <label class="choice"><input type="radio" name="kk" value="brain" /><span><strong>Brain wallet</strong><span class="desc">Unsafe. SHA-256 of your text, as one private key or a 24-word seed.</span></span></label>
     </div>
     ${hodlBrainOutputMarkup(hodlKeys[hodlActiveKey]?.brainWalletOutput || "scalar")}
     <p class="label" id="private-key-input-label">Private key or recovery passphrase</p>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2618,17 +2618,19 @@ function hodlImportedExtendedKeyDepth() {
   }
 }
 function hodlUpdateKeyModeControls() {
-  let singleKey = Ne === "key", settings = document.getElementById("key-settings");
+  let singleKey = Ne === "key", hdBrain = hodlBrainHdActive(), settings = document.getElementById("key-settings");
   ["passphrase-field", "master-fingerprint-preview", "script-type-field", "derivation-path-field", "derivation-advanced"].forEach((id) => {
     let element = document.getElementById(id);
-    if (element) element.hidden = singleKey;
+    // The HD brain output is a wallet, not a single key: it needs these fields.
+    // The fingerprint preview stays hidden so nothing is shown before Derive.
+    if (element) element.hidden = id === "master-fingerprint-preview" ? singleKey : singleKey && !hdBrain;
   });
-  settings?.classList.toggle("single-key-mode", singleKey);
+  settings?.classList.toggle("single-key-mode", singleKey && !hdBrain);
 }
 function hodlUpdateDerivationPathPreview() {
   hodlUpdateKeyModeControls();
   let input = document.getElementById("derivation-path"), help = document.getElementById("derivation-path-help");
-  if (!input || Ne === "key") return;
+  if (!input || Ne === "key" && !hodlBrainHdActive()) return;
   try {
     let visible = hodlReadVisibleDerivationPath();
     input.dataset.accountPath = `m${visible.accountComponents.map((entry) => `/${hodlPathIndex(entry.index, entry.hardened)}`).join("")}`;
@@ -4439,6 +4441,12 @@ function hodlBrainWalletText(value, trim = hodlBrainWalletTrimEnabled()) {
     return "";
   }
 }
+function hodlBrainHdActive() {
+  if (Ne !== "key") return false;
+  let input = document.getElementById("key");
+  if (!input) return false;
+  return hodlNormalizePrivateKeyKind(document.querySelector('input[name="kk"]:checked')?.value, input.value) === "brain" && hodlBrainWalletOutput() === "hd";
+}
 function hodlBrainWalletOutput() {
   return document.querySelector('input[name="bo"]:checked')?.value === "hd" ? "hd" : "scalar";
 }
@@ -4846,7 +4854,7 @@ function hodlBindBase64Keyboard(input) {
   refresh();
 }
 function hodlRenderPassphraseKeyboard() {
-  let host = document.getElementById("passphrase-keyboard-host"), toggleHost = document.getElementById("passphrase-keyboard-toggle-host"), privateKey = Ne === "key", passphrase = !privateKey;
+  let host = document.getElementById("passphrase-keyboard-host"), toggleHost = document.getElementById("passphrase-keyboard-toggle-host"), privateKey = Ne === "key" && !hodlBrainHdActive(), passphrase = !privateKey;
   // The seed keyboard already follows focus between the seed box and the
   // passphrase box, so where it exists it serves both and a second on-screen
   // keyboard would only stack another copy under the first.
@@ -6237,6 +6245,9 @@ function hodlBindKeyFields() {
     });
     let refreshBrain = () => {
       hodlSyncBrainOutput();
+      hodlUpdateKeyModeControls();
+      hodlRenderPassphraseKeyboard();
+      hodlUpdateDerivationPathPreview();
       hodlRenderPrivateKeyInputState(key);
       hodlSyncKeyClearButton();
       hodlSyncDeriveButton();
@@ -6533,8 +6544,8 @@ async function hodlCalculateKey(progress) {
   // recovery export.
   hodlWalletDatBirthday = "genesis";
   try {
-    let derivationPlan = Ne === "key" ? null : hodlReadDerivationPlan(), coinType = derivationPlan?.coinType ?? hodlReadCoinType(document.getElementById("network")), network = derivationPlan?.network ?? hodlNetworkFromCoinType(coinType), addressWindow = Ne === "key" ? { start: 0, range: 1 } : hodlReadAddressWindow(), branchWindow = Ne === "key" ? { start: 0, range: 2 } : hodlReadBranchWindow(), count = addressWindow.range, addressStart = addressWindow.start, branchStart = branchWindow.start, branchRange = branchWindow.range, passphrase = document.getElementById("pass").value, scriptType = hodlSelectedScriptType(), purpose = derivationPlan?.purpose ?? 84, account = derivationPlan?.accountIndex ?? 0, hardening = derivationPlan?.hardening ?? hodlDefaultHardening();
-    if (Ne !== "key" && hodlPassphraseBip39Enabled() && passphrase) {
+    let derivationPlan = Ne === "key" && !hodlBrainHdActive() ? null : hodlReadDerivationPlan(), coinType = derivationPlan?.coinType ?? hodlReadCoinType(document.getElementById("network")), network = derivationPlan?.network ?? hodlNetworkFromCoinType(coinType), addressWindow = Ne === "key" ? { start: 0, range: 1 } : hodlReadAddressWindow(), branchWindow = Ne === "key" ? { start: 0, range: 2 } : hodlReadBranchWindow(), count = addressWindow.range, addressStart = addressWindow.start, branchStart = branchWindow.start, branchRange = branchWindow.range, passphrase = document.getElementById("pass").value, scriptType = hodlSelectedScriptType(), purpose = derivationPlan?.purpose ?? 84, account = derivationPlan?.accountIndex ?? 0, hardening = derivationPlan?.hardening ?? hodlDefaultHardening();
+    if ((Ne !== "key" || hodlBrainHdActive()) && hodlPassphraseBip39Enabled() && passphrase) {
       let passphraseAnalysis = hodlAnalyzeBip39Passphrase(passphrase);
       if (passphraseAnalysis.invalidRanges.length || passphraseAnalysis.incomplete || passphraseAnalysis.trailingSeparator) throw new Error("Correct the highlighted BIP39-word passphrase inconsistencies before deriving.");
     }
@@ -6605,6 +6616,7 @@ async function hodlCalculateKey(progress) {
       if (kind === "brain" && hodlBrainWalletOutput() === "hd") {
         // The digest becomes BIP39 entropy rather than the private key itself,
         // which is a different wallet from the same text.
+        if (passphrase && document.getElementById("passphrase-field")?.hidden) throw new Error("A passphrase is set but not visible for this output. Show it and confirm it, or clear it, before deriving.");
         let entropy = hodlBrainLabEntropy(hodlBrainWalletPassphrase(value, hodlBrainWalletTrimEnabled()));
         if (!entropy.ok) throw new Error(entropy.error);
         re = await hodlEntropyWalletWithProgress(entropy, passphrase, network, count, account, addressStart, progress, purpose, coinType, hardening, branchStart, branchRange, derivationPlan);

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1119,7 +1119,7 @@ function lr() {
       <label class="choice"><input type="radio" name="kk" value="wif" checked /><span><strong>WIF</strong><span class="desc">Bitcoin wallet import format (Base58Check).</span></span></label>
       <label class="choice"><input type="radio" name="kk" value="hex-key" /><span><strong>Private key hex</strong><span class="desc">Raw 32-byte private key as 64 hexadecimal characters.</span></span></label>
       <label class="choice"><input type="radio" name="kk" value="minikey" /><span><strong>Mini key</strong><span class="desc">Casascius-style short key.</span></span></label>
-      <label class="choice"><input type="radio" name="kk" value="brain" /><span><strong>Brain wallet</strong><span class="desc">Unsafe. SHA-256 of your text, as one private key or a 24-word seed.</span></span></label>
+      <label class="choice"><input type="radio" name="kk" value="brain" /><span><strong>Brain wallet</strong><span class="desc">Unsafe. SHA-256 of your text, as a single key pair or a 24-word seed.</span></span></label>
     `;
   hodlBindFields();
 }
@@ -4882,7 +4882,7 @@ function hodlBindBase64Keyboard(input) {
   refresh();
 }
 function hodlRenderPassphraseKeyboard() {
-  let host = document.getElementById("passphrase-keyboard-host"), toggleHost = document.getElementById("passphrase-keyboard-toggle-host"),
+  let host = document.getElementById(Ne === "key" ? "private-keyboard-host" : "passphrase-keyboard-host"), toggleHost = document.getElementById("passphrase-keyboard-toggle-host"),
     keyMode = Ne === "key", hdBrain = hodlBrainHdActive(),
     // The HD brain output needs the passphrase controls, but its keyboard is
     // still the private-key one, which now follows focus into the passphrase.
@@ -6000,13 +6000,13 @@ function hodlRenderKeyForm() {
     <label class="choice"><input type="radio" name="kk" value="wif" checked /><span><strong>WIF</strong><span class="desc">Bitcoin wallet import format (Base58Check).</span></span></label>
     <label class="choice"><input type="radio" name="kk" value="hex-key" /><span><strong>Private key hex</strong><span class="desc">Raw 32-byte private key as 64 hexadecimal characters.</span></span></label>
     <label class="choice"><input type="radio" name="kk" value="minikey" /><span><strong>Mini key</strong><span class="desc">Casascius-style short key.</span></span></label>
-    <label class="choice"><input type="radio" name="kk" value="brain" /><span><strong>Brain wallet</strong><span class="desc">Unsafe. SHA-256 of your text, as one private key or a 24-word seed.</span></span></label>
+    <label class="choice"><input type="radio" name="kk" value="brain" /><span><strong>Brain wallet</strong><span class="desc">Unsafe. SHA-256 of your text, as a single key pair or a 24-word seed.</span></span></label>
     </div>
     ${hodlBrainOutputMarkup(hodlKeys[hodlActiveKey]?.brainWalletOutput || "scalar")}
     <p class="label" id="private-key-input-label">Private key or recovery passphrase</p>
     <p class="muted" id="private-key-input-help">Enter the value matching the selected format. Brain wallets are for recovery only.</p>
     ${hodlPrivateKeyKeyboardToggleMarkup()}
-    <div class="dice-input-shell private-key-input-shell"><pre class="dice-input-highlight" id="private-key-highlight" aria-hidden="true"></pre><textarea id="key" placeholder="5\u2026 / K\u2026 / L\u2026" aria-labelledby="private-key-input-label" aria-describedby="private-key-input-help private-key-meta"></textarea></div><p class="muted" id="private-key-meta" aria-live="polite"></p>`;
+    <div class="dice-input-shell private-key-input-shell"><pre class="dice-input-highlight" id="private-key-highlight" aria-hidden="true"></pre><textarea id="key" placeholder="5\u2026 / K\u2026 / L\u2026" aria-labelledby="private-key-input-label" aria-describedby="private-key-input-help private-key-meta"></textarea></div><p class="muted" id="private-key-meta" aria-live="polite"></p><div class="passphrase-keyboard-host" id="private-keyboard-host" hidden></div>`;
   hodlBindKeyFields();
   hodlRenderPassphraseKeyboard();
 }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1114,7 +1114,7 @@ function lr() {
     hodlBindFields();
   } else at.innerHTML = `
       <p class="label">Your Bitcoin Core private key</p>
-      <p class="muted">WIF, hex, mini key, or a brain-wallet passphrase (unsafe \u2014 recovery only).</p>
+      <p class="muted">WIF, hex, mini key, or brain-wallet text (unsafe).</p>
       <textarea id="key" placeholder="5\u2026 / K\u2026 / L\u2026"></textarea>
       <label class="choice"><input type="radio" name="kk" value="wif" checked /><span><strong>WIF</strong><span class="desc">Bitcoin wallet import format (Base58Check).</span></span></label>
       <label class="choice"><input type="radio" name="kk" value="hex-key" /><span><strong>Private key hex</strong><span class="desc">Raw 32-byte private key as 64 hexadecimal characters.</span></span></label>
@@ -4431,7 +4431,7 @@ function hodlNormalizePrivateKeyKind(kind, value = "") {
 function hodlPrivateKeyPlaceholder(kind, network = "mainnet") {
   if (kind === "hex-key") return "64 hexadecimal characters";
   if (kind === "minikey") return "S\u2026 (22 or 30 Base58 characters)";
-  if (kind === "brain") return "Recovery passphrase";
+  if (kind === "brain") return "Text to hash";
   return network === "testnet" ? "9\u2026 / c\u2026" : "5\u2026 / K\u2026 / L\u2026";
 }
 function hodlBrainWalletText(value, trim = hodlBrainWalletTrimEnabled()) {
@@ -6004,7 +6004,7 @@ function hodlRenderKeyForm() {
     </div>
     ${hodlBrainOutputMarkup(hodlKeys[hodlActiveKey]?.brainWalletOutput || "scalar")}
     <p class="label" id="private-key-input-label">Private key or recovery passphrase</p>
-    <p class="muted" id="private-key-input-help">Enter the value matching the selected format. Brain wallets are for recovery only.</p>
+    <p class="muted" id="private-key-input-help">Enter the value matching the selected format. Brain wallet text is hashed with SHA-256.</p>
     ${hodlPrivateKeyKeyboardToggleMarkup()}
     <div class="dice-input-shell private-key-input-shell"><pre class="dice-input-highlight" id="private-key-highlight" aria-hidden="true"></pre><textarea id="key" placeholder="5\u2026 / K\u2026 / L\u2026" aria-labelledby="private-key-input-label" aria-describedby="private-key-input-help private-key-meta"></textarea></div><p class="muted" id="private-key-meta" aria-live="polite"></p><div class="passphrase-keyboard-host" id="private-keyboard-host" hidden></div>`;
   hodlBindKeyFields();
@@ -6139,7 +6139,7 @@ function hodlPrivateKeyInputAnalysis(value, kind, network, trimBrainWallet = hod
       ready = false;
     }
     let convention = trimBrainWallet ? hasBoundaryWhitespace ? "boundary whitespace will be trimmed" : "trim enabled; no boundary whitespace present" : hasBoundaryWhitespace ? "exact text will be used, including boundary whitespace" : "exact text will be used";
-    let status = exact.length ? ready ? `Recovery passphrase entered \xB7 ${convention} \xB7 brain wallets are unsafe \xB7 recovery only` : "Boundary whitespace trimming leaves an empty passphrase \xB7 enter non-whitespace text or turn trimming off" : "No recovery passphrase entered \xB7 brain wallets are unsafe \xB7 recovery only";
+    let status = exact.length ? ready ? `Text entered \xB7 ${convention} \xB7 brain wallets are unsafe` : "Boundary whitespace trimming leaves an empty passphrase \xB7 enter non-whitespace text or turn trimming off" : "No text entered \xB7 brain wallets are unsafe";
     return { invalidRanges, ready, status, kind: selected };
   }
   if (selected === "hex-key") {

--- a/test/brain-wallet.test.mjs
+++ b/test/brain-wallet.test.mjs
@@ -85,15 +85,24 @@ test("brain-wallet lab rejects empty text and keeps private-key hashing separate
   const labHex = lab.hodlBrainLabEntropy(text).hex;
   const scalarHex = Buffer.from(helpers.hodlBrainWalletPrivateKey(text)).toString("hex");
   assert.equal(labHex, scalarHex);
-  assert.equal(app.includes('Ne === "brain-lab"'), true);
+  assert.match(app, /kind === "brain" && hodlBrainWalletOutput\(\) === "hd"/);
   assert.match(app, /function hodlBrainWalletPrivateKey\(/);
   assert.match(app, /function hodlBrainLabEntropy\(/);
 });
 
-test("brain-lab has no silent fingerprint or mnemonic preview path", () => {
-  assert.match(app, /hodlKeyModes = \["dice", "cards", "hex", "seed", "key", "brain-lab"\]/);
-  assert.match(app, /Brain wallet — lab/);
-  assert.match(loadSlice("hodlFingerprintMnemonic"), /if \(Ne === "brain-lab"\) return null;/);
+test("the brain-wallet HD output has no silent fingerprint or mnemonic preview path", () => {
+  // It lives under Private key > Brain wallet rather than in its own mode, so the
+  // two uses of the same digest are chosen explicitly instead of by tab.
+  assert.match(app, /hodlKeyModes = \["dice", "cards", "hex", "seed", "key"\]/);
+  assert.doesNotMatch(app, /"brain-lab" \? "Brain wallet/);
+  assert.doesNotMatch(app, /Brain wallet — lab/);
+  assert.doesNotMatch(app, /id="brain-lab-details"/);
+  assert.match(app, /id="brain-warning"/);
+  assert.match(app, /name="bo" value="scalar"/);
+  assert.match(app, /name="bo" value="hd"/);
+  // The private-key mode never previews a fingerprint or mnemonic, which now
+  // covers the HD brain output too.
+  assert.match(app, /if \(Ne === "key"\) \{\s*preview\.hidden = true;/);
   assert.match(app, /24 words appear only after Derive Wallet/);
   assert.match(app, /Acknowledge the lab warning before deriving/);
   assert.doesNotMatch(loadSlice("hodlBrainLabEntropy"), /localStorage/);

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -205,7 +205,7 @@
   await test("limited private-key prefixes replace the full keypad until selected", async () => {
     await chooseMode("Private key");
     const privateKey = await until(() => document.getElementById("key"), "private-key input");
-    const keyboard = document.querySelector("#passphrase-keyboard-host [data-on-screen-keyboard]");
+    const keyboard = document.getElementById("private-keyboard");
     const toggle = document.getElementById("private-keyboard-toggle");
     const initialRow = keyboard?.querySelector("[data-private-key-initial-row]");
     assert(keyboard && toggle && initialRow, "Private-key initial choices are missing");
@@ -926,7 +926,7 @@
 
     await chooseMode("Private key");
     toggle = await until(() => document.getElementById("private-keyboard-toggle"), "private-key keyboard toggle");
-    keyboard = document.querySelector("#passphrase-keyboard-host [data-on-screen-keyboard]");
+    keyboard = await until(() => document.getElementById("private-keyboard"), "private-key keyboard");
     const privateKey = document.getElementById("key");
     assert(toggle.getAttribute("aria-expanded") === "true" && !keyboard.hidden, "Private-key keyboard did not inherit the shared open state");
     assert(

--- a/test/global-sync.test.mjs
+++ b/test/global-sync.test.mjs
@@ -69,7 +69,7 @@ test("hashed methods publish one way without being overwritten", () => {
   const current = loadSlice("hodlGlobalSyncCurrentBits");
   assert.match(current, /hodlDiceEntropy\(value, ge, config\.words\)/);
   assert.match(current, /hodlCardsEntropy\(value, config\.words, hodlCardColemanSymbols\)/);
-  assert.match(current, /hodlBrainLabEntropy\(value\)/);
+  assert.match(current, /hodlBrainWalletPrivateKey\(value, hodlBrainWalletTrimEnabled\(\)\)/);
   const apply = loadSlice("hodlApplyGlobalSync");
   assert.doesNotMatch(apply, /fields\.dice\s*=/);
   assert.doesNotMatch(apply, /fields\.cards\s*=/);

--- a/test/private-key-inputs.test.mjs
+++ b/test/private-key-inputs.test.mjs
@@ -249,7 +249,7 @@ test("character entries skip whitespace and keep astral characters whole", () =>
 test("brain analysis reports the exact-text and trim conventions", () => {
   let analysis = hodlPrivateKeyInputAnalysis("", "brain", "mainnet", false);
   assert.equal(analysis.ready, false);
-  assert.match(analysis.status, /No recovery passphrase entered/);
+  assert.match(analysis.status, /No text entered/);
   analysis = hodlPrivateKeyInputAnalysis("correct horse battery staple", "brain", "mainnet", false);
   assert.equal(analysis.ready, true);
   assert.match(analysis.status, /exact text will be used/);

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -205,7 +205,7 @@ test("Seed phrase offers one-based or zero-based BIP39 word-number entry", () =>
   assert.match(appSource, /\[0, 1, 2, 3, 4, 5, 6, 7, 8, 9\]/);
   assert.match(appSource, /id="seed-number-words" class="dice-word-grid"/);
   assert.match(css, /\.dice-input-pad\.seed-number-pad \{ grid-template-columns: repeat\(5/);
-  assert.match(appSource, /passphrase = !privateKey/);
+  assert.match(appSource, /passphrase = !keyMode \|\| hdBrain/);
 });
 
 test("hashed cards can match Ian Coleman's suit-symbol SHA-256 transcript", () => {
@@ -391,11 +391,14 @@ test("seed phrase mode has a lowercase Jade-style on-screen keyboard", () => {
   assert.match(app, /hodlKeyboardMarkup\(!0,"private key","private-keyboard",!0\)/);
   assert.doesNotMatch(app, /hodlKeyboardMarkup\(!0\)/);
   assert.match(app, /function hodlRenderPassphraseKeyboard\(\)/);
-  assert.match(app, /privateKey=Ne==="key"&&!hodlBrainHdActive\(\),passphrase=!privateKey/);
+  assert.match(app, /keyMode=Ne==="key",hdBrain=hodlBrainHdActive\(\),privateKey=keyMode,passphrase=!keyMode\|\|hdBrain/);
   // Where the seed keyboard exists it already follows focus into the passphrase
   // box, so no second on-screen keyboard is rendered underneath it.
-  assert.match(app, /shared=passphrase&&!!document\.getElementById\("seed-keyboard"\),enabled=!shared/);
-  assert.match(app, /passphrase\?\(shared\?"":hodlPassphraseKeyboardToggleMarkup\(\)\)\+hodlPassphraseBip39ToggleMarkup\(\)/);
+  assert.match(app, /shared=passphrase&&!!document\.getElementById\("seed-keyboard"\),ownToggle=passphrase&&!shared&&!hdBrain,enabled=!shared/);
+  // Only one on-screen keyboard toggle per section: the seed keyboard and the
+  // private-key keyboard each already serve the passphrase field too.
+  assert.match(app, /ownToggle\?hodlPassphraseKeyboardToggleMarkup\(\):""/);
+  assert.match(app, /passphrase\?\(ownToggle\?hodlPassphraseKeyboardToggleMarkup\(\):""\)\+hodlPassphraseBip39ToggleMarkup\(\)/);
   assert.match(app, /hodlPassphraseKeyboardToggleMarkup\(\)/);
   assert.match(app, /function hodlPassphraseBip39ToggleMarkup\(checked=hodlPassphraseBip39Enabled\(\)\)/);
   assert.match(app, /function hodlAnalyzeBip39Passphrase\(value,activeCaret=null\)/);

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -391,7 +391,7 @@ test("seed phrase mode has a lowercase Jade-style on-screen keyboard", () => {
   assert.match(app, /hodlKeyboardMarkup\(!0,"private key","private-keyboard",!0\)/);
   assert.doesNotMatch(app, /hodlKeyboardMarkup\(!0\)/);
   assert.match(app, /function hodlRenderPassphraseKeyboard\(\)/);
-  assert.match(app, /privateKey=Ne==="key",passphrase=!privateKey/);
+  assert.match(app, /privateKey=Ne==="key"&&!hodlBrainHdActive\(\),passphrase=!privateKey/);
   // Where the seed keyboard exists it already follows focus into the passphrase
   // box, so no second on-screen keyboard is rendered underneath it.
   assert.match(app, /shared=passphrase&&!!document\.getElementById\("seed-keyboard"\),enabled=!shared/);


### PR DESCRIPTION
The brain-wallet lab was its own mode sitting beside a Brain wallet radio that already existed, so the same idea had two entry points. This folds it into one section under **Private key → Brain wallet**, with an explicit choice of what the SHA-256 digest becomes.

```
Brain wallet — Unsafe. SHA-256 of your text, as a single key pair or a 24-word seed.

Brain wallet output:
  (•) Single key pair              The digest is the private key. One address.
  ( ) HD wallet with seed phrase   The digest is 256-bit BIP39 entropy, 24 words.
```

### These are different wallets, so the choice is stated rather than implied

```
text:    "correct horse battery staple"
SHA-256: c4bbcb1f…d4e39a8a

as private key    -> bc1q08alc0e5ua69scxhvyma568nvguqccrv4cc9n4
as BIP39 entropy  -> bc1qsf8lfrr6fv9rg4yk5prvsxayfea2nfhgjznnvr   (fp 9f534563)
```

Previously which one you got depended on which place you happened to open. The scalar path keeps its original behaviour as the default.

### The HD output keeps the wallet controls it derives with

Worth calling out, because the first version of this branch got it wrong. Moving an HD derivation into `key` mode put it behind the single-key UI rules, which hide the passphrase, script type and derivation fields and pass a null derivation plan — while the derive still read the passphrase field. A passphrase left over from another mode therefore changed every derived address **silently**, with the 24 words identical either way, which makes a words-only backup unrecoverable. The standalone lab did not have this: it was its own mode, so those fields were visible and the passphrase was deliberate.

The HD output now shows the passphrase, script type and derivation fields and derives with the real plan, so paths are chosen rather than defaulted. A BIP39-word passphrase is validated there as in any other wallet mode. The fingerprint preview stays hidden, as it was in the lab, so nothing is previewed before Derive. The single key pair keeps hiding all of it, since a raw private key has no BIP39 passphrase or derivation path.

There is also a guard that refuses to derive when a passphrase is set while its field is hidden, so this cannot silently recur.

### Warning and acknowledgement

The warning applies to **both** outputs and is no longer collapsible — the `<details>` wrapper and the "Brain wallet — lab" summary are gone, and ticking "I understand" no longer hides it. The acknowledgement gates deriving **either** way, where the single key pair previously had no gate. Two bullets are specific to the seed phrase and appear only when that output is selected.

### Whitespace trimming

Offered for both outputs and applied to both, so the two paths differ in methodology only. It stays **off** by default, so the seed-phrase output still hashes the exact UTF-8 text as the lab always did. Its toggle also now refreshes the digest preview, which it did not do before.

```
"  correct horse battery staple  "
trim off -> db0f8b21…   (exact text)
trim on  -> c4bbcb1f…   (trimmed)
```

### One keyboard, laid out like the seed section

Adding the passphrase controls also added a second keyboard toggle beside the private-key one, with two keyboards stacked under it. The private-key keyboard now follows focus into the passphrase field, the way the seed keyboard already does for the seed box, so the section renders one keyboard and one toggle whichever output is selected, switching its key alphabet with the focused field and announcing which field it is typing into. It also renders directly under its own input rather than after the passphrase field, so both sections read input → status → keyboard → passphrase.

The passphrase field is resolved on demand and only while shown, so nothing changes for WIF, hex or mini keys.

### Global entropy sync

`#212`/`#214` landed while this was in progress and had wired `brain-lab` in as its own mode in four places. Each folds into the key-mode branch that already handles the brain wallet: it is a hashed source either way, `key:brain` covers the mode identity, the value comes from `#key`, and the bits come from the trim-aware digest. That last one is a small fix — the lab branch hashed the exact text and ignored the trim setting, so sync could disagree with what was actually derived.

### Also

Removes the parenthetical notes beside the **Autocomplete BIP39 words** toggles. The seed one claimed `2+ letters normally`, which reads as two letters usually being enough; two letters uniquely identifies 34 of the 2048 words, and one identifies none. BIP39 words are unique at four letters.

### Checks

`npm run test:ci` 754/761, `npm run verify` clean, 6/0 startup checks, no duplicate element ids.

Every derivation was compared against values computed independently with `@scure/bip39`, `@scure/bip32` and `@scure/btc-signer` outside the app:

| Path | Result |
| --- | --- |
| Brain scalar, trim off / on | `bc1qmdzcxel5d439xqql6mxsuc3e4xj0cmheq8svz9` / `bc1q08alc0e5ua69scxhvyma568nvguqccrv4cc9n4` |
| Brain HD, trim off / on | fp `0dc83092` / `9f534563` |
| Brain HD, passphrase set / cleared | fp `6f6d2ea1` / `9f534563` |
| Seed phrase (regression) | `bc1qgkju4yvvtuz0s8vqn837q396jezu2h8ex7gk98` |
| D++ 12-word (regression) | `bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu` |

The brain-wallet, global-sync and integration invariants were updated to the new structure rather than dropped: they still assert that nothing previews a fingerprint or mnemonic, that the acknowledgement gates deriving, that the brain text is a hashed sync source, and that nothing touches localStorage.

No change to the built artifact in this branch.
