### PR TITLE
Replace the tool dropdown with a tab strip

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -854,45 +854,74 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .hint.bad { color: var(--danger); }
 .hint.ok { color: var(--ok); }
 .hint:empty, .err:empty { display: none; }
-/* The workspace switcher is a videogame-style settings menu at every width:
-   a hamburger bar above the tool that drops the menu down over it. The
-   pitch-to-tool seam lands on it, as it did on the tab strip before. */
-.workspace { position: relative; margin: var(--space-lede) 0 4px; }
-.workspace-menu-toggle {
-  display: flex; align-items: center; gap: 10px; width: 100%; min-height: 44px;
-  padding: 0 14px; border: 1px solid var(--border); border-radius: 12px;
-  background: var(--surface); color: var(--fg); font-weight: 600; text-align: left;
+/* The tool switcher keeps every tool on screen, in the same folder-tab shape
+   the Keys section uses for its dynamic key tabs. It scrolls rather than
+   collapsing, so a sixth tool widens the row instead of disappearing behind a
+   control the user has to know to open. The strip sits on its own rule rather
+   than merging into the panel below, because for two of the tools what
+   follows is a manager with its own tab strip. */
+.workspace { position: relative; margin: var(--space-lede) 0 0; }
+/* Sits in the seam above the strip's right edge, where it reads as a label on
+   the tabs rather than another control. Uppercase and accent-coloured like the
+   page's other small labels; it never takes a click, the strip does. */
+.workspace-more {
+  position: absolute; right: 0; bottom: 100%; z-index: 4;
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 4px 2px 6px; border: 0; background: none; cursor: pointer;
+  font-size: 11px; font-weight: 700; line-height: 1; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--accent);
 }
-.workspace-menu-toggle:hover { border-color: var(--faint); }
-.workspace-menu-toggle:focus-visible { outline: 2px solid var(--selection-accent); outline-offset: 2px; }
-.workspace-menu-toggle svg { flex: 0 0 auto; }
-.workspace-menu-current {
-  flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+.workspace-more[hidden] { display: none; }
+.workspace-more:hover { color: var(--fg); }
+.workspace-more:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 4px; }
+.workspace-tabs {
+  display: flex; align-items: flex-end; gap: 0; min-width: 0; height: 50px;
+  position: relative; z-index: 2; margin-bottom: -1px;
+  overflow-x: auto; overflow-y: hidden; overscroll-behavior-inline: contain;
+  scrollbar-width: none; -ms-overflow-style: none; -webkit-overflow-scrolling: touch; cursor: grab;
 }
