### PR TITLE
Name Lockdown Mode on the WASM kill screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,12 @@ Official website: [entropylab.online](https://entropylab.online)
   sender taproot outputs from pasted vin JSON, and receiver verification of
   pasted x-only outputs. This is a calculator: it does not scan the chain.
 - Runs a quick barrage of startup sanity checks on the host browser (secure
-  context, CSPRNG, BigInt, UTF-8 encoding, and NFKD normalization). If any
+  context, CSPRNG, BigInt, UTF-8 encoding, NFKD, and WebAssembly). If any
   check fails, the page is replaced with a failure report listing the failed
   checks, because wallet output from a broken host cannot be trusted.
+  iPhone/iPad/Mac Lockdown Mode blocks WebAssembly (the secp256k1 engine):
+  exclude the site in Safari's page menu, or open the saved HTML in Firefox
+  on an air-gapped computer. There is no JavaScript secp256k1 fallback.
 - Produces recovery information that can be saved or printed for offline use.
 - Exports a Bitcoin Core `wallet.dat` (SQLite descriptor wallet) with every
   derived output descriptor already imported — receive and change for each

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,6 +47,9 @@ material. Its security posture rests on the following model:
   runner's copy back to the repository, the same flow as the site artifact.
    Cross-machine byte identity is not claimed — the C side compiles with the
    builder's clang, and build-host paths are remapped out of the binary.
+  iOS/macOS Lockdown Mode disables WebAssembly. Exclude the site in Safari
+  or use a host that can compile WASM. There is no JavaScript secp256k1
+  fallback; a host that cannot run the module is treated as broken.
 - Secret byte buffers are overwritten after use, on a best-effort basis. The
   WASM bindings zero every linear-memory buffer before freeing it
   (`secp_free`/`psbt_free` use volatile writes) and erase their own secret

--- a/llms.txt
+++ b/llms.txt
@@ -16,7 +16,7 @@ EntropyLab is a single HTML file with no runtime dependencies. It is designed to
 - Optional global entropy sync keeps direct dice, cards, number bases, BIP39 words/numbers, and private-key encodings aligned live. It stays visible but is unavailable for hashed input methods. Off by default.
 - SLIP-132 display is prefix-swap only. Shows as-pasted, Bitcoin Core xpub/xprv (or tpub/tprv), and descriptor. SLIP form only when path/script match. No Taproot prefix. Testnet t/u/v/U/V.
 - Exports a Bitcoin Core wallet.dat (watch-only by default) with all derived descriptors imported.
