### PR TITLE
Add a page footer and quiet the closing sections

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -94,13 +94,18 @@ button:not(:disabled):active {
   border-color: var(--selection-accent) !important;
 }
 button:not(:disabled):active * { color: inherit !important; }
-.wrap { max-width: 1000px; margin: 0 auto; padding: calc(var(--site-header-height) + 20px) 16px 64px; }
+/* No bottom padding: the closing footer supplies the page's last band of
+   space itself, so it sits flush with the bottom of the document. */
+.wrap { max-width: 1000px; margin: 0 auto; padding: calc(var(--site-header-height) + 20px) 16px 0; }
 .kicker { font-size: 12px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--accent); font-weight: 600; }
 .card { background: var(--surface); border: 1px solid var(--border); border-radius: 20px; padding: 20px; margin: 16px 0; }
 /* Major seam above the closing Sources card. It collapses with the previous
    card's 16px, so the larger value wins rather than the two adding up. The seam
    below the marketing card lives on #workspace and is deliberately wider. */
-.sources { margin-top: var(--space-major); }
+/* It keeps .card for its padding and seam, but not the surface: the closing
+   reference list reads as the page's own bottom matter rather than one more
+   panel. Padding stays, so its text still aligns with the cards above. */
+.sources { margin-top: var(--space-major); background: none; border: 0; }
 .warn { background: color-mix(in oklab, var(--danger) 12%, var(--bg)); border-color: color-mix(in oklab, var(--danger) 40%, var(--border)); }
 .muted { color: var(--muted); font-size: 14px; line-height: 1.5; }
 /* The pitch is a set of discrete claims rather than prose, so it reads as a
@@ -108,6 +113,11 @@ button:not(:disabled):active * { color: inherit !important; }
    bottom one lets the card's own padding close it out. */
 .pitch-list { display: grid; gap: 7px; margin: var(--space-component) 0 0; padding-left: 20px; }
 .sources-heading { color: var(--fg); font-size: 1.17rem; }
+/* One step dimmer than the .muted it carries for its size and leading, so
+   the closing line sits behind the sources it follows. The banana is the
+   one thing in it worth reading, so it keeps its own size. */
+.page-footer { margin-top: var(--space-lede); padding: 24px 0; border-top: 1px solid var(--border); text-align: center; color: var(--faint); }
+.page-footer-emoji { font-size: 1.5em; line-height: 1; vertical-align: -0.15em; }
 .row { display: flex; flex-wrap: wrap; gap: 8px; }
 .tab, .btn {
   min-height: 44px; padding: 0 14px; border-radius: 8px; border: 1px solid var(--border);
@@ -922,6 +932,10 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .tool-intro > .muted { max-width: 760px; margin: 0; }
 .workspace-panel > :first-child { margin-top: 0; }
 .workspace-panel > :last-child { margin-bottom: 0; }
+/* Inside the panel a card closes on its own bottom edge. Whatever follows
+   brings its own 16px top margin (they collapsed to one 16px before), so the
+   only thing this drops is the gap left above the panel's bottom padding. */
+.workspace-panel .card { margin-bottom: 0; }
 .segmented-control {
   display: flex; align-items: stretch; flex-wrap: wrap; gap: 0; max-width: 100%; isolation: isolate;
 }
@@ -1393,9 +1407,15 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
   width: 36px; min-width: 36px; min-height: 44px; padding: 0; border: 0; border-radius: 0;
   background: transparent; box-shadow: none; color: var(--muted); font-size: 28px; line-height: 1; cursor: pointer;
 }
-.add-key:hover { background: transparent; color: var(--accent); }
+.add-key:not(:disabled):hover { background: transparent; color: var(--accent); }
 .add-key:focus-visible { outline: 2px solid var(--accent); outline-offset: -4px; }