-.workspace-menu-chevron { color: var(--accent); transition: transform 120ms ease; }
-.workspace.is-open .workspace-menu-chevron { transform: rotate(180deg); }
-@media (prefers-reduced-motion: reduce) { .workspace-menu-chevron { transition: none; } }
-/* The menu is a dropdown panel under the toggle, closed until it is asked
-   for. */
-.workspace-menu {
-  position: absolute; top: calc(100% + 6px); left: 0; right: 0; z-index: 60;
-  display: none; gap: 4px; padding: 8px;
-  border: 1px solid var(--border); border-radius: 14px; background: var(--surface);
-  box-shadow: 0 16px 36px rgb(0 0 0 / 55%);
+.workspace-tabs::-webkit-scrollbar { display: none; width: 0; height: 0; }
+.workspace-tabs.dragging, .workspace-tabs.dragging .workspace-tab { cursor: grabbing; user-select: none; }
+.workspace-tab {
+  position: relative; display: inline-flex; align-items: center; flex: 0 0 auto;
+  width: max-content; min-height: 44px; padding: 0 16px; white-space: nowrap;
+  border: 1px solid transparent; border-radius: 10px 10px 0 0; background: transparent;
+  color: var(--muted); font-weight: 600;
 }
-.workspace.is-open .workspace-menu { display: grid; }
-.workspace-menu .tab {
-  display: flex; align-items: center; margin: 0; border: 1px solid transparent;
-  border-radius: 10px; background: transparent; color: var(--muted);
-  text-align: left; white-space: nowrap;
+.workspace-tab:not(.active):hover { background: color-mix(in oklab, var(--surface-2) 60%, transparent); color: var(--fg); }
+/* Hairlines between neighbours, dropped beside the active tab and at the end,
+   exactly as the key tabs do it. */
+.workspace-tab:not(.active)::after {
+  content: ""; position: absolute; top: 12px; right: -1px; width: 1px; height: 20px; background: var(--border);
 }
-.workspace-menu .tab:not(.active):hover { background: color-mix(in oklab, var(--surface-2) 70%, transparent); color: var(--fg); }
-.workspace-menu .tab:is(.active, [aria-pressed="true"]) {
-  background: var(--selection-accent); border-color: var(--selection-accent); color: var(--selection-fg); font-weight: 600;
+.workspace-tab:last-child::after, .workspace-tab:has(+ .workspace-tab.active)::after { display: none; }
+/* The chosen tool takes the panel's own ground and paints its bottom border in
+   that same colour, cutting the strip's rule so the tab and the panel below it
+   are one continuous enclosure rather than a chip resting on a line. */
+.workspace-tab.active {
+  background: var(--bg); color: var(--fg); border-color: var(--border); border-bottom-color: var(--bg);
 }
-.workspace-menu .tab:focus-visible {
-  outline: 2px solid color-mix(in oklab, var(--selection-accent) 72%, var(--fg)); outline-offset: 2px;
+.workspace-tab:focus-visible { outline: 2px solid var(--accent); outline-offset: -3px; }
+/* Full names by default; the short forms wait for the narrow breakpoint, the
+   same width at which the header drops its control labels. */
+.workspace-tab-short { display: none; }
+/* The panel completes the folder: the strip's rule is its top edge, so the
+   chosen tab and the tool below it read as one enclosure. Transparent, so the
+   cards inside keep the surface-on-ground contrast they have everywhere else
+   and the key tabs still merge into their own card. */
+.workspace-panel {
+  position: relative; z-index: 1;
+  border: 1px solid var(--border); border-radius: 0 0 20px 20px;
+  padding: 20px 16px;
 }
+/* The tool's context sits on the panel's own ground above the card, so the
+   grey surface starts at the controls rather than at the explanation. */
+.tool-intro { margin: 0 0 24px; }
+.tool-intro[hidden] { display: none; }
+.tool-intro h2 { margin: 5px 0 8px; }
+.tool-intro > .muted { max-width: 760px; margin: 0; }
+.workspace-panel > :first-child { margin-top: 0; }
+.workspace-panel > :last-child { margin-bottom: 0; }
 .segmented-control {
   display: flex; align-items: stretch; flex-wrap: wrap; gap: 0; max-width: 100%; isolation: isolate;
 }
@@ -1525,6 +1554,10 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 @media (max-width: 719px) {
   :root { --site-header-pad: 12px; }
   .control-label { display: none; }
+  /* Short tool names here: the strip is the page's only horizontal scroll, so
+     fitting more of it on screen matters more than the fuller wording. */
+  .workspace-tab-full { display: none; }
+  .workspace-tab-short { display: inline; }
   /* Icon-only: square them off against the 40px theme toggle. */
   .download-controls .btn:is(.download-html, .github-repo-link) { flex: 0 0 40px; width: 40px; padding: 0; justify-content: center; }
   /* The wordmark gives back the width the icon-only buttons still need. */

--- a/src/index.html
+++ b/src/index.html
@@ -43,16 +43,18 @@
         <li>Keep your private keys offline.</li>
       </ul>
     </section>
-    <nav class="workspace no-print" id="workspace"><button type="button" class="workspace-menu-toggle" id="workspace-menu-toggle" aria-expanded="false" aria-controls="workspace-menu"><svg class="workspace-menu-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true" focusable="false"><path d="M4 7h16M4 12h16M4 17h16"/></svg><span class="workspace-menu-current" id="workspace-menu-current">Key Derivation</span><svg class="workspace-menu-chevron" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="m6 9 6 6 6-6"/></svg></button><div class="workspace-menu" id="workspace-menu" role="group" aria-label="Workspace"><button class="tab active" aria-pressed="true">Key Derivation</button><button class="tab" aria-pressed="false">BIP-85</button><button class="tab" aria-pressed="false">Multi Signature</button><button class="tab" aria-pressed="false">Silent Payments</button><button class="tab" aria-pressed="false">PSBT / Nonce</button></div></nav>
-    <section class="key-manager no-print" id="key-manager">
-      <div class="key-manager-head"><h2>Keys</h2></div>
-      <div class="key-tab-strip"><div class="key-tabs" id="key-tabs" role="tablist" aria-label="Keys"></div><div class="add-item-control"><button class="add-key" id="add-key" type="button" aria-label="Add key" aria-describedby="add-key-tooltip">+</button><span class="add-item-tooltip" id="add-key-tooltip" role="tooltip">Add another key</span></div></div>
+    <nav class="workspace no-print" id="workspace"><button type="button" class="workspace-more" id="workspace-more" aria-controls="workspace-tabs" aria-label="Scroll the tool list to see more tools" hidden>More tools<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M5 12h13M13 6l6 6-6 6"/></svg></button><div class="workspace-tabs" id="workspace-tabs" role="tablist" aria-label="Tool"><button type="button" class="workspace-tab active" role="tab" aria-selected="true" aria-label="Key Derivation"><span class="workspace-tab-full">Key Derivation</span><span class="workspace-tab-short">Keys</span></button><button type="button" class="workspace-tab" role="tab" aria-selected="false" aria-label="BIP-85"><span class="workspace-tab-full">BIP-85</span><span class="workspace-tab-short">BIP85</span></button><button type="button" class="workspace-tab" role="tab" aria-selected="false" aria-label="Multi Signature"><span class="workspace-tab-full">Multi Signature</span><span class="workspace-tab-short">MultiSig</span></button><button type="button" class="workspace-tab" role="tab" aria-selected="false" aria-label="Silent Payments"><span class="workspace-tab-full">Silent Payments</span><span class="workspace-tab-short">SP</span></button><button type="button" class="workspace-tab" role="tab" aria-selected="false" aria-label="PSBT / Nonce"><span class="workspace-tab-full">PSBT / Nonce</span><span class="workspace-tab-short">PSBT</span></button><button type="button" class="workspace-tab" role="tab" aria-selected="false" aria-label="PSBT Editor"><span class="workspace-tab-full">PSBT Editor</span><span class="workspace-tab-short">Editor</span></button></div></nav>
+    <div class="workspace-panel" id="workspace-panel">
+      <div class="tool-intro" id="calc-tool-intro">
+        <div class="kicker">Your entropy enters the lab</div>
+        <h2>Create. Derive. Verify.</h2>
+        <p class="muted calc-intro">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+      </div>
+      <section class="key-manager no-print" id="key-manager">
+      <div class="key-tab-strip"><div class="key-tabs" id="key-tabs" role="tablist" aria-label="Keys"></div><div class="add-item-control"><button class="add-key" id="add-key" type="button" aria-label="Add key" aria-describedby="add-key-tooltip">+</button><span class="add-item-tooltip" id="add-key-tooltip" role="tooltip">Add another key</span></div><div class="add-item-control"><button class="add-key remove-key" id="delete-key" type="button" aria-label="Delete current key" aria-describedby="delete-key-tooltip" disabled>−</button><span class="add-item-tooltip" id="delete-key-tooltip" role="tooltip">Delete this key</span></div></div>
     </section>
     <section class="card no-print" id="calc-card" role="tabpanel" hidden>
-      <div class="key-panel-head">
-        <div class="row segmented-control" id="modes"><button class="tab active" aria-pressed="true">Dice rolls</button><button class="tab" aria-pressed="false">Cards</button><button class="tab" aria-pressed="false">Number bases</button><button class="tab" aria-pressed="false">Seed phrase</button><button class="tab" aria-pressed="false">Private key</button><button class="tab" aria-pressed="false">Brain wallet — lab</button></div>
-        <button class="btn delete-key" id="delete-key" type="button" aria-label="Delete current key" disabled>Delete Key</button>
-      </div>
+      <div class="row segmented-control" id="modes"><button class="tab active" aria-pressed="true">Dice rolls</button><button class="tab" aria-pressed="false">Cards</button><button class="tab" aria-pressed="false">Number bases</button><button class="tab" aria-pressed="false">Seed phrase</button><button class="tab" aria-pressed="false">Private key</button><button class="tab" aria-pressed="false">Brain wallet — lab</button></div>
       <section class="seed-length-control" id="seed-length" aria-labelledby="seed-length-label">
         <p class="label" id="seed-length-label">Seed phrase length</p>
         <div class="row seed-length-options segmented-control" role="group" aria-label="Seed phrase length">
@@ -179,10 +181,12 @@ words, pick one of the checksum words.</span></span>
       </div>
       <p class="err" id="error"></p>
     </section>
-    <section class="card no-print" id="bip85-card" role="tabpanel" hidden>
-      <div class="kicker">One seed. Many children.</div>
-      <h2>Derive BIP-85 child entropy</h2>
-      <p class="muted bip85-intro">Deterministic child seeds, keys, and passwords from the active key's BIP32 root. Same parent, application, and index always reproduce the same child. This does not invent entropy — it is a calculator. English BIP-39 children match COLDCARD.</p>
+    <div class="tool-intro" id="bip85-tool-intro" hidden>
+        <div class="kicker">One seed. Many children.</div>
+        <h2>Derive BIP-85 child entropy</h2>
+        <p class="muted bip85-intro">Deterministic child seeds, keys, and passwords from the active key's BIP32 root. Same parent, application, and index always reproduce the same child. This does not invent entropy — it is a calculator. English BIP-39 children match COLDCARD.</p>
+      </div>
+      <section class="card no-print" id="bip85-card" role="tabpanel" hidden>
       <label class="field">Optional root xprv (leave blank to use the active key)
         <textarea id="bip85-key" placeholder="xprv… or leave blank to use the active key" spellcheck="false" autocomplete="off" autocapitalize="off"></textarea>
       </label>
@@ -233,16 +237,15 @@ words, pick one of the checksum words.</span></span>
       <div id="bip85-out" aria-live="polite"></div>
       <p class="muted">Derived children remain in this page only. Anyone with the parent seed, passphrase, application, and index can reproduce them. Memory clearing is best-effort; close the page before reconnecting the computer.</p>
     </section>
-    <section class="key-manager no-print" id="msig-manager" hidden="">
-      <div class="key-manager-head"><h2>Multisigs</h2></div>
-      <div class="key-tab-strip"><div class="key-tabs" id="msig-tabs" role="tablist" aria-label="Multisigs"></div><div class="add-item-control"><button class="add-key" id="add-msig" type="button" aria-label="Add multisig" aria-describedby="add-msig-tooltip">+</button><span class="add-item-tooltip" id="add-msig-tooltip" role="tooltip">Add another multisig</span></div></div>
+      <div class="tool-intro" id="msig-tool-intro" hidden>
+        <div class="kicker">Multiple keys, one wallet</div>
+        <h2>Derive a multisig wallet</h2>
+        <p class="muted msig-intro">Combine extended public keys into a multisignature wallet. Paste each key origin and extended public key as exported by its signer: <span class="mono">[fingerprint/48h/0h/0h/2h]xpub…</span>. Private keys are not needed. The derived addresses can receive bitcoin, and spending requires the configured number of signatures.</p>
+      </div>
+      <section class="key-manager no-print" id="msig-manager" hidden="">
+      <div class="key-tab-strip"><div class="key-tabs" id="msig-tabs" role="tablist" aria-label="Multisigs"></div><div class="add-item-control"><button class="add-key" id="add-msig" type="button" aria-label="Add multisig" aria-describedby="add-msig-tooltip">+</button><span class="add-item-tooltip" id="add-msig-tooltip" role="tooltip">Add another multisig</span></div><div class="add-item-control"><button class="add-key remove-key" id="delete-msig" type="button" aria-label="Delete current multisig" aria-describedby="delete-msig-tooltip" disabled>−</button><span class="add-item-tooltip" id="delete-msig-tooltip" role="tooltip">Delete this multisig</span></div></div>
     </section>
     <section class="card no-print" id="msig-card" role="tabpanel" hidden="">
-      <div class="key-panel-head">
-        <div><div class="kicker">Multiple keys, one wallet</div><h2>Derive a multisig wallet</h2></div>
-        <button class="btn delete-key" id="delete-msig" type="button" aria-label="Delete current multisig" disabled>Delete Multisig</button>
-      </div>
-      <p class="muted msig-intro">Combine extended public keys into a multisignature wallet. Paste each key origin and extended public key as exported by its signer: <span class="mono">[fingerprint/48h/0h/0h/2h]xpub…</span>. Private keys are not needed. The derived addresses can receive bitcoin, and spending requires the configured number of signatures.</p>
       <div class="msig-threshold-labels">
         <label for="msig-m-number"><span>Signatures needed to spend (m)</span><input class="msig-threshold-number" id="msig-m-number" type="number" min="1" max="15" step="1" value="2" inputmode="numeric" aria-describedby="msig-threshold-help"></label>
         <label for="msig-n-number"><span>Total signing keys (n)</span><input class="msig-threshold-number" id="msig-n-number" type="number" min="1" max="15" step="1" value="3" inputmode="numeric" aria-describedby="msig-threshold-help"></label>
@@ -328,10 +331,12 @@ words, pick one of the checksum words.</span></span>
       </div>
       <p class="err" id="msig-error"></p>
     </section>
-    <section class="card no-print" id="sp-card" role="tabpanel" hidden>
-      <div class="kicker">BIP-352 · reusable address, unique outputs</div>
-      <h2>Silent Payments</h2>
-      <p class="muted psbt-intro">A calculator, not a chain scanner. Derive a reusable <code>sp1q…</code> address from your seed, compute the unique taproot output a sender must pay, or check pasted outputs against your scan key. Nothing here talks to the network.</p>
+    <div class="tool-intro" id="sp-tool-intro" hidden>
+        <div class="kicker">BIP-352 · reusable address, unique outputs</div>
+        <h2>Silent Payments</h2>
+        <p class="muted psbt-intro">A calculator, not a chain scanner. Derive a reusable <code>sp1q…</code> address from your seed, compute the unique taproot output a sender must pay, or check pasted outputs against your scan key. Nothing here talks to the network.</p>
+      </div>
+      <section class="card no-print" id="sp-card" role="tabpanel" hidden>
       <div class="row no-print segmented-control" id="sp-modes">
         <button class="tab active" type="button" data-sp-mode="receive" aria-pressed="true">Receive</button>
         <button class="tab" type="button" data-sp-mode="send" aria-pressed="false">Send</button>
@@ -398,10 +403,12 @@ words, pick one of the checksum words.</span></span>
       <div id="sp-out" aria-live="polite"></div>
       <p class="muted">Session keys remain in this page only and are never intentionally stored or sent. Memory clearing is best-effort because browsers may retain internal copies; close the page before reconnecting the computer.</p>
     </section>
-    <section class="card no-print" id="psbt-card" role="tabpanel" hidden>
-      <div class="kicker">Inspect first. Sign elsewhere.</div>
-      <h2>Read a PSBT or a signed transaction.</h2>
-      <p class="muted psbt-intro">Inspecting a PSBT v0 or a raw Bitcoin transaction does not require a private key. EntropyLab can show outputs, PSBT-provided input amounts and fees, signatures, and repeated ECDSA nonce values. Optional Jade anti-exfil transcripts (host nonce ρ and signer opening R) are checked without a key. Every input's declared sighash policy and each signature's appended sighash byte are also decoded without a key; anything other than exact SIGHASH_ALL is a blocking warning. Finalized taproot witnesses and tap-leaf scripts are scanned for inscription envelopes (OP_FALSE OP_IF "ord"); this does not number sats or fetch content from the chain. Loading a matching key additionally labels which outputs belong to this wallet (change vs receive vs not yours) and checks whether supported signatures match plain RFC 6979 or Bitcoin Core-style low-r grinding; a mismatch alone is not evidence of a compromised signer.</p>
+    <div class="tool-intro" id="psbt-tool-intro" hidden>
+        <div class="kicker">Inspect first. Sign elsewhere.</div>
+        <h2>Read a PSBT or a signed transaction.</h2>
+        <p class="muted psbt-intro">Inspecting a PSBT v0 or a raw Bitcoin transaction does not require a private key. EntropyLab can show outputs, PSBT-provided input amounts and fees, signatures, and repeated ECDSA nonce values. Optional Jade anti-exfil transcripts (host nonce ρ and signer opening R) are checked without a key. Every input's declared sighash policy and each signature's appended sighash byte are also decoded without a key; anything other than exact SIGHASH_ALL is a blocking warning. Finalized taproot witnesses and tap-leaf scripts are scanned for inscription envelopes (OP_FALSE OP_IF "ord"); this does not number sats or fetch content from the chain. Loading a matching key additionally labels which outputs belong to this wallet (change vs receive vs not yours) and checks whether supported signatures match plain RFC 6979 or Bitcoin Core-style low-r grinding; a mismatch alone is not evidence of a compromised signer.</p>
+      </div>
+      <section class="card no-print" id="psbt-card" role="tabpanel" hidden>
       <label class="field">PSBT v0 or raw transaction (base64 or hex)
         <textarea id="psbt-text" placeholder="cHNidP8B… or 020000000001…" spellcheck="false" autocomplete="off" autocapitalize="off"></textarea>
       </label>
@@ -432,10 +439,12 @@ words, pick one of the checksum words.</span></span>
       <div id="psbt-out" aria-live="polite"></div>
       <p class="muted">Session keys remain in this page only and are never intentionally stored or sent. Memory clearing is best-effort because browsers may retain internal copies; close the page before reconnecting the computer.</p>
     </section>
-    <section class="card no-print" id="psbted-card" role="tabpanel" hidden>
-      <div class="kicker">Full-fidelity editor. Sign elsewhere.</div>
-      <h2>Edit a PSBT, field by field.</h2>
-      <p class="muted psbt-intro">A BIP-174 editor in the spirit of bip174.org, backed by rust-bitcoin compiled to WebAssembly. A transaction-flow diagram in the manner of mempool.space leads: one box per input and output with its claimed amount, address or script template, and signing status. Activating a box opens that key-value map in a panel under the diagram, output amounts edit directly in their boxes, and every key-value pair of the global, per-input and per-output maps is shown with a typed decode (BIP-174 and BIP-371 taproot fields) and stays editable as raw hex; the unsigned transaction's version, locktime, input prevouts/sequences and output amounts/scripts get structured fields. Adding or removing a pair re-validates the file immediately; Re-serialize validates the pending field edits and produces the new PSBT. PSBT v0 only; unknown and proprietary pairs round-trip untouched. Editing never signs anything.</p>
+    <div class="tool-intro" id="psbted-tool-intro" hidden>
+        <div class="kicker">Full-fidelity editor. Sign elsewhere.</div>
+        <h2>Edit a PSBT, field by field.</h2>
+        <p class="muted psbt-intro">A BIP-174 editor in the spirit of bip174.org, backed by rust-bitcoin compiled to WebAssembly. A transaction-flow diagram in the manner of mempool.space leads: one box per input and output with its claimed amount, address or script template, and signing status. Activating a box opens that key-value map in a panel under the diagram, output amounts edit directly in their boxes, and every key-value pair of the global, per-input and per-output maps is shown with a typed decode (BIP-174 and BIP-371 taproot fields) and stays editable as raw hex; the unsigned transaction's version, locktime, input prevouts/sequences and output amounts/scripts get structured fields. Adding or removing a pair re-validates the file immediately; Re-serialize validates the pending field edits and produces the new PSBT. PSBT v0 only; unknown and proprietary pairs round-trip untouched. Editing never signs anything.</p>
+      </div>
+      <section class="card no-print" id="psbted-card" role="tabpanel" hidden>
       <label class="field">PSBT v0 (base64 or hex)
         <textarea id="psbted-text" placeholder="cHNidP8B..." spellcheck="false" autocomplete="off" autocapitalize="off"></textarea>
       </label>
@@ -451,6 +460,7 @@ words, pick one of the checksum words.</span></span>
       <p class="muted">Fees and input amounts shown here are unverified PSBT claims; the editor does not check them against previous transactions or the blockchain. Nothing is signed or broadcast.</p>
     </section>
     <div id="out"></div>
+    </div>
     <section class="card muted sources">
       <h3 class="sources-heading">Sources</h3>
       <p>Ian Coleman BIP39: <a href="https://github.com/iancoleman/bip39" target="_blank" rel="noopener noreferrer">github.com/iancoleman/bip39</a> — pull <code>bip39-standalone.html</code> from Releases, or <code>src/js/index.js</code>, <code>entropy.js</code>, <code>jsbip39.js</code>, <code>wordlist_english.js</code>.</p>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -615,15 +615,17 @@ ec.innerHTML = `
       </ul>
     </section>
     <nav class="workspace no-print" id="workspace"></nav>
-    <section class="key-manager no-print" id="key-manager">
-      <div class="key-manager-head"><h2>Keys</h2></div>
-      <div class="key-tab-strip"><div class="key-tabs" id="key-tabs" role="tablist" aria-label="Keys"></div><div class="add-item-control"><button class="add-key" id="add-key" type="button" aria-label="Add key" aria-describedby="add-key-tooltip">+</button><span class="add-item-tooltip" id="add-key-tooltip" role="tooltip">Add another key</span></div></div>
+      <div class="workspace-panel" id="workspace-panel">
+      <div class="tool-intro" id="calc-tool-intro">
+        <div class="kicker">Your entropy enters the lab</div>
+        <h2>Create. Derive. Verify.</h2>
+        <p class="muted calc-intro">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+      </div>
+      <section class="key-manager no-print" id="key-manager">
+      <div class="key-tab-strip"><div class="key-tabs" id="key-tabs" role="tablist" aria-label="Keys"></div><div class="add-item-control"><button class="add-key" id="add-key" type="button" aria-label="Add key" aria-describedby="add-key-tooltip">+</button><span class="add-item-tooltip" id="add-key-tooltip" role="tooltip">Add another key</span></div><div class="add-item-control"><button class="add-key remove-key" id="delete-key" type="button" aria-label="Delete current key" aria-describedby="delete-key-tooltip" disabled>−</button><span class="add-item-tooltip" id="delete-key-tooltip" role="tooltip">Delete this key</span></div></div>
     </section>
     <section class="card no-print" id="calc-card" role="tabpanel" hidden>
-      <div class="key-panel-head">
-        <div class="row segmented-control" id="modes" role="group" aria-label="Key input mode"></div>
-        <button class="btn delete-key" id="delete-key" type="button" aria-label="Delete current key" disabled>Delete Key</button>
-      </div>
+      <div class="row segmented-control" id="modes" role="group" aria-label="Key input mode"></div>
       <div class="global-sync-host" id="global-sync-host"></div>
       <section class="seed-length-control" id="seed-length" aria-labelledby="seed-length-label">
         <p class="label" id="seed-length-label">Seed phrase length</p>
@@ -719,10 +721,12 @@ ec.innerHTML = `
       </div>
       <p class="err" id="error"></p>
     </section>
-    <section class="card no-print" id="bip85-card" role="tabpanel" hidden>
-      <div class="kicker">One seed. Many children.</div>
-      <h2>Derive BIP-85 child entropy</h2>
-      <p class="muted bip85-intro">Deterministic child seeds, keys, and passwords from the active key's BIP32 root. Same parent, application, and index always reproduce the same child. This does not invent entropy \u2014 it is a calculator. English BIP-39 children match COLDCARD.</p>
+    <div class="tool-intro" id="bip85-tool-intro" hidden>
+        <div class="kicker">One seed. Many children.</div>
+        <h2>Derive BIP-85 child entropy</h2>
+        <p class="muted bip85-intro">Deterministic child seeds, keys, and passwords from the active key's BIP32 root. Same parent, application, and index always reproduce the same child. This does not invent entropy \u2014 it is a calculator. English BIP-39 children match COLDCARD.</p>
+      </div>
+      <section class="card no-print" id="bip85-card" role="tabpanel" hidden>
       <label class="field">Optional root xprv (leave blank to use the active key)
         <textarea id="bip85-key" placeholder="xprv\u2026 or leave blank to use the active key" spellcheck="false" autocomplete="off" autocapitalize="off"></textarea>
       </label>
@@ -773,16 +777,15 @@ ec.innerHTML = `
       <div id="bip85-out" aria-live="polite"></div>
       <p class="muted">Derived children remain in this page only. Anyone with the parent seed, passphrase, application, and index can reproduce them. Memory clearing is best-effort; close the page before reconnecting the computer.</p>
     </section>
-    <section class="key-manager no-print" id="msig-manager" hidden>
-      <div class="key-manager-head"><h2>Multisigs</h2></div>
-      <div class="key-tab-strip"><div class="key-tabs" id="msig-tabs" role="tablist" aria-label="Multisigs"></div><div class="add-item-control"><button class="add-key" id="add-msig" type="button" aria-label="Add multisig" aria-describedby="add-msig-tooltip">+</button><span class="add-item-tooltip" id="add-msig-tooltip" role="tooltip">Add another multisig</span></div></div>
+      <div class="tool-intro" id="msig-tool-intro" hidden>
+        <div class="kicker">Multiple keys, one wallet</div>
+        <h2>Derive a multisig wallet</h2>
+        <p class="muted msig-intro">Combine extended public keys into a multisignature wallet. Paste each key origin and extended public key as exported by its signer: <span class="mono">[fingerprint/48h/0h/0h/2h]xpub\u2026</span>. Private keys are not needed. The derived addresses can receive bitcoin, and spending requires the configured number of signatures.</p>
+      </div>
+      <section class="key-manager no-print" id="msig-manager" hidden>
+      <div class="key-tab-strip"><div class="key-tabs" id="msig-tabs" role="tablist" aria-label="Multisigs"></div><div class="add-item-control"><button class="add-key" id="add-msig" type="button" aria-label="Add multisig" aria-describedby="add-msig-tooltip">+</button><span class="add-item-tooltip" id="add-msig-tooltip" role="tooltip">Add another multisig</span></div><div class="add-item-control"><button class="add-key remove-key" id="delete-msig" type="button" aria-label="Delete current multisig" aria-describedby="delete-msig-tooltip" disabled>−</button><span class="add-item-tooltip" id="delete-msig-tooltip" role="tooltip">Delete this multisig</span></div></div>
     </section>
     <section class="card no-print" id="msig-card" role="tabpanel" hidden>
-      <div class="key-panel-head">
-        <div><div class="kicker">Multiple keys, one wallet</div><h2>Derive a multisig wallet</h2></div>
-        <button class="btn delete-key" id="delete-msig" type="button" aria-label="Delete current multisig" disabled>Delete Multisig</button>
-      </div>
-      <p class="muted msig-intro">Combine extended public keys into a multisignature wallet. Paste each key origin and extended public key as exported by its signer: <span class="mono">[fingerprint/48h/0h/0h/2h]xpub\u2026</span>. Private keys are not needed. The derived addresses can receive bitcoin, and spending requires the configured number of signatures.</p>
       <div class="msig-threshold-labels">
         <label for="msig-m-number"><span>Signatures needed to spend (m)</span><input class="msig-threshold-number" id="msig-m-number" type="number" min="1" max="15" step="1" value="2" inputmode="numeric" aria-describedby="msig-threshold-help"></label>
         <label for="msig-n-number"><span>Total signing keys (n)</span><input class="msig-threshold-number" id="msig-n-number" type="number" min="1" max="15" step="1" value="3" inputmode="numeric" aria-describedby="msig-threshold-help"></label>
@@ -868,10 +871,12 @@ ec.innerHTML = `
       </div>
       <p class="err" id="msig-error"></p>
     </section>
-    <section class="card no-print" id="sp-card" role="tabpanel" hidden>
-      <div class="kicker">BIP-352 · reusable address, unique outputs</div>
-      <h2>Silent Payments</h2>
-      <p class="muted psbt-intro">A calculator, not a chain scanner. Derive a reusable <code>sp1q…</code> address from your seed, compute the unique taproot output a sender must pay, or check pasted outputs against your scan key. Nothing here talks to the network.</p>
+    <div class="tool-intro" id="sp-tool-intro" hidden>
+        <div class="kicker">BIP-352 · reusable address, unique outputs</div>
+        <h2>Silent Payments</h2>
+        <p class="muted psbt-intro">A calculator, not a chain scanner. Derive a reusable <code>sp1q…</code> address from your seed, compute the unique taproot output a sender must pay, or check pasted outputs against your scan key. Nothing here talks to the network.</p>
+      </div>
+      <section class="card no-print" id="sp-card" role="tabpanel" hidden>
       <div class="row no-print segmented-control" id="sp-modes">
         <button class="tab active" type="button" data-sp-mode="receive" aria-pressed="true">Receive</button>
         <button class="tab" type="button" data-sp-mode="send" aria-pressed="false">Send</button>
@@ -938,10 +943,12 @@ ec.innerHTML = `
       <div id="sp-out" aria-live="polite"></div>
       <p class="muted">Session keys remain in this page only and are never intentionally stored or sent. Memory clearing is best-effort because browsers may retain internal copies; close the page before reconnecting the computer.</p>
     </section>
-    <section class="card no-print" id="psbt-card" role="tabpanel" hidden>
-      <div class="kicker">Inspect first. Sign elsewhere.</div>
-      <h2>Read a PSBT or a signed transaction.</h2>
-      <p class="muted psbt-intro">Inspecting a PSBT v0 or a raw Bitcoin transaction does not require a private key. EntropyLab can show outputs, PSBT-provided input amounts and fees, signatures, and repeated ECDSA nonce values. Optional Jade anti-exfil transcripts (host nonce \u03C1 and signer opening R) are checked without a key. Finalized taproot witnesses and tap-leaf scripts are scanned for inscription envelopes (OP_FALSE OP_IF "ord"); this does not number sats or fetch content from the chain. Loading a matching key additionally labels which outputs belong to this wallet (change vs receive vs not yours) and checks whether supported signatures match plain RFC 6979 or Bitcoin Core-style low-r grinding; a mismatch alone is not evidence of a compromised signer.</p>
+    <div class="tool-intro" id="psbt-tool-intro" hidden>
+        <div class="kicker">Inspect first. Sign elsewhere.</div>
+        <h2>Read a PSBT or a signed transaction.</h2>
+        <p class="muted psbt-intro">Inspecting a PSBT v0 or a raw Bitcoin transaction does not require a private key. EntropyLab can show outputs, PSBT-provided input amounts and fees, signatures, and repeated ECDSA nonce values. Optional Jade anti-exfil transcripts (host nonce \u03C1 and signer opening R) are checked without a key. Finalized taproot witnesses and tap-leaf scripts are scanned for inscription envelopes (OP_FALSE OP_IF "ord"); this does not number sats or fetch content from the chain. Loading a matching key additionally labels which outputs belong to this wallet (change vs receive vs not yours) and checks whether supported signatures match plain RFC 6979 or Bitcoin Core-style low-r grinding; a mismatch alone is not evidence of a compromised signer.</p>
+      </div>
+      <section class="card no-print" id="psbt-card" role="tabpanel" hidden>
       <label class="field">PSBT v0 or raw transaction (base64 or hex)
         <textarea id="psbt-text" placeholder="cHNidP8B\u2026 or 020000000001\u2026" spellcheck="false" autocomplete="off" autocapitalize="off"></textarea>
       </label>
@@ -972,10 +979,12 @@ ec.innerHTML = `
       <div id="psbt-out" aria-live="polite"></div>
       <p class="muted">Session keys remain in this page only and are never intentionally stored or sent. Memory clearing is best-effort because browsers may retain internal copies; close the page before reconnecting the computer.</p>
     </section>
-    <section class="card no-print" id="psbted-card" role="tabpanel" hidden>
-      <div class="kicker">Full-fidelity editor. Sign elsewhere.</div>
-      <h2>Edit a PSBT, field by field.</h2>
-      <p class="muted psbt-intro">A BIP-174 editor in the spirit of bip174.org, backed by rust-bitcoin compiled to WebAssembly. Every key-value pair of the global, per-input and per-output maps is shown with a typed decode (BIP-174 and BIP-371 taproot fields) and stays editable as raw hex, and the unsigned transaction's version, locktime, input prevouts/sequences and output amounts/scripts get structured fields. Adding or removing a pair re-validates the file immediately; Re-serialize validates the pending field edits and produces the new PSBT. PSBT v0 only; unknown and proprietary pairs round-trip untouched. Editing never signs anything.</p>
+    <div class="tool-intro" id="psbted-tool-intro" hidden>
+        <div class="kicker">Full-fidelity editor. Sign elsewhere.</div>
+        <h2>Edit a PSBT, field by field.</h2>
+        <p class="muted psbt-intro">A BIP-174 editor in the spirit of bip174.org, backed by rust-bitcoin compiled to WebAssembly. Every key-value pair of the global, per-input and per-output maps is shown with a typed decode (BIP-174 and BIP-371 taproot fields) and stays editable as raw hex, and the unsigned transaction's version, locktime, input prevouts/sequences and output amounts/scripts get structured fields. Adding or removing a pair re-validates the file immediately; Re-serialize validates the pending field edits and produces the new PSBT. PSBT v0 only; unknown and proprietary pairs round-trip untouched. Editing never signs anything.</p>
+      </div>
+      <section class="card no-print" id="psbted-card" role="tabpanel" hidden>
       <label class="field">PSBT v0 (base64 or hex)
         <textarea id="psbted-text" placeholder="cHNidP8B..." spellcheck="false" autocomplete="off" autocapitalize="off"></textarea>
       </label>
@@ -991,6 +1000,7 @@ ec.innerHTML = `
       <p class="muted">Fees and input amounts shown here are unverified PSBT claims; the editor does not check them against previous transactions or the blockchain. Nothing is signed or broadcast.</p>
     </section>
     <div id="out"></div>
+    </div>
     <section class="card muted sources">
       <h3 class="sources-heading">Sources</h3>
       <p>Ian Coleman BIP39: <a href="https://github.com/iancoleman/bip39" target="_blank" rel="noopener noreferrer">github.com/iancoleman/bip39</a> \u2014 pull <code>bip39-standalone.html</code> from Releases, or <code>src/js/index.js</code>, <code>entropy.js</code>, <code>jsbip39.js</code>, <code>wordlist_english.js</code>.</p>
@@ -10083,12 +10093,12 @@ function hodlShowWorkspace(id) {
   if (hodlWorkspace === "calc") hodlCaptureKey();
   else if (hodlWorkspace === "msig") hodlCaptureMsig();
   hodlWorkspace = id;
-  [...W("#workspace-menu").children].forEach((button) => {
+  [...W("#workspace-tabs").querySelectorAll("[data-workspace]")].forEach((button) => {
     let active = button.dataset.workspace === id;
     button.classList.toggle("active", active);
-    button.setAttribute("aria-pressed", String(active));
+    button.setAttribute("aria-selected", String(active));
+    if (active) hodlRevealTab(W("#workspace-tabs"), [...W("#workspace-tabs").children].indexOf(button));
   });
-  W("#workspace-menu-current").textContent = hodlWorkspaceTabs.find(([tab]) => tab === id)?.[1] ?? "";
   document.getElementById("key-manager").hidden = id !== "calc";
   document.getElementById("msig-manager").hidden = id !== "msig";
   document.getElementById("calc-card").hidden = true;
@@ -10097,6 +10107,11 @@ function hodlShowWorkspace(id) {
   document.getElementById("psbted-card").hidden = id !== "psbted";
   document.getElementById("bip85-card").hidden = id !== "bip85";
   document.getElementById("sp-card").hidden = id !== "sp";
+  // The context block sits outside its tool's card, so it is shown and hidden
+  // with the card rather than by it.
+  ["psbt", "psbted", "bip85", "sp", "msig", "calc"].forEach((tool) => {
+    document.getElementById(`${tool}-tool-intro`).hidden = id !== tool;
+  });
   re = null;
   Ge = false;
   dr.innerHTML = "";
@@ -10188,54 +10203,77 @@ function hodlSeedInitialManagers() {
     hodlActiveMsig = 0;
   }
 }
-var hodlWorkspaceTabs = [["calc", "Key Derivation"], ["bip85", "BIP-85"], ["msig", "Multi Signature"], ["sp", "Silent Payments"], ["psbt", "PSBT / Nonce"], ["psbted", "PSBT Editor"]];
-// The switcher reads as a videogame settings menu at every width: a
-// hamburger bar that drops the menu down over the tool. The is-open class
-// opens and closes the dropdown.
-function hodlSetWorkspaceMenuOpen(open) {
-  W("#workspace").classList.toggle("is-open", open);
-  W("#workspace-menu-toggle").setAttribute("aria-expanded", String(open));
+// Each tool carries a full name and a short one. Narrow screens show the
+// short form so more tools stay on screen instead of off the right edge.
+var hodlWorkspaceTabs = [["calc", "Key Derivation", "Keys"], ["bip85", "BIP-85", "BIP85"], ["msig", "Multi Signature", "MultiSig"], ["sp", "Silent Payments", "SP"], ["psbt", "PSBT / Nonce", "PSBT"], ["psbted", "PSBT Editor", "Editor"]];
+// The switcher keeps every tool on screen as a folder-tab strip that scrolls
+// when it must, in the shape the Keys section uses for its own tabs.
+function hodlWorkspaceTabKeydown(event, index) {
+  let next = null, length = hodlWorkspaceTabs.length;
+  if (event.key === "ArrowRight") next = (index + 1) % length;
+  else if (event.key === "ArrowLeft") next = (index - 1 + length) % length;
+  else if (event.key === "Home") next = 0;
+  else if (event.key === "End") next = length - 1;
+  if (next === null) return;
+  event.preventDefault();
+  hodlShowWorkspace(hodlWorkspaceTabs[next][0]);
+  W("#workspace-tabs").querySelectorAll("[data-workspace]")[next]?.focus();
+}
+function hodlSyncWorkspaceOverflow() {
+  let strip = document.getElementById("workspace-tabs"), hint = document.getElementById("workspace-more");
+  if (!strip || !hint) return;
+  hint.hidden = strip.scrollWidth - strip.clientWidth - strip.scrollLeft <= 1;
 }
 function hodlInitWorkspace() {
   let box = W("#workspace");
   box.innerHTML = "";
-  let toggle = document.createElement("button");
-  toggle.type = "button";
-  toggle.className = "workspace-menu-toggle";
-  toggle.id = "workspace-menu-toggle";
-  toggle.setAttribute("aria-expanded", "false");
-  toggle.setAttribute("aria-controls", "workspace-menu");
-  toggle.innerHTML = `<svg class="workspace-menu-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true" focusable="false"><path d="M4 7h16M4 12h16M4 17h16"/></svg><span class="workspace-menu-current" id="workspace-menu-current"></span><svg class="workspace-menu-chevron" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="m6 9 6 6 6-6"/></svg>`;
-  toggle.onclick = () => hodlSetWorkspaceMenuOpen(!box.classList.contains("is-open"));
-  let menu = document.createElement("div");
-  menu.className = "workspace-menu";
-  menu.id = "workspace-menu";
-  menu.setAttribute("role", "group");
-  menu.setAttribute("aria-label", "Workspace");
-  hodlWorkspaceTabs.forEach(([id, label]) => {
+  // Every tool stays on screen. The strip scrolls rather than collapsing, so
+  // adding tools later widens the row instead of hiding them behind a control
+  // the user has to know to open.
+  let hint = document.createElement("button");
+  hint.type = "button";
+  hint.className = "workspace-more";
+  hint.id = "workspace-more";
+  hint.setAttribute("aria-controls", "workspace-tabs");
+  hint.setAttribute("aria-label", "Scroll the tool list to see more tools");
+  hint.hidden = true;
+  hint.innerHTML = `More tools<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M5 12h13M13 6l6 6-6 6"/></svg>`;
+  let strip = document.createElement("div");
+  strip.className = "workspace-tabs";
+  strip.id = "workspace-tabs";
+  strip.setAttribute("role", "tablist");
+  strip.setAttribute("aria-label", "Tool");
+  hodlWorkspaceTabs.forEach(([id, label, short], index) => {
     let button = document.createElement("button"), active = hodlWorkspace === id;
     button.type = "button";
-    button.className = "tab" + (active ? " active" : "");
+    button.className = "workspace-tab" + (active ? " active" : "");
     button.dataset.workspace = id;
-    button.setAttribute("aria-pressed", String(active));
-    button.textContent = label;
-    button.onclick = () => {
-      hodlShowWorkspace(id);
-      hodlSetWorkspaceMenuOpen(false);
-    };
-    menu.appendChild(button);
+    button.setAttribute("role", "tab");
+    button.setAttribute("aria-selected", String(active));
+    button.innerHTML = `<span class="workspace-tab-full"></span><span class="workspace-tab-short"></span>`;
+    button.firstChild.textContent = label;
+    button.lastChild.textContent = short;
+    // The short form is display:none at wide widths and the full one is hidden
+    // at narrow ones, and hidden text is not in the accessibility tree — so the
+    // name is stated outright rather than left to whichever span is showing.
+    button.setAttribute("aria-label", label);
+    button.onclick = () => hodlShowWorkspace(id);
+    button.onkeydown = (event) => hodlWorkspaceTabKeydown(event, index);
+    strip.appendChild(button);
   });
-  box.append(toggle, menu);
-  W("#workspace-menu-current").textContent = hodlWorkspaceTabs.find(([id]) => id === hodlWorkspace)?.[1] ?? "";
-  document.addEventListener("click", (event) => {
-    if (box.classList.contains("is-open") && !event.target.closest("#workspace")) hodlSetWorkspaceMenuOpen(false);
+  box.append(hint, strip);
+  hodlInitTabDrag(strip);
+  // The hint points at tools that are off the right edge, so it answers "is
+  // there more that way": it goes once the end is reached, and one click
+  // finishes the journey rather than stopping part of the way.
+  hint.onclick = () => strip.scrollTo({
+    left: strip.scrollWidth,
+    behavior: matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth",
   });
-  document.addEventListener("keydown", (event) => {
-    if (event.key === "Escape" && box.classList.contains("is-open")) {
-      hodlSetWorkspaceMenuOpen(false);
-      toggle.focus();
-    }
-  });
+  hodlSyncWorkspaceOverflow();
+  strip.addEventListener("scroll", hodlSyncWorkspaceOverflow, { passive: true });
+  addEventListener("resize", hodlSyncWorkspaceOverflow);
+  new ResizeObserver(hodlSyncWorkspaceOverflow).observe(strip);
   hodlInitMsig();
   hodlInitPsbt();
   initPsbtEditor();

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -775,6 +775,74 @@
     );
   });
 
+  await test("tool tabs answer the arrow keys and name themselves in full", async () => {
+    const strip = document.getElementById("workspace-tabs");
+    const tabs = [...strip.querySelectorAll("[data-workspace]")];
+    assert(tabs.length === 6, `Expected six tool tabs, found ${tabs.length}`);
+    // The visible label may be abbreviated; the accessible name never is.
+    const names = ["Key Derivation", "BIP-85", "Multi Signature", "Silent Payments", "PSBT / Nonce", "PSBT Editor"];
+    tabs.forEach((tab, i) => {
+      assert(tab.getAttribute("aria-label") === names[i], `Tab ${i} should be named "${names[i]}"`);
+    });
+    const start = document.querySelector('#workspace [data-workspace="calc"]');
+    try {
+      start.focus();
+      // Right moves to the next tool and takes focus with it.
+      start.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+      await until(() => !document.getElementById("bip85-card").hidden, "BIP-85 to open on ArrowRight");
+      assert(document.activeElement === tabs[1], "Focus should follow the arrow key");
+      assert(tabs[1].getAttribute("aria-selected") === "true", "The reached tab should be selected");
+      // End jumps to the last tool, Home returns to the first.
+      tabs[1].dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }));
+      await until(() => !document.getElementById("psbted-card").hidden, "End to reach the last tool");
+      assert(document.activeElement === tabs[5], "End should move focus to the last tab");
+      tabs[5].dispatchEvent(new KeyboardEvent("keydown", { key: "Home", bubbles: true }));
+      await until(() => document.activeElement === tabs[0], "Home to return to the first tab");
+      // Left from the first wraps round to the last.
+      tabs[0].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
+      await until(() => document.activeElement === tabs[5], "ArrowLeft to wrap to the last tab");
+    } finally {
+      document.querySelector('#workspace [data-workspace="calc"]').click();
+      await until(() => !document.getElementById("key-manager").hidden, "key workspace");
+    }
+  });
+  await test("the tool strip advertises tools that are off its right edge", async () => {
+    const strip = document.getElementById("workspace-tabs");
+    const hint = document.getElementById("workspace-more");
+    assert(strip && hint, "The tool strip or its overflow hint is missing");
+    // It scrolls the strip, so it is a labelled button rather than decoration:
+    // an interactive control must stay in the accessibility tree.
+    assert(hint.tagName === "BUTTON", "The hint must be a button now that it acts");
+    assert(!hint.hasAttribute("aria-hidden"), "An interactive control must not be hidden from assistive tech");
+    assert(hint.getAttribute("aria-label"), "The hint needs a label naming what it does");
+    const width = strip.style.maxWidth;
+    try {
+      // Wide enough for every tab: nothing is out of reach, so no hint.
+      await until(() => hint.hidden, "the hint to stay hidden when every tool fits");
+      // Squeeze the strip until tabs overflow.
+      strip.style.maxWidth = "180px";
+      await until(() => !hint.hidden, "the hint to appear once tools overflow");
+      assert(/more tools/i.test(hint.textContent), "The hint should name what is off-screen");
+      assert(hint.querySelector("svg"), "The hint should carry its arrow");
+      // Positioned against the switcher, which is the strip's full width in
+      // the real layout; the squeeze above only narrows the strip itself.
+      const box = document.getElementById("workspace").getBoundingClientRect();
+      const mark = hint.getBoundingClientRect();
+      assert(Math.abs(mark.right - box.right) < 12, "The hint should sit at the switcher's right edge");
+      assert(mark.bottom <= strip.getBoundingClientRect().top + 1, "The hint should sit above the strip");
+      // One click reaches the end, and the label clears itself on arrival.
+      hint.click();
+      await until(() => hint.hidden, "one click to reach the end and clear the hint");
+      assert(
+        strip.scrollWidth - strip.clientWidth - strip.scrollLeft <= 1,
+        "A single click should land at the far right, not part of the way",
+      );
+    } finally {
+      strip.style.maxWidth = width;
+      strip.scrollLeft = 0;
+    }
+  });
+
   await test("the beta banner's dismiss control clears the banner from the page", () => {
     const banner = document.getElementById("beta-warning");
     const dismiss = document.getElementById("beta-warning-dismiss");

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -1096,7 +1096,9 @@ test("the seam into the tool is wider than the page's other major seams", () => 
   // The pitch-to-tool seam is the page's widest; the closing Sources card keeps
   // the ordinary major one. Both collapse with a neighbouring card's 16px, so
   // the larger value wins rather than the two adding up.
-  assert.match(css, /\.workspace \{ position: relative; margin: var\(--space-lede\) 0 4px; \}/);
+  // The strip is the panel's top edge now, so the tool seam is above the tabs
+  // and there is no gap below them to collapse with anything.
+  assert.match(css, /\.workspace \{ position: relative; margin: var\(--space-lede\) 0 0; \}/);
   assert.match(css, /\.sources \{ margin-top: var\(--space-major\); \}/);
   for (const markup of [template, app]) {
     assert.match(markup, /<section class="card muted sources">/);
@@ -1234,7 +1236,7 @@ test("virtual keypads never focus the field on touch so the mobile keyboard stay
 });
 
 test("workspace tabs place BIP-85 between Key Derivation and Multi Signature", () => {
-  assert.match(appSource, /\["calc", "Key Derivation"\], \["bip85", "BIP-85"\], \["msig", "Multi Signature"\], \["sp", "Silent Payments"\], \["psbt", "PSBT \/ Nonce"\], \["psbted", "PSBT Editor"\]/);
+  assert.match(appSource, /\["calc", "Key Derivation", "Keys"\], \["bip85", "BIP-85", "BIP85"\], \["msig", "Multi Signature", "MultiSig"\], \["sp", "Silent Payments", "SP"\], \["psbt", "PSBT \/ Nonce", "PSBT"\], \["psbted", "PSBT Editor", "Editor"\]/);
   for (const markup of [template, appSource]) {
     assert.match(markup, /id="bip85-card"/);
     assert.match(markup, /id="bip85-go"/);
@@ -1245,7 +1247,7 @@ test("workspace tabs place BIP-85 between Key Derivation and Multi Signature", (
 });
 
 test("PSBT Editor tab follows PSBT / Nonce and wires the rust-bitcoin editor", () => {
-  assert.match(appSource, /\["psbt", "PSBT \/ Nonce"\], \["psbted", "PSBT Editor"\]/);
+  assert.match(appSource, /\["psbt", "PSBT \/ Nonce", "PSBT"\], \["psbted", "PSBT Editor", "Editor"\]/);
   assert.match(appSource, /getElementById\("psbted-card"\)\.hidden = id !== "psbted"/);
   for (const markup of [template, appSource]) {
     assert.match(markup, /id="psbted-card"/);
@@ -1279,7 +1281,7 @@ test("BIP-85 entry point sits beside Derive Wallet and opens the BIP-85 tab", ()
 test("Silent Payments sits between Multi Signature and PSBT / Nonce", () => {
   const order = /Key Derivation[\s\S]*Multi Signature[\s\S]*Silent Payments[\s\S]*PSBT \/ Nonce/;
   assert.match(template, order);
-  assert.match(appSource, /\["calc", "Key Derivation"\], \["bip85", "BIP-85"\], \["msig", "Multi Signature"\], \["sp", "Silent Payments"\], \["psbt", "PSBT \/ Nonce"\], \["psbted", "PSBT Editor"\]/);
+  assert.match(appSource, /\["calc", "Key Derivation", "Keys"\], \["bip85", "BIP-85", "BIP85"\], \["msig", "Multi Signature", "MultiSig"\], \["sp", "Silent Payments", "SP"\], \["psbt", "PSBT \/ Nonce", "PSBT"\], \["psbted", "PSBT Editor", "Editor"\]/);
   for (const markup of [template, appSource]) {
     assert.match(markup, /id="sp-card"/);
     assert.match(markup, /id="sp-key"/);
@@ -1292,36 +1294,101 @@ test("Silent Payments sits between Multi Signature and PSBT / Nonce", () => {
   assert.match(css, /#sp-card\[hidden\]/);
 });
 
-test("the workspace switcher is a hamburger dropdown menu at every width", () => {
-  // The switcher is a nav holding a hamburger toggle and the menu it
-  // controls; it is no longer one of the segmented controls.
+test("the workspace switcher keeps every tool on screen as a tab strip", () => {
+  // The switcher is a nav holding one scrollable strip of tabs; it is neither
+  // a segmented control nor a dropdown. Every tool is visible without asking.
   assert.match(template, /<nav class="workspace no-print" id="workspace">/);
   assert.match(appSource, /<nav class="workspace no-print" id="workspace"><\/nav>/);
   assert.doesNotMatch(template, /segmented-control" id="workspace"/);
-  // The toggle is wired to the menu it opens, and names the current
-  // workspace in the collapsed bar.
-  assert.match(template, /<button type="button" class="workspace-menu-toggle" id="workspace-menu-toggle" aria-expanded="false" aria-controls="workspace-menu">/);
-  assert.match(template, /<span class="workspace-menu-current" id="workspace-menu-current">Key Derivation<\/span>/);
-  assert.match(template, /<div class="workspace-menu" id="workspace-menu" role="group" aria-label="Workspace">/);
-  // The menu hides until toggled. There is no wide-screen sidebar layout:
-  // the same dropdown serves every width and the page keeps its single
-  // 1000px measure.
-  assert.match(css, /\.workspace-menu \{[^}]*position: absolute;[^}]*display: none;/s);
-  assert.match(css, /\.workspace\.is-open \.workspace-menu \{ display: grid; \}/);
-  assert.doesNotMatch(css, /min-width: 1024px|max-width: 1260px|tool-shell|tool-content/);
-  assert.doesNotMatch(appSource, /matchMedia\("\(min-width: 1024px\)"\)/);
-  assert.doesNotMatch(`${template}${appSource}`, /tool-shell|tool-content/);
-  // Menu entries keep the app's orange active state.
-  assert.match(css, /\.workspace-menu \.tab:is\(\.active, \[aria-pressed="true"\]\) \{[^}]*background: var\(--selection-accent\);/s);
-  // Runtime: the toggle flips aria-expanded with the open class, picking an
-  // entry closes the dropdown, and the collapsed bar tracks the workspace.
-  assert.match(appSource, /function hodlSetWorkspaceMenuOpen\(open\) \{/);
-  assert.match(appSource, /W\("#workspace"\)\.classList\.toggle\("is-open", open\);/);
-  assert.match(appSource, /W\("#workspace-menu-toggle"\)\.setAttribute\("aria-expanded", String\(open\)\);/);
-  assert.match(appSource, /hodlShowWorkspace\(id\);\s*hodlSetWorkspaceMenuOpen\(false\);/);
-  assert.match(appSource, /\[\.\.\.W\("#workspace-menu"\)\.children\]\.forEach/);
-  assert.match(appSource, /W\("#workspace-menu-current"\)\.textContent = hodlWorkspaceTabs\.find/);
-  // Clicking outside or pressing Escape closes the dropdown.
-  assert.match(appSource, /!event\.target\.closest\("#workspace"\)\) hodlSetWorkspaceMenuOpen\(false\);/);
-  assert.match(appSource, /event\.key === "Escape" && box\.classList\.contains\("is-open"\)/);
+  assert.match(template, /<div class="workspace-tabs" id="workspace-tabs" role="tablist" aria-label="Tool">/);
+  // All five tools ship in the static markup, each with a full name and the
+  // short form narrow screens show instead.
+  for (const [full, short] of [["Key Derivation", "Keys"], ["BIP-85", "BIP85"], ["Multi Signature", "MultiSig"], ["Silent Payments", "SP"], ["PSBT / Nonce", "PSBT"], ["PSBT Editor", "Editor"]]) {
+    assert.ok(
+      template.includes(`<span class="workspace-tab-full">${full}</span><span class="workspace-tab-short">${short}</span>`),
+      `${full} is missing from the workspace strip`,
+    );
+    assert.match(appSource, new RegExp(`\\["[a-z0-9]+", "${full.replace("/", "\\/")}", "${short}"\\]`));
+  }
+  // One swaps for the other at the width the header drops its own labels.
+  assert.match(css, /\.workspace-tab-short \{ display: none; \}/);
+  assert.match(css, /@media \(max-width: 719px\) \{[\s\S]*?\.workspace-tab-full \{ display: none; \}\s*\.workspace-tab-short \{ display: inline; \}/);
+  assert.match(appSource, /button\.firstChild\.textContent = label;\s*button\.lastChild\.textContent = short;/);
+  // Hidden text leaves the accessibility tree, so the full name is stated on
+  // the tab itself and assistive tech hears it at every width.
+  assert.match(appSource, /button\.setAttribute\("aria-label", label\);/);
+  for (const full of ["Key Derivation", "BIP-85", "Multi Signature", "Silent Payments", "PSBT / Nonce"]) {
+    assert.ok(template.includes(`aria-label="${full}"><span class="workspace-tab-full">${full}</span>`), `${full} tab needs its accessible name`);
+  }
+  // A tablist owes arrow keys; the key and multisig strips already answer them.
+  assert.match(appSource, /function hodlWorkspaceTabKeydown\(event, index\) \{/);
+  assert.match(appSource, /if \(event\.key === "ArrowRight"\) next = \(index \+ 1\) % length;/);
+  assert.match(appSource, /else if \(event\.key === "ArrowLeft"\) next = \(index - 1 \+ length\) % length;/);
+  assert.match(appSource, /else if \(event\.key === "Home"\) next = 0;/);
+  assert.match(appSource, /else if \(event\.key === "End"\) next = length - 1;/);
+  assert.match(appSource, /button\.onkeydown = \(event\) => hodlWorkspaceTabKeydown\(event, index\);/);
+  // Nothing collapses the strip behind a control: no toggle, no dropdown, and
+  // no open/close state left over from one.
+  assert.doesNotMatch(`${template}${appSource}`, /workspace-menu|hodlSetWorkspaceMenuOpen/);
+  assert.doesNotMatch(css, /\.workspace-menu/);
+  // It wears the key tabs' folder shape: a raised active tab whose bottom
+  // border is painted out against the strip's rule.
+  // The strip overlaps the panel by a pixel rather than drawing its own rule:
+  // it is a scroll container, so it would clip any tab reaching past its edge
+  // and the chosen tab could never cut the line.
+  assert.match(css, /\.workspace-tabs \{[^}]*margin-bottom: -1px;/s);
+  assert.doesNotMatch(css, /\.workspace-tabs \{[^}]*border-bottom:/s);
+  assert.match(css, /\.workspace-tab \{[^}]*border-radius: 10px 10px 0 0;/s);
+  // The chosen tab takes the panel's ground and hides its own bottom edge in
+  // it, so the strip's rule is cut and the two become one shape.
+  assert.match(css, /\.workspace-tab\.active \{[^}]*background: var\(--bg\); color: var\(--fg\); border-color: var\(--border\); border-bottom-color: var\(--bg\);/s);
+  // The panel closes the folder: the tool content sits inside a border that
+  // carries on from the strip, open at the top where the strip's rule is.
+  for (const markup of [template, appSource]) {
+    assert.match(markup, /<div class="workspace-panel" id="workspace-panel">/);
+  }
+  assert.match(css, /\.workspace-panel \{[^}]*border: 1px solid var\(--border\); border-radius: 0 0 20px 20px;/s);
+  // Every tool panel lives inside it, and the closing Sources card does not.
+  for (const markup of [template, appSource]) {
+    const panel = markup.slice(markup.indexOf('<div class="workspace-panel"'), markup.indexOf('class="card muted sources"'));
+    for (const id of ["calc-card", "bip85-card", "msig-card", "sp-card", "psbt-card"]) {
+      assert.ok(panel.includes(`id="${id}"`), `${id} must sit inside the workspace panel`);
+    }
+    assert.ok(panel.includes('<div id="out">'), "the results region must sit inside the workspace panel");
+  }
+  // Overflow scrolls instead of wrapping or hiding, so more tools still fit.
+  assert.match(css, /\.workspace-tabs \{[^}]*overflow-x: auto;/s);
+  assert.match(css, /\.workspace-tabs::-webkit-scrollbar \{ display: none;/);
+  // Runtime: entries drive the workspace, the strip drags like the key tabs,
+  // and the active tab is scrolled into view when it changes.
+  assert.match(appSource, /strip\.setAttribute\("role", "tablist"\);/);
+  assert.match(appSource, /button\.onclick = \(\) => hodlShowWorkspace\(id\);/);
+  assert.match(appSource, /hodlInitTabDrag\(strip\);/);
+  assert.match(appSource, /\[\.\.\.W\("#workspace-tabs"\)\.querySelectorAll\("\[data-workspace\]"\)\]\.forEach/);
+  assert.match(appSource, /hodlRevealTab\(W\("#workspace-tabs"\)/);
+  // A hint points at tools past the right edge. It tracks what is still out
+  // there rather than merely whether the strip scrolls, so it clears once the
+  // end is reached, and it is decorative: the tabs are the real route.
+  for (const markup of [template, appSource]) {
+    assert.match(markup, /More tools/);
+  }
+  // It is a real control, so it is a button with a label rather than a
+  // decorative span: an interactive element must not be hidden from the
+  // accessibility tree.
+  assert.match(template, /<button type="button" class="workspace-more" id="workspace-more" aria-controls="workspace-tabs" aria-label="Scroll the tool list to see more tools" hidden>/);
+  assert.match(appSource, /hint\.setAttribute\("aria-label", "Scroll the tool list to see more tools"\);/);
+  assert.doesNotMatch(appSource, /hint\.setAttribute\("aria-hidden"/);
+  // One click finishes the journey: the label promises the remaining tools and
+  // clears at the end, so stopping short would read as a broken control.
+  assert.match(appSource, /hint\.onclick = \(\) => strip\.scrollTo\(\{\s*left: strip\.scrollWidth,/s);
+  assert.match(appSource, /behavior: matchMedia\("\(prefers-reduced-motion: reduce\)"\)\.matches \? "auto" : "smooth",/);
+  // No edge fade: the strip is narrow enough on a phone that every pixel of a
+  // label has to stay readable.
+  assert.doesNotMatch(`${css}${appSource}`, /has-overflow/);
+  assert.match(appSource, /function hodlSyncWorkspaceOverflow\(\) \{/);
+  assert.match(appSource, /hint\.hidden = strip\.scrollWidth - strip\.clientWidth - strip\.scrollLeft <= 1;/);
+  assert.match(appSource, /strip\.addEventListener\("scroll", hodlSyncWorkspaceOverflow, \{ passive: true \}\);/);
+  assert.match(appSource, /new ResizeObserver\(hodlSyncWorkspaceOverflow\)\.observe\(strip\);/);
+  assert.match(css, /\.workspace-more \{[^}]*position: absolute; right: 0; bottom: 100%;/s);
+  assert.match(css, /\.workspace-more\[hidden\] \{ display: none; \}/);
 });


### PR DESCRIPTION
- Workspace switcher is a scrollable folder-tab strip, not a dropdown menu.
- Tool content wrapped in #workspace-panel; the active tab merges into it.
- Each tool's kicker, heading and intro moved above the card as .tool-intro.
- Added a Key Derivation intro (description is placeholder lorem ipsum).
- Removed the "Keys" and "Multisigs" headings and .key-panel-head.
- Delete Key and Delete Multisig become "−" buttons beside their "+".
- Short tab names below 719px; aria-label carries the full name.
- Arrow/Home/End keys move between tabs.
- "More tools" button appears when tabs overflow and scrolls to the end.