-- Runs startup sanity checks on the host browser and refuses to render if they fail.
+- Runs startup sanity checks on the host browser and refuses to render if they fail. Lockdown Mode blocks WebAssembly; exclude the site in Safari or use Firefox on an air-gapped computer. No JS secp256k1 fallback.
 
 ## Links
 

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -822,6 +822,7 @@ td { border-top: 1px solid var(--border); padding: 8px; vertical-align: top; fon
 .sanity-failure-table th { color: var(--muted); font-weight: 600; }
 .sanity-failure-table td:last-child { color: var(--danger); font-weight: 700; }
 .sanity-failure-advice { margin: 0; color: var(--muted); font-size: 14px; }
+.sanity-failure-advice + .sanity-failure-advice { margin-top: 10px; }
 @media print {
   :root, :root[data-theme] {
     color-scheme: light;

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -10410,7 +10410,8 @@ const hodlCurveFailure = () => {
       <thead><tr><th>Startup sanity check</th><th>Result</th></tr></thead>
       <tbody>${rows}</tbody>
     </table>
-    <p class="sanity-failure-advice">Open this file in a current, mainstream browser such as Firefox on a trusted, air-gapped computer.</p>
+    <p class="sanity-failure-advice">iPhone, iPad, and Mac Lockdown Mode block WebAssembly. This calculator needs it for secp256k1.</p>
+    <p class="sanity-failure-advice">In Safari: tap the page-menu button in the address bar, tap More, turn off Lockdown Mode for this website, then reload. Or open the saved HTML in Firefox on a trusted air-gapped computer. Do not enter seed material until every check passes.</p>
   </div>
 </main>`;
 };

--- a/src/js/browser-check.js
+++ b/src/js/browser-check.js
@@ -106,6 +106,13 @@
   // Kill the page: replace everything with the centered failure report.
   // Check names are trusted literals defined above, never user input.
   const rows = failed.map((name) => `<tr><td>${name}</td><td>Failed</td></tr>`).join("");
+  const wasmFailed = failed.includes("WebAssembly (secp256k1 engine)");
+  // Lockdown Mode (iPhone, iPad, Mac) disables WebAssembly. There is no JS
+  // secp256k1 fallback: wallet math is libsecp256k1 compiled to WASM.
+  const advice = wasmFailed
+    ? `<p class="sanity-failure-advice">iPhone, iPad, and Mac Lockdown Mode block WebAssembly. This calculator needs it for secp256k1.</p>
+    <p class="sanity-failure-advice">In Safari: tap the page-menu button in the address bar, tap More, turn off Lockdown Mode for this website, then reload. Or open the saved HTML in Firefox on a trusted air-gapped computer. Do not enter seed material until every check passes.</p>`
+    : `<p class="sanity-failure-advice">Open this file in a current, mainstream browser such as Firefox on a trusted, air-gapped computer.</p>`;
   document.body.innerHTML = `
 <main class="sanity-failure">
   <div class="sanity-failure-card" role="alert">
@@ -116,7 +123,7 @@
       <thead><tr><th>Startup sanity check</th><th>Result</th></tr></thead>
       <tbody>${rows}</tbody>
     </table>
-    <p class="sanity-failure-advice">Open this file in a current, mainstream browser such as Firefox on a trusted, air-gapped computer.</p>
+    ${advice}
   </div>
 </main>`;
 })();

--- a/test/browser-check.test.mjs
+++ b/test/browser-check.test.mjs
@@ -215,6 +215,9 @@ test("a wrong UTF-8 decoding kills the page", () => {
 test("missing WebAssembly kills the page", () => {
   const { body } = loadModule({ webAssemblyImpl: undefined });
   assertPageKilled(body, ["WebAssembly (secp256k1 engine)"]);
+  assert.match(body.innerHTML, /Lockdown Mode block WebAssembly/);
+  assert.match(body.innerHTML, /page-menu button/);
+  assert.match(body.innerHTML, /turn off Lockdown Mode for this website/);
 });
 
 test("a CSP or engine that refuses WebAssembly compilation kills the page", () => {
@@ -227,6 +230,14 @@ test("a CSP or engine that refuses WebAssembly compilation kills the page", () =
   };
   const { body } = loadModule({ webAssemblyImpl });
   assertPageKilled(body, ["WebAssembly (secp256k1 engine)"]);
+  assert.match(body.innerHTML, /Lockdown Mode/);
+});
+
+test("a non-WASM failure keeps the generic air-gap advice", () => {
+  const { body } = loadModule({ secure: false });
+  assertPageKilled(body, ["Secure browser context"]);
+  assert.doesNotMatch(body.innerHTML, /Lockdown Mode/);
+  assert.match(body.innerHTML, /Firefox on a trusted, air-gapped computer/);
 });
 
 test("missing String.normalize kills the page", () => {
@@ -285,6 +296,7 @@ test("the build inlines the module and the failure screen is styled", () => {
     ".sanity-failure-table {",
     ".sanity-failure-table th, .sanity-failure-table td {",
     ".sanity-failure-advice {",
+    ".sanity-failure-advice + .sanity-failure-advice {",
   ]) {
     assert.ok(css.includes(selector), `styles.css is missing ${selector}`);
   }

--- a/test/validate.test.mjs
+++ b/test/validate.test.mjs
@@ -171,6 +171,9 @@ test("the WASM boot chain has a failure path that kills the page", () => {
   );
   assert.match(app, /hodlCurveFailure/, "the boot rejection must render the sanity-failure kill screen");
   assert.match(app, /<tr><td>secp256k1 WebAssembly module<\/td><td>Failed<\/td><\/tr>/);
+  assert.match(app, /Lockdown Mode block WebAssembly/);
+  const check = read("src/js/browser-check.js");
+  assert.match(check, /Lockdown Mode block WebAssembly/);
 });
 
 test("the release build attests the wallet artifact and ships a checksum manifest (issue #58)", () => {


### PR DESCRIPTION
iPhone, iPad, and Mac Lockdown Mode disable WebAssembly. The secp256k1 engine is libsecp256k1 compiled to WASM, so there is no JS fallback. The kill screen now tells Safari users how to exclude this site, or to open the saved HTML in Firefox on an air-gapped computer.