-.add-key:active { background: transparent; color: var(--accent); }
+.add-key:not(:disabled):active { background: transparent; color: var(--accent); }
+/* The minus is disabled while a single key or multisig is all there is. It
+   drops to the border tone, which sits close to its ground in either theme,
+   and stops answering hover, so nothing about it invites a click. Disabled
+   controls are exempt from the contrast floor, and the state is on the
+   element for assistive tech besides. */
+.add-key:disabled { color: var(--border); cursor: not-allowed; }
 .add-item-control { position: relative; display: inline-flex; flex: 0 0 auto; }
 .add-item-tooltip {
   position: absolute; top: calc(100% + 10px); right: 0; z-index: 10; width: max-content; max-width: min(240px, calc(100vw - 32px));

--- a/src/index.html
+++ b/src/index.html
@@ -473,6 +473,7 @@ words, pick one of the checksum words.</span></span>
       <p>BIP-352 Silent Payments: <a href="https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki" target="_blank" rel="noopener noreferrer">bips/bip-0352</a> — reusable <code>sp1q…</code> addresses and unique taproot outputs. Descriptors: <a href="https://github.com/bitcoin/bips/blob/master/bip-0392.mediawiki" target="_blank" rel="noopener noreferrer">BIP-392</a>.</p>
       <p>Inscription envelopes: <a href="https://docs.ordinals.com/inscriptions.html" target="_blank" rel="noopener noreferrer">docs.ordinals.com/inscriptions</a> — <code>OP_FALSE OP_IF "ord"</code> parser only. This tool does not create inscriptions or number sats.</p>
     </section>
+    <footer class="page-footer muted no-print">Ooga Booga <span class="page-footer-emoji">🍌</span></footer>
   </div>
 </div><!--/$--><div class="disclaimer-overlay no-print" id="beta-disclaimer" role="alertdialog" aria-modal="true" aria-labelledby="beta-disclaimer-title" aria-describedby="beta-disclaimer-text" hidden>
   <div class="disclaimer-card">

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1012,6 +1012,7 @@ ec.innerHTML = `
       <p>BIP-352 Silent Payments: <a href="https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki" target="_blank" rel="noopener noreferrer">bips/bip-0352</a> — reusable <code>sp1q…</code> addresses and unique taproot outputs. Descriptors: <a href="https://github.com/bitcoin/bips/blob/master/bip-0392.mediawiki" target="_blank" rel="noopener noreferrer">BIP-392</a>.</p>
       <p>Inscription envelopes: <a href="https://docs.ordinals.com/inscriptions.html" target="_blank" rel="noopener noreferrer">docs.ordinals.com/inscriptions</a> — <code>OP_FALSE OP_IF "ord"</code> parser only. This tool does not create inscriptions or number sats.</p>
     </section>
+    <footer class="page-footer muted no-print">Ooga Booga <span class="page-footer-emoji">🍌</span></footer>
   </div>
 `;
 if (/^(www\.)?entropylab\.online$/i.test(location.hostname)) document.getElementById("online-warning")?.removeAttribute("hidden");

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -781,6 +781,28 @@ test("key and multisig add controls stay pinned to the right of their tab strips
   assert.match(css, /\.add-item-control \{ position: relative; display: inline-flex; flex: 0 0 auto; \}/);
 });
 
