### PR TITLE
Align card transcript display and hash on conventional notation

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -3712,12 +3712,12 @@ function hodlParseCards(raw, targetWords = Pt) {
   let firstCount = Math.min(cards.length, needed.first), extraCount = Math.max(0, cards.length - needed.first);
   let bits = hodlCardWithoutReplacementBits(firstCount);
   for (let i = 0; i < extraCount; i++) bits += Math.log2(52 - i);
-  return { cards, invalid, duplicates, entries, invalidEntries, duplicateEntries, bits, needed, hashInput: cards.join(" ") };
+  return { cards, invalid, duplicates, entries, invalidEntries, duplicateEntries, bits, needed, hashInput: hodlCardsHashInput(cards) };
 }
 function hodlCardsHashInput(cards, coleman = false) {
-  let transcript = (cards || []).join(" ");
+  let transcript = (cards || []).map((card) => card.slice(0, -1) + card.slice(-1).toLowerCase()).join(" ");
   if (!coleman) return transcript;
-  return transcript.replace(/C/g, "\u2663").replace(/D/g, "\u2666").replace(/H/g, "\u2665").replace(/S/g, "\u2660");
+  return transcript.replace(/c/g, "\u2663").replace(/d/g, "\u2666").replace(/h/g, "\u2665").replace(/s/g, "\u2660");
 }
 function hodlCardTokenCanContinue(token) {
   return /^(?:[A2-9TJQK]|1|10)$/i.test(String(token ?? ""));
@@ -3725,13 +3725,12 @@ function hodlCardTokenCanContinue(token) {
 function hodlFilterCards(value, coleman = false) {
   let text = String(value ?? "").toUpperCase().replace(/\u2660/g, "S").replace(/\u2665/g, "H").replace(/\u2666/g, "D").replace(/\u2663/g, "C");
   if (coleman) {
-    text = text.replace(/10([CDHS])/g, "10\0$1");
-    text = text.replace(/([A2-9TJQK])([CDHS])/g, (_, rank, suit) => rank + ({ C: "\u2663", D: "\u2666", H: "\u2665", S: "\u2660" })[suit]);
-    text = text.replace(/10\0([CDHS])/g, (_, suit) => "10" + ({ C: "\u2663", D: "\u2666", H: "\u2665", S: "\u2660" })[suit]);
+    text = text.replace(/10(?=[CDHS])/g, "T");
+    text = text.replace(/([A2-9TJQK])([CDHS])[\s,.;:_|/-]*/g, (_, rank, suit) => rank + ({ C: "\u2663", D: "\u2666", H: "\u2665", S: "\u2660" })[suit] + " ");
     return text.replace(/[^0-9A-Z\s,.;:_|/\-\u2660\u2663\u2665\u2666]/g, "").replace(/[\s,.;:_|/-]+/g, " ");
   }
-  text = text.replace(/[^0-9A-Z\s,.;:_|/-]/g, "").replace(/[\s,.;:_|/-]+/g, " ");
-  return text.replace(/(^| )(10|[A2-9TJQK])([CDHS])(?= |$)/g, (_, separator, rank, suit) => separator + rank + suit.toLowerCase());
+  text = text.replace(/[^0-9A-Z\s,.;:_|/-]/g, "").replace(/[\s,.;:_|/-]+/g, " ").replace(/10(?=[CDHS])/g, "T");
+  return text.replace(/([A2-9TJQK])([CDHS])[\s,.;:_|/-]*/g, (_, rank, suit) => rank + suit.toLowerCase() + " ");
 }
 function hodlCardTypedCharactersAllowed(value) {
   return [...String(value ?? "")].every((character) => /[A2-9TJQKCDHS10\s,.;:_|/\-\u2660\u2663\u2665\u2666]/i.test(character));
@@ -3763,7 +3762,7 @@ function hodlCardsEntropy(value, targetWords = Pt, coleman = false) {
   if (!parsed.cards.length) return { ok: false, error: "Deal at least one card from a shuffled deck.", notes, warnings, parsed };
   let required = parsed.needed.first + parsed.needed.extra, hashInput = hodlCardsHashInput(parsed.cards, coleman);
   notes.push(`${parsed.cards.length} card${parsed.cards.length === 1 ? "" : "s"} \u2248 ${parsed.bits.toFixed(1)} bits.`);
-  notes.push(coleman ? "SHA-256 hashes Ian Coleman's suit-symbol transcript (A\u2660 2\u2663 T\u2666), then the first " + config.bits + " bits become the selected " + config.words + "-word seed. One shuffled deck is about 225.6 bits." : "SHA-256 hashes the ASCII transcript (AS 2C TD), then the first " + config.bits + " bits become the selected " + config.words + "-word seed. One shuffled deck is about 225.6 bits.");
+  notes.push(coleman ? "SHA-256 hashes Ian Coleman's suit-symbol transcript (A\u2660 2\u2663 T\u2666), then the first " + config.bits + " bits become the selected " + config.words + "-word seed. One shuffled deck is about 225.6 bits." : "SHA-256 hashes the ASCII transcript (As 2c Td), then the first " + config.bits + " bits become the selected " + config.words + "-word seed. One shuffled deck is about 225.6 bits.");
   if (parsed.cards.length < required) warnings.push(`Only ${parsed.cards.length} of ${required} recommended cards were entered. The ${config.words}-word phrase is deterministic, but its security cannot exceed the approximately ${parsed.bits.toFixed(1)} bits supplied. Use only for testing until the recommendation is met.`);
   if (parsed.cards.length > required) notes.push(`All ${parsed.cards.length} cards, including extras, are included in the hash.`);
   let digest = Z(new TextEncoder().encode(hashInput)), bytes = digest.slice(0, config.bytes);
@@ -5579,7 +5578,7 @@ function hodlRenderKeyForm() {
     if (!direct) hodlCardSuit = hodlCardRank = "";
     let suitPad = hodlCardSuits.map((suit) => `<button type="button" class="card-suit${suit.red ? " is-red" : ""}" data-card-suit="${suit.code}" aria-label="${suit.label}" aria-pressed="false">${suit.symbol}</button>`).join("");
     let rankPad = direct ? hodlDirectCardRanks.map((rank) => `<button type="button" data-direct-card-rank="${rank}" aria-label="Enter rank ${rank}">${rank}</button>`).join("") : hodlCardRanks.map((rank) => `<button type="button" data-card-rank="${rank}" aria-label="${rank === "T" ? "10" : rank}">${rank === "T" ? "10" : rank}</button>`).join("");
-    let inputId = direct ? "direct-cards" : "cards", inputLabel = direct ? "Rank-only draw transcript" : "Card transcript", inputHelp = direct ? `For each of the first ${config.partialWords} words, shuffle and draw from A\u20138 three times, then A\u20134 once. Each four-character group selects one word; spaces separate the groups. The shorter final group supplies the remaining entropy bits, and EntropyLab calculates the BIP39 checksum bits.` : `Each valid card updates a deterministic test seed. For real security, ${config.words === 24 ? "deal all 52 unique cards, shuffle again, then deal 6 more" : `deal ${needed.first} unique cards without putting them back`}. SHA-256 hashes the canonical ASCII transcript (AS 2C TD).`, placeholder = direct ? "A284 37A2 \u2026" : hodlCardColemanSymbols ? "A\u2660 2\u2663 10\u2665 T\u2666\u2026" : "As 2c 10h Td\u2026";
+    let inputId = direct ? "direct-cards" : "cards", inputLabel = direct ? "Rank-only draw transcript" : "Card transcript", inputHelp = direct ? `For each of the first ${config.partialWords} words, shuffle and draw from A\u20138 three times, then A\u20134 once. Each four-character group selects one word; spaces separate the groups. The shorter final group supplies the remaining entropy bits, and EntropyLab calculates the BIP39 checksum bits.` : `Each valid card updates a deterministic test seed. For real security, ${config.words === 24 ? "deal all 52 unique cards, shuffle again, then deal 6 more" : `deal ${needed.first} unique cards without putting them back`}. SHA-256 hashes the ASCII transcript (As 2c Td).`, placeholder = direct ? "A284 37A2 \u2026" : hodlCardColemanSymbols ? "A\u2660 2\u2663 T\u2665 T\u2666\u2026" : "As 2c Th Td\u2026";
     at.innerHTML = `
       <p class="label">How to turn cards into a ${config.words}-word seed</p>
       <div class="choice-grid">
@@ -5603,6 +5602,7 @@ function hodlRenderKeyForm() {
     let input = document.getElementById(inputId);
     input.onbeforeinput = direct ? (event) => hodlHandleGroupedSeparatorDelete(input, event) : (event) => {
       if (event.inputType === "insertText" && event.data && !hodlCardTypedCharactersAllowed(event.data)) event.preventDefault();
+      else hodlHandleGroupedSeparatorDelete(input, event);
     };
     input.oninput = () => {
       if (!direct) hodlCardSuit = hodlCardRank = "";
@@ -5660,7 +5660,7 @@ function hodlRenderKeyForm() {
     if (colemanToggle) colemanToggle.onchange = () => {
       hodlCardColemanSymbols = colemanToggle.checked;
       input.value = hodlFilterCards(input.value, hodlCardColemanSymbols);
-      input.placeholder = hodlCardColemanSymbols ? "A\u2660 2\u2663 10\u2665 T\u2666\u2026" : "As 2c 10h Td\u2026";
+      input.placeholder = hodlCardColemanSymbols ? "A\u2660 2\u2663 T\u2665 T\u2666\u2026" : "As 2c Th Td\u2026";
       input.setSelectionRange(input.value.length, input.value.length);
       if (state) {
         state.cardColemanSymbols = hodlCardColemanSymbols;

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -407,7 +407,7 @@
     const emptyHistoryHeight = dealt.getBoundingClientRect().height;
     input(cards, "as");
     await wait(0);
-    equal(cards.value, "As");
+    equal(cards.value, "As ");
     assert(!document.getElementById("go").disabled, "One valid card did not enable derivation");
     assert(document.getElementById("cards-meta").textContent.includes("seed available for testing"), "One-card warning is missing");
     equal([...document.querySelectorAll("#dice-words [data-word]")].filter((word) => word.textContent !== "—").length, 24);
@@ -423,7 +423,7 @@
     assert(document.querySelector("#cards-highlight .dice-roll-invalid")?.textContent === "As", "Repeated card was not highlighted red");
     input(cards, "as, 10♥; td");
     await wait(0);
-    equal(cards.value, "As 10h Td");
+    equal(cards.value, "As Th Td ");
     assert(!document.getElementById("go").disabled, "Normalized valid cards did not enable derivation");
     cards.focus();
     const disallowed = new InputEvent("beforeinput", { bubbles: true, cancelable: true, inputType: "insertText", data: "B" });

--- a/test/cards.test.mjs
+++ b/test/cards.test.mjs
@@ -50,15 +50,16 @@ const hodlCardNeeded = new Function(
   "hodlCardWithoutReplacementBits",
   `${loadSlice("hodlCardNeeded")}; return hodlCardNeeded;`,
 )(hodlSeedConfig, hodlCardWithoutReplacementBits);
+const hodlCardsHashInput = new Function(`${loadSlice("hodlCardsHashInput")}; return hodlCardsHashInput;`)();
 const hodlParseCards = new Function(
   "hodlCardNeeded",
   "hodlNormalizeCardToken",
   "hodlCardWithoutReplacementBits",
+  "hodlCardsHashInput",
   `${loadSlice("hodlParseCards")}; return hodlParseCards;`,
-)(hodlCardNeeded, hodlNormalizeCardToken, hodlCardWithoutReplacementBits);
+)(hodlCardNeeded, hodlNormalizeCardToken, hodlCardWithoutReplacementBits, hodlCardsHashInput);
 const Z = (input) => new Uint8Array(createHash("sha256").update(input).digest());
 const M = { encode: (bytes) => Buffer.from(bytes).toString("hex") };
-const hodlCardsHashInput = new Function(`${loadSlice("hodlCardsHashInput")}; return hodlCardsHashInput;`)();
 const hodlCardsEntropy = new Function(
   "hodlSeedConfig",
   "hodlParseCards",
@@ -125,15 +126,18 @@ test("card tokens normalize 10 and suit glyphs to ASCII", () => {
 });
 
 test("card transcript input uses uppercase ranks and lowercase suits", () => {
-  assert.equal(hodlFilterCards("4h"), "4h");
-  assert.equal(hodlFilterCards("js"), "Js");
-  assert.equal(hodlFilterCards("td"), "Td");
-  assert.equal(hodlFilterCards("4H"), "4h");
-  assert.equal(hodlFilterCards("as, 10♥;td"), "As 10h Td");
+  assert.equal(hodlFilterCards("4h"), "4h ");
+  assert.equal(hodlFilterCards("js"), "Js ");
+  assert.equal(hodlFilterCards("td"), "Td ");
+  assert.equal(hodlFilterCards("4H"), "4h ");
+  assert.equal(hodlFilterCards("10h"), "Th ");
+  assert.equal(hodlFilterCards("as2ctd"), "As 2c Td ");
+  assert.equal(hodlFilterCards("as, 10♥;td"), "As Th Td ");
   assert.equal(hodlFilterCards("as <img>"), "As IMG");
-  assert.equal(hodlFilterCards("AS 2C TD", true), "A♠ 2♣ T♦");
-  assert.equal(hodlFilterCards("A♠ 2♣ T♦", false), "As 2c Td");
-  assert.equal(hodlFilterCards("AS 10H", true), "A♠ 10♥");
+  assert.equal(hodlFilterCards("AS 2C TD", true), "A♠ 2♣ T♦ ");
+  assert.equal(hodlFilterCards("A♠ 2♣ T♦", false), "As 2c Td ");
+  assert.equal(hodlFilterCards("AS 10H", true), "A♠ T♥ ");
+  assert.equal(hodlFilterCards("as2c td"), hodlFilterCards(hodlFilterCards("as2c td")));
   assert.equal(hodlCardTypedCharactersAllowed("aS 10♥, TD"), true);
   assert.equal(hodlCardTypedCharactersAllowed("B"), false);
 });
@@ -176,15 +180,18 @@ test("24-word extra cards may repeat the first shuffle", () => {
   assert.ok(parsed.bits >= 256);
 });
 
-test("hashed transcript is SHA-256 of canonical ASCII codes", () => {
-  const transcript = "AS 2C TD";
-  const displayedTranscript = "As 2c Td";
+test("hashed transcript is SHA-256 of the displayed ASCII codes", () => {
+  const transcript = "As 2c Td";
   const digest = createHash("sha256").update(transcript, "utf8").digest("hex");
   assert.match(app, /Z\(new TextEncoder\(\)\.encode\(hashInput\)\)/);
-  assert.equal(hodlParseCards(transcript, 12).hashInput, transcript);
-  assert.equal(hodlParseCards(displayedTranscript, 12).hashInput, transcript);
+  assert.equal(hodlParseCards("AS 2C TD", 12).hashInput, transcript);
+  assert.equal(hodlParseCards("as 2c td", 12).hashInput, transcript);
+  assert.equal(hodlFilterCards("as 2c td"), "As 2c Td ");
+  assert.equal(hodlFilterCards("AS 10H TD"), "As Th Td ");
+  assert.equal(hodlParseCards(hodlFilterCards("as2ctd"), 12).hashInput, transcript);
   assert.equal(hodlCardsHashInput(["AS", "2C", "TD"], false), transcript);
-  assert.equal(hodlCardsEntropy(displayedTranscript, 12).hex, hodlCardsEntropy(transcript, 12).hex);
+  assert.equal(hodlCardsEntropy("AS 2C TD", 12).hex, digest.slice(0, 32));
+  assert.equal(hodlCardsEntropy("as 2c td", 12).hex, digest.slice(0, 32));
   assert.equal(digest.length, 64);
 });
 
@@ -234,7 +241,8 @@ test("a complete card transcript keeps deriving the expected deterministic seed"
   assert.equal(entropy.ok, true);
   assert.equal(entropy.warnings.length, 0);
   assert.equal(entropy.bytes.length, 32);
-  const expected = createHash("sha256").update(transcript, "utf8").digest();
+  const canonical = transcript.split(" ").map((card) => card.slice(0, -1) + card.slice(-1).toLowerCase()).join(" ");
+  const expected = createHash("sha256").update(canonical, "utf8").digest();
   assert.deepEqual([...entropy.bytes], [...expected.subarray(0, 32)]);
   const mnemonic = entropyToMnemonic(entropy.bytes, bip39English);
   assert.equal(mnemonic.split(" ").length, 24);

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -212,10 +212,10 @@ test("hashed cards can match Ian Coleman's suit-symbol SHA-256 transcript", () =
   assert.match(appSource, /id="cards-ian-coleman"/);
   assert.match(appSource, /Match Ian Coleman method/);
   assert.match(appSource, /show and hash A\\u2660 2\\u2663 instead of As 2c/);
-  assert.match(appSource, /placeholder = direct \? "A284 37A2 \\u2026" : hodlCardColemanSymbols \? "A\\u2660 2\\u2663 10\\u2665 T\\u2666\\u2026" : "As 2c 10h Td\\u2026"/);
+  assert.match(appSource, /placeholder = direct \? "A284 37A2 \\u2026" : hodlCardColemanSymbols \? "A\\u2660 2\\u2663 T\\u2665 T\\u2666\\u2026" : "As 2c Th Td\\u2026"/);
   assert.match(appSource, /autocapitalize="off" aria-labelledby="cards-input-label"/);
   assert.match(appSource, /function hodlCardsHashInput\(cards, coleman = false\)/);
-  assert.match(appSource, /transcript\.replace\(\/C\/g, "\\u2663"\)\.replace\(\/D\/g, "\\u2666"\)\.replace\(\/H\/g, "\\u2665"\)\.replace\(\/S\/g, "\\u2660"\)/);
+  assert.match(appSource, /transcript\.replace\(\/c\/g, "\\u2663"\)\.replace\(\/d\/g, "\\u2666"\)\.replace\(\/h\/g, "\\u2665"\)\.replace\(\/s\/g, "\\u2660"\)/);
   assert.match(appSource, /hodlFilterCards\(value, hodlCardColemanSymbols\)/);
   assert.match(appSource, /input\.value = hodlFilterCards\(input\.value, hodlCardColemanSymbols\)/);
 });
@@ -282,6 +282,7 @@ test("Cards offers isolated hashed and direct word-selection methods", () => {
   assert.match(appSource, /Each four-character group selects one word; spaces separate the groups/);
   assert.match(appSource, /placeholder = direct \? "A284 37A2/);
   assert.match(appSource, /input\.onbeforeinput = direct \? \(event\) => hodlHandleGroupedSeparatorDelete/);
+  assert.match(appSource, /else hodlHandleGroupedSeparatorDelete\(input, event\);/);
   assert.match(appSource, /<aside class="cards-reshuffle" id="cards-reshuffle" hidden><\/aside>\s*<div class="dealt-cards" id="dealt-cards"/);
   assert.match(appSource, /Shuffle \$\{hodlDirectCardSetLabel\(parsed\.expectedMax\)\} \(any suit\) before the \$\{parsed\.entries\.length \? "next" : "first"\} draw\./);
   assert.doesNotMatch(appSource, /Shuffle before the next draw\./);


### PR DESCRIPTION
## Summary

PR #142 displayed card transcripts in conventional notation (`As 2c Td`) but still SHA-256 hashed the old all-caps string (`AS 2C TD`) — the field showed one transcript while the seed came from another. This makes the displayed string the hashed string:

- **Canonical transcript:** uppercase rank (`T` for 10), lowercase suit, single spaces — `As 2c Th Td` — and SHA-256 hashes exactly what the box shows.
- **Live formatting while typing:** ranks capitalize and suits lowercase as soon as a valid pair completes; a completed card inserts its own space (pasted/concatenated streams like `as2c10htd` become `As 2c Th Td `); `10` before a suit becomes `T`, which also closes the older `10H`-displayed vs `TH`-hashed gap. Pending ranks and invalid tokens are left untouched so highlighting can flag them.
- **Backspace** over an auto-inserted space deletes the whole last card, reusing the separator-delete handler the direct-cards input already had.
- **Coleman mode:** same auto-spacing, and verified byte-identical to iancoleman.io's clean string (`A♠ 2♣ T♦`) — the exact string his tool SHA-256s for 12/24-word mnemonics (`src/js/entropy.js`: `events.join(" ").toUpperCase()` with suit symbols; `index.js`: `sjcl.hash.sha256.hash(entropy.cleanStr)` truncated to the entropy length). That method's derivation is unchanged.

## ⚠️ Breaking change

Default hashed-cards transcripts recorded **before PR #142** hashed as `AS 2C TD` and now derive from `As 2c Td` — old default-method card seeds do not reproduce. Coleman-mode seeds are unaffected.

## Tests

- `test/cards.test.mjs`: display==hash assertions (incl. tens and concatenated streams), filter idempotency, hash pinned to `sha256("As 2c Td")`, Coleman transcript pinned to his clean string; harness now injects `hodlCardsHashInput` into the `hodlParseCards` slice.
- `test/browser-suite.html`: updated live-typing expectations (`As `, `As Th Td `).
- `test/ui-defaults.test.mjs`: placeholder/notation assertions, separator-delete wiring.

## Commands run

- `npm run build` ✓
- `npm test` — 764/764 passed, 1 skipped (Firefox suite self-skips when Firefox is absent) ✓
- Keystroke-by-keystroke simulation of `as2c10htd` → `As 2c Th Td `, Coleman `as2c10h` → `A♠ 2♣ T♥ `, filter idempotency, and external `sha256` digest equality ✓

Closes #122