### PR TITLE
Fix duplicated card pad clicks

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -3583,7 +3583,7 @@ function hodlUpdateCards() {
   hodlCardRank = selection.rank;
   if (selection.card && !parsed.invalidRanges.length) {
     hodlCommitCardSelection(input, selection.card);
-    return;
+    return true;
   }
   let dealt = document.getElementById("dealt-cards");
   if (dealt) {
@@ -3632,6 +3632,7 @@ function hodlUpdateCards() {
   let undo = document.getElementById("card-undo");
   if (undo) undo.disabled = !parsed.cards.length && !String(input.value || "").trim();
   hodlQueueMasterFingerprintPreview();
+  return false;
 }
 function hodlSetInputValueAtEnd(input, value) {
   input.value = value;
@@ -5368,16 +5369,25 @@ function hodlRenderKeyForm() {
         hodlQueueMasterFingerprintPreview(0);
       };
     });
+    let cardPadCommitting = false;
     hodlFormEl.querySelectorAll("[data-card-suit]").forEach((button) => {
       button.onclick = () => {
+        if (cardPadCommitting) return;
         hodlCardSuit = hodlToggleCardChoice(hodlCardSuit, button.getAttribute("data-card-suit"));
-        hodlUpdateCards();
+        if (hodlUpdateCards()) {
+          cardPadCommitting = true;
+          queueMicrotask(() => cardPadCommitting = false);
+        }
       };
     });
     hodlFormEl.querySelectorAll("[data-card-rank]").forEach((button) => {
       button.onclick = () => {
+        if (cardPadCommitting) return;
         hodlCardRank = hodlToggleCardChoice(hodlCardRank, button.getAttribute("data-card-rank"));
-        hodlUpdateCards();
+        if (hodlUpdateCards()) {
+          cardPadCommitting = true;
+          queueMicrotask(() => cardPadCommitting = false);
+        }
       };
     });
     hodlBindKeypadPointer(hodlFormEl.querySelectorAll("[data-direct-card-rank], #card-undo"), () => input);

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -432,6 +432,20 @@
     input(cards, "");
   });
 
+  await test("a duplicated card-pad click commits once and clears both selections", async () => {
+    await chooseMode("Cards");
+    const cards = await until(() => document.getElementById("cards"), "card transcript input");
+    const ace = document.querySelector('[data-card-rank="A"]');
+    const hearts = document.querySelector('[data-card-suit="H"]');
+    ace.click();
+    hearts.click();
+    hearts.click();
+    equal(cards.value, "Ah ");
+    assert(!document.querySelector(".card-suit-pad .active"), "Suit remained selected after the duplicated click");
+    assert(!document.querySelector(".card-rank-pad .active"), "Rank remained selected after the duplicated click");
+    input(cards, "");
+  });
+
   await test("partial entropy word grids remain copyable", async () => {
     await chooseMode("Number bases");
     document.querySelector('input[name="entropy-format"][value="bin"]').click();


### PR DESCRIPTION
Closes #243.

A card commit now keeps a per-render guard active through the current event turn, preventing a duplicated compatibility click from re-selecting the suit after the rank and suit have been cleared. The pads stay wired through `click` only, so touch, mouse, keyboard, and screen-reader activation are unchanged.

The browser regression dispatches the duplicated suit click and verifies that exactly one card is committed and neither pad retains an active selection.

Tests:
- `npm run build`
- `npm test` (829 passing)
- `npm run verify`
- Firefox and Chrome/Chromium browser suites (including the new regression test in both engines)

Edge was not installed.