+test("the delete control reads as unavailable while one item is all there is", () => {
+  // Both strips ship it disabled: a fresh page holds a single key and a single
+  // multisig, and app.js re-syncs the attribute as items come and go.
+  for (const markup of [template, appSource]) {
+    for (const id of ["delete-key", "delete-msig"]) {
+      assert.match(
+        markup,
+        new RegExp(`<button class="add-key remove-key" id="${id}"[^>]*disabled`),
+        `${id} must ship disabled`,
+      );
+    }
+  }
+  assert.match(appSource, /button\.disabled = hodlKeys\.length <= 1;/);
+  assert.match(appSource, /button\.disabled = hodlMsigs\.length <= 1;/);
+  // Disabled, it drops off the muted tone the live plus keeps.
+  assert.match(css, /\.add-key:disabled \{ color: var\(--border\); cursor: not-allowed; \}/);
+  assert.match(css, /\.add-key \{[^}]*color: var\(--muted\);/s);
+  // And it never lights up under the pointer: both accent states exclude it.
+  assert.match(css, /\.add-key:not\(:disabled\):hover \{ background: transparent; color: var\(--accent\); \}/);
+  assert.match(css, /\.add-key:not\(:disabled\):active \{ background: transparent; color: var\(--accent\); \}/);
+});
+
 test("seed-entry tools keep a square keyboard toggle and a block note on narrow screens", () => {
   assert.match(
     css,
@@ -832,6 +854,37 @@ test("the beta notice sits at the top of the page as a banner", () => {
     assert.doesNotMatch(live, /site-footer|fine-print/);
   }
   assert.doesNotMatch(css, /\.site-footer|\.fine-print/);
+});
+
+test("the page closes on a footer in both markups", () => {
+  // Not the removed beta fine print: a plain closing line that ships in the
+  // static template and the runtime template alike, and stays off paper.
+  for (const markup of [template, app]) {
+    // esbuild escapes the emoji when it minifies the runtime template, so the
+    // two markups carry the same character in two spellings.
+    assert.match(
+      markup,
+      /<footer class="page-footer muted no-print">Ooga Booga <span class="page-footer-emoji">(?:🍌|\\u\{1F34C\})<\/span><\/footer>/,
+    );
+    // It closes the wrap, so nothing of the page follows it.
+    assert.ok(
+      markup.indexOf('class="page-footer') > markup.indexOf('class="card muted sources"'),
+      "the footer must follow the sources card",
+    );
+  }
+  // The wrap gives up its bottom padding so the footer's own padding is the
+  // page's last band of space; a top border draws the seam above it.
+  // The widest seam in the page opens above it, wider than the major seam the
+  // sources card takes, so the closing line reads as its own band.
+  assert.match(css, /\.page-footer \{ margin-top: var\(--space-lede\); padding: 24px 0; border-top: 1px solid var\(--border\); text-align: center; color: var\(--faint\);/);
+  // .muted would otherwise colour it: the footer rule has to win on order.
+  assert.ok(
+    css.indexOf(".page-footer {") > css.indexOf(".muted {"),
+    "the footer rule must follow .muted so its colour wins",
+  );
+  // The banana outgrows the line it sits on.
+  assert.match(css, /\.page-footer-emoji \{[^}]*font-size: 1\.5em;/);
+  assert.doesNotMatch(css, /\.wrap \{[^}]*16px 64px/);
 });
 
 test("the beta banner carries a dismiss control in a narrow right-hand column", () => {
@@ -1069,7 +1122,7 @@ test("the site header is fixed, carries the logo, and holds the version, downloa
   // markup is the only source, and the app makes no runtime requests.
   assert.doesNotMatch(online, /fetch\s*\(|site-version|innerHTML/);
   // Content clears the fixed header on screen, and reclaims the space in print.
-  assert.match(css, /\.wrap \{ max-width: 1000px; margin: 0 auto; padding: calc\(var\(--site-header-height\) \+ 20px\) 16px 64px; \}/);
+  assert.match(css, /\.wrap \{ max-width: 1000px; margin: 0 auto; padding: calc\(var\(--site-header-height\) \+ 20px\) 16px 0; \}/);
   assert.match(css, /@media print \{[\s\S]*?\.wrap \{ padding-top: 20px; \}/);
   assert.match(css, /html \{[^}]*scroll-padding-top: calc\(var\(--site-header-height\) \+ 12px\)/);
   // Every header control is one height, and the bar is sized to match it.
@@ -1099,7 +1152,8 @@ test("the seam into the tool is wider than the page's other major seams", () => 
   // The strip is the panel's top edge now, so the tool seam is above the tabs
   // and there is no gap below them to collapse with anything.
   assert.match(css, /\.workspace \{ position: relative; margin: var\(--space-lede\) 0 0; \}/);
-  assert.match(css, /\.sources \{ margin-top: var\(--space-major\); \}/);
+  // The card's surface comes off it: no background, no border, padding kept.
+  assert.match(css, /\.sources \{ margin-top: var\(--space-major\); background: none; border: 0; \}/);
   for (const markup of [template, app]) {
     assert.match(markup, /<section class="card muted sources">/);
   }
@@ -1348,6 +1402,10 @@ test("the workspace switcher keeps every tool on screen as a tab strip", () => {
     assert.match(markup, /<div class="workspace-panel" id="workspace-panel">/);
   }
   assert.match(css, /\.workspace-panel \{[^}]*border: 1px solid var\(--border\); border-radius: 0 0 20px 20px;/s);
+  // Cards in the panel close on their own edge; the page's other cards, the
+  // pitch and the sources among them, keep the shared 16px both ways.
+  assert.match(css, /\.workspace-panel \.card \{ margin-bottom: 0; \}/);
+  assert.match(css, /\.card \{[^}]*margin: 16px 0; \}/);
   // Every tool panel lives inside it, and the closing Sources card does not.
   for (const markup of [template, appSource]) {
     const panel = markup.slice(markup.indexOf('<div class="workspace-panel"'), markup.indexOf('class="card muted sources"'));


### PR DESCRIPTION
- New footer at the bottom of both markups: "Ooga Booga" with the emoji sized 1.5em, --faint text, 24px vertical padding and a top border.
- .wrap drops its 64px bottom padding so the footer sits flush.
- Sources section loses its background and border, keeps padding.
- Cards inside .workspace-panel drop their bottom margin.
- The disabled +/- minus goes to --border with not-allowed, and the hover/active accent rules now exclude :disabled.