### PR TITLE
Add Station workflows and cross-station key selection

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -962,18 +962,13 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .key-result-main { margin-top: 8px; padding: 16px 16px 20px; border: 1px solid var(--border); border-radius: 20px; background: var(--surface); }
 .key-result .wallet-result-messages { margin: 0 0 16px; }
 .account-receive-section { margin-top: 0; }
-.msig-session-keys { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 8px; }
-.msig-session-keys[hidden] { display: none; }
-.msig-session-key {
-  display: inline-flex; align-items: center; gap: 8px;
-  min-height: 44px; padding: 6px 10px; border: 1px solid var(--border); border-radius: 10px;
-  background: var(--surface-2); color: var(--fg); font-family: var(--mono); font-size: 13px; cursor: pointer;
-}
-.msig-session-key.active { border-color: var(--accent); color: var(--fg); }
 .station-key-source { margin: 0 0 20px; }
 #sp-modes + .station-key-source { margin-top: 20px; }
 .station-key-source > .label { margin: 0 0 8px; }
 .station-key-source > .field-note { display: block; margin: 8px 0 0; }
+.msig-key-reuse-toggle { margin-top: 12px; }
+.msig-station-key-source #msig-session-key-status:empty { display: none; }
+.msig-station-key-source + .msig-threshold-labels { margin-top: 0; }
 .session-key-picker { display: flex; flex-wrap: wrap; gap: 8px; }
 .session-key-picker[hidden] { display: none; }
 .session-key-option {

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -937,7 +937,7 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .tool-intro[hidden] { display: none; }
 .tool-intro h2 { margin: 5px 0 8px; }
 .tool-intro > .muted { max-width: 760px; margin: 0; }
-.key-lab[hidden], .key-summary[hidden], .msig-lab[hidden] { display: none; }
+.key-lab[hidden], .key-summary[hidden], .msig-lab[hidden], .bip85-bench[hidden] { display: none; }
 #calc-card.is-result-view #modes,
 #calc-card:not(.is-result-view) #out,
 #msig-card:not(.is-result-view) #msig-out { display: none; }
@@ -955,11 +955,8 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .key-summary-path { font-family: var(--mono); word-break: break-all; }
 .key-tab-lifehash { width: 22px; height: 22px; border-radius: 4px; image-rendering: pixelated; background: #fff; }
 .key-tab.is-lab { font-weight: 700; }
-.key-tab-lab-icon { width: 18px; height: 22px; padding: 0; color: inherit; }
+.key-tab-lab-icon { width: 16px; height: 16px; padding: 0; color: var(--muted); }
 .key-tab-lab-icon svg { display: block; width: 100%; height: 100%; }
-.key-tab-lab-icon .site-logo-light { display: none; }
-:root[data-theme="light"] .key-tab-lab-icon .site-logo-dark { display: none; }
-:root[data-theme="light"] .key-tab-lab-icon .site-logo-light { display: block; }
 .key-result { margin-top: 16px; }
 .key-result-scripts-label { margin: 0 0 8px; color: var(--muted); font-size: 12px; font-weight: 700; }
 .key-result-main { margin-top: 8px; padding: 16px 16px 20px; border: 1px solid var(--border); border-radius: 20px; background: var(--surface); }
@@ -973,6 +970,18 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
   background: var(--surface-2); color: var(--fg); font-family: var(--mono); font-size: 13px; cursor: pointer;
 }
 .msig-session-key.active { border-color: var(--accent); color: var(--fg); }
+.station-key-source { margin: 0 0 20px; }
+#sp-modes + .station-key-source { margin-top: 20px; }
+.station-key-source > .label { margin: 0 0 8px; }
+.station-key-source > .field-note { display: block; margin: 8px 0 0; }
+.session-key-picker { display: flex; flex-wrap: wrap; gap: 8px; }
+.session-key-picker[hidden] { display: none; }
+.session-key-option {
+  display: inline-flex; align-items: center; gap: 8px;
+  min-height: 44px; padding: 6px 10px; border: 1px solid var(--border); border-radius: 10px;
+  background: var(--surface-2); color: var(--fg); font-family: var(--mono); font-size: 13px; cursor: pointer;
+}
+.session-key-option.active { border-color: var(--accent); }
 .msig-key-ident { display: inline-flex; align-items: center; gap: 8px; margin: 0; }
 .msig-key-ident[hidden] { display: none; }
 .msig-key-ident-fp { font-family: var(--mono); font-size: 13px; letter-spacing: 0.04em; }
@@ -1006,7 +1015,7 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .segmented-control.is-stacked > .tab:last-child { border-radius: 0 0 8px 8px; }
 .segmented-control.is-stacked > .tab:only-child { border-radius: 8px; }
 #msig-card[hidden], #calc-card[hidden], #psbt-card[hidden], #psbted-card[hidden], #bip85-card[hidden], #sp-card[hidden] { display: none !important; }
-#calc-card:not([hidden]), #msig-card:not([hidden]) { margin-top: 0; border-radius: 0 0 20px 20px; position: relative; z-index: 1; }
+#calc-card:not([hidden]), #msig-card:not([hidden]), #bip85-card:not([hidden]), #sp-card:not([hidden]) { margin-top: 0; border-radius: 0 0 20px 20px; position: relative; z-index: 1; }
 .psbt-grid { display: grid; grid-template-columns: minmax(0, 1fr); gap: 0 14px; }
 @media (min-width: 720px) {
   .psbt-grid { grid-template-columns: minmax(0, 2fr) minmax(220px, 1fr); }
@@ -1460,6 +1469,7 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .bip85-actions { margin-top: var(--space-component); }
 .bip85-notes { margin: var(--space-component) 0 0; padding-left: 20px; color: var(--muted); font-size: 13px; line-height: 1.5; }
 #bip85-out { margin-top: var(--space-component); }
+#bip85-card.is-result-view #bip85-out { margin-top: 0; }
 #bip85-out .wallet-private-section { margin-top: 0; }
 #psbt-session { margin: var(--space-control) 0 0; }
 .key-manager { margin: 14px 0 -1px; position: relative; z-index: 2; }
@@ -1473,7 +1483,7 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .add-key:not(:disabled):hover { background: transparent; color: var(--accent); }
 .add-key:focus-visible { outline: 2px solid var(--accent); outline-offset: -4px; }
 .add-key:not(:disabled):active { background: transparent; color: var(--accent); }
-/* The minus is disabled while a single key or multisig is all there is. It
+/* The minus is disabled while a Station tab is selected. It
    drops to the border tone, which sits close to its ground in either theme,
    and stops answering hover, so nothing about it invites a click. Disabled
    controls are exempt from the contrast floor, and the state is on the
@@ -1682,10 +1692,15 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 }
 .key-tab-icon { display: inline-flex; flex: 0 0 auto; width: 16px; height: 16px; color: var(--key-color); }
 .key-tab-icon svg { display: block; width: 16px; height: 16px; }
-.key-tab-lab-icon { display: inline-flex; width: 18px; height: 22px; }
+.key-tab-icon.key-tab-lab-icon { display: inline-flex; width: 16px; height: 16px; color: var(--muted); }
 .key-tab-lab-icon svg { width: 100%; height: 100%; }
 .multisig-tab-icon { display: inline-flex; flex: 0 0 auto; width: 28px; height: 23px; margin-left: -5px; }
 .multisig-tab-icon svg { display: block; width: 100%; height: 100%; overflow: visible; }
+.bench-tab-icon,
+.multisig-tab-icon.bench-tab-icon {
+  flex: 0 0 18px; width: 18px; height: 18px; margin-left: 0; padding: 0; color: var(--muted);
+}
+.bench-tab-icon svg { display: block; width: 100%; height: 100%; }
 .key-tab-label { display: inline-block; white-space: nowrap; }
 .key-tab-editing { height: 44px; }
 .key-tabs .key-tab-editing input.key-tab-name-input {

--- a/src/index.html
+++ b/src/index.html
@@ -195,8 +195,8 @@ words, pick one of the checksum words.</span></span>
       </div>
       <p class="field-note address-estimate derivation-estimate" id="address-estimate" role="status">Measuring this device…</p>
       <div class="row key-action-row current-item-actions">
-        <button class="btn primary" id="go" disabled aria-disabled="true">Derive Wallet</button>
-        <div class="derive-progress" id="derive-progress" role="progressbar" aria-label="Wallet derivation progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-valuetext="0% complete" hidden><span class="derive-progress-track"><span class="derive-progress-bar"></span></span><span class="derive-progress-label">0%</span></div>
+        <button class="btn primary" id="go" disabled aria-disabled="true">Derive Key</button>
+        <div class="derive-progress" id="derive-progress" role="progressbar" aria-label="Key derivation progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-valuetext="0% complete" hidden><span class="derive-progress-track"><span class="derive-progress-bar"></span></span><span class="derive-progress-label">0%</span></div>
         <button class="btn secondary" id="bip85-open" type="button">Derive BIP-85 child</button>
         <button class="btn clear-current-action" id="wipe" type="button" disabled aria-disabled="true">Clear Current Key</button>
       </div>

--- a/src/index.html
+++ b/src/index.html
@@ -43,7 +43,17 @@
         <li>Keep your private keys offline.</li>
       </ul>
     </section>
-    <nav class="workspace no-print" id="workspace"><button type="button" class="workspace-more" id="workspace-more" aria-controls="workspace-tabs" aria-label="Scroll the tool list to see more tools" hidden>More tools<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M5 12h13M13 6l6 6-6 6"/></svg></button><div class="workspace-tabs" id="workspace-tabs" role="tablist" aria-label="Tool"><button type="button" class="workspace-tab active" role="tab" aria-selected="true" aria-label="Keys"><span class="workspace-tab-full">Keys</span><span class="workspace-tab-short">Keys</span></button><button type="button" class="workspace-tab" role="tab" aria-selected="false" aria-label="BIP-85"><span class="workspace-tab-full">BIP-85</span><span class="workspace-tab-short">BIP85</span></button><button type="button" class="workspace-tab" role="tab" aria-selected="false" aria-label="Multi Signature"><span class="workspace-tab-full">Multi Signature</span><span class="workspace-tab-short">MultiSig</span></button><button type="button" class="workspace-tab" role="tab" aria-selected="false" aria-label="Silent Payments"><span class="workspace-tab-full">Silent Payments</span><span class="workspace-tab-short">SP</span></button><button type="button" class="workspace-tab" role="tab" aria-selected="false" aria-label="PSBT / Nonce"><span class="workspace-tab-full">PSBT / Nonce</span><span class="workspace-tab-short">PSBT</span></button><button type="button" class="workspace-tab" role="tab" aria-selected="false" aria-label="PSBT Editor"><span class="workspace-tab-full">PSBT Editor</span><span class="workspace-tab-short">Editor</span></button></div></nav>
+    <nav class="workspace no-print" id="workspace">
+      <button type="button" class="workspace-more" id="workspace-more" aria-controls="workspace-tabs" aria-label="Scroll the tool list to see more tools" hidden>More tools<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M5 12h13M13 6l6 6-6 6"/></svg></button>
+      <div class="workspace-tabs" id="workspace-tabs" role="tablist" aria-label="Tool">
+        <button type="button" class="workspace-tab active" role="tab" aria-selected="true" aria-label="Keys"><span class="workspace-tab-full">Keys</span><span class="workspace-tab-short">Keys</span></button>
+        <button type="button" class="workspace-tab" role="tab" aria-selected="false" aria-label="BIP-85"><span class="workspace-tab-full">BIP-85</span><span class="workspace-tab-short">BIP85</span></button>
+        <button type="button" class="workspace-tab" role="tab" aria-selected="false" aria-label="Multi Signature"><span class="workspace-tab-full">Multi Signature</span><span class="workspace-tab-short">MultiSig</span></button>
+        <button type="button" class="workspace-tab" role="tab" aria-selected="false" aria-label="Silent Payments"><span class="workspace-tab-full">Silent Payments</span><span class="workspace-tab-short">SP</span></button>
+        <button type="button" class="workspace-tab" role="tab" aria-selected="false" aria-label="PSBT / Nonce"><span class="workspace-tab-full">PSBT / Nonce</span><span class="workspace-tab-short">PSBT</span></button>
+        <button type="button" class="workspace-tab" role="tab" aria-selected="false" aria-label="PSBT Editor"><span class="workspace-tab-full">PSBT Editor</span><span class="workspace-tab-short">Editor</span></button>
+      </div>
+    </nav>
     <div class="workspace-panel" id="workspace-panel">
       <div class="tool-intro" id="calc-tool-intro">
         <div class="kicker">Your entropy enters the lab</div>
@@ -51,7 +61,7 @@
         <p class="muted calc-intro">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
       </div>
       <section class="key-manager no-print" id="key-manager">
-      <div class="key-tab-strip"><div class="key-tabs" id="key-tabs" role="tablist" aria-label="Keys"></div><div class="add-item-control"><button class="add-key" id="add-key" type="button" aria-label="Open the lab to derive another key" aria-describedby="add-key-tooltip">+</button><span class="add-item-tooltip" id="add-key-tooltip" role="tooltip">Open the lab to derive another key</span></div><div class="add-item-control"><button class="add-key remove-key" id="delete-key" type="button" aria-label="Delete current key" aria-describedby="delete-key-tooltip" disabled>−</button><span class="add-item-tooltip" id="delete-key-tooltip" role="tooltip">Delete this key</span></div></div>
+      <div class="key-tab-strip"><div class="key-tabs" id="key-tabs" role="tablist" aria-label="Keys"></div><div class="add-item-control"><button class="add-key" id="add-key" type="button" aria-label="Open Key Station to derive another key" aria-describedby="add-key-tooltip">+</button><span class="add-item-tooltip" id="add-key-tooltip" role="tooltip">Open Key Station to derive another key</span></div><div class="add-item-control"><button class="add-key remove-key" id="delete-key" type="button" aria-label="Delete current key" aria-describedby="delete-key-tooltip" disabled>−</button><span class="add-item-tooltip" id="delete-key-tooltip" role="tooltip">Delete this key</span></div></div>
     </section>
     <section class="card no-print" id="calc-card" role="tabpanel" hidden>
       <div class="row segmented-control" id="modes"><button class="tab active" aria-pressed="true">Dice rolls</button><button class="tab" aria-pressed="false">Cards</button><button class="tab" aria-pressed="false">Number bases</button><button class="tab" aria-pressed="false">Seed phrase</button><button class="tab" aria-pressed="false">Private key</button><button class="tab" aria-pressed="false">Brain wallet — lab</button></div>
@@ -194,14 +204,23 @@ words, pick one of the checksum words.</span></span>
       </div>
       <div id="out"></div>
     </section>
-    <div class="tool-intro" id="bip85-tool-intro" hidden>
+      <div class="tool-intro" id="bip85-tool-intro" hidden>
         <div class="kicker">One seed. Many children.</div>
         <h2>Derive BIP-85 child entropy</h2>
-        <p class="muted bip85-intro">Deterministic child seeds, keys, and passwords from the active key's BIP32 root. Same parent, application, and index always reproduce the same child. This does not invent entropy — it is a calculator. English BIP-39 children match COLDCARD.</p>
+        <p class="muted bip85-intro">Deterministic child seeds, keys, and passwords from a Key Station BIP32 root. Same parent, application, and index always reproduce the same child. This does not invent entropy — it is a calculator. English BIP-39 children match COLDCARD.</p>
       </div>
+      <section class="key-manager no-print" id="bip85-manager" hidden>
+        <div class="key-tab-strip"><div class="key-tabs" id="bip85-tabs" role="tablist" aria-label="BIP-85 child seeds"></div><div class="add-item-control"><button class="add-key" id="add-bip85" type="button" aria-label="Open BIP-85 Station to derive another child" aria-describedby="add-bip85-tooltip">+</button><span class="add-item-tooltip" id="add-bip85-tooltip" role="tooltip">Open BIP-85 Station</span></div><div class="add-item-control"><button class="add-key remove-key" id="delete-bip85" type="button" aria-label="Delete current BIP-85 child" aria-describedby="delete-bip85-tooltip" disabled>−</button><span class="add-item-tooltip" id="delete-bip85-tooltip" role="tooltip">Delete this BIP-85 child</span></div></div>
+      </section>
       <section class="card no-print" id="bip85-card" role="tabpanel" hidden>
-      <label class="field">Optional root xprv (leave blank to use the active key)
-        <textarea id="bip85-key" placeholder="xprv… or leave blank to use the active key" spellcheck="false" autocomplete="off" autocapitalize="off"></textarea>
+      <div class="bip85-bench" id="bip85-bench">
+      <div class="station-key-source">
+        <p class="label">Bring in a key from Key Station</p>
+        <div class="session-key-picker" id="bip85-session-keys" role="group" aria-label="Compatible Key Station keys" hidden></div>
+        <p class="field-note">Choose a compatible HD-root key from this session, or paste a root extended private key below.</p>
+      </div>
+      <label class="field">Root xprv (optional)
+        <textarea id="bip85-key" placeholder="Paste a root xprv or tprv" spellcheck="false" autocomplete="off" autocapitalize="off"></textarea>
       </label>
       <div class="bip85-grid">
         <label class="field">Application
@@ -242,11 +261,11 @@ words, pick one of the checksum words.</span></span>
       <p class="muted bip85-path-row">Path <code id="bip85-path">m/83696968'/39'/0'/24'/0'</code></p>
       <div class="row bip85-actions">
         <button class="btn primary" id="bip85-go" type="button">Derive child</button>
-        <button class="btn secondary" id="bip85-use-calc" type="button">Use active key</button>
-        <button class="btn secondary" id="bip85-wipe" type="button">Clear derived child</button>
+        <button class="btn secondary" id="bip85-wipe" type="button">Clear parent session</button>
       </div>
-      <p class="muted" id="bip85-session" aria-live="polite">No parent loaded. Derive a key first, or paste a root xprv.</p>
+      <p class="muted" id="bip85-session" aria-live="polite">No parent loaded. Choose a Key Station key, or paste a root xprv.</p>
       <p class="err" id="bip85-error" role="alert"></p>
+      </div>
       <div id="bip85-out" aria-live="polite"></div>
       <p class="muted">Derived children remain in this page only. Anyone with the parent seed, passphrase, application, and index can reproduce them. Memory clearing is best-effort; close the page before reconnecting the computer.</p>
     </section>
@@ -256,7 +275,7 @@ words, pick one of the checksum words.</span></span>
         <p class="muted msig-intro">Combine extended public keys into a multisignature wallet. Paste each key origin and extended public key as exported by its signer: <span class="mono">[fingerprint/48h/0h/0h/2h]xpub…</span>. Private keys are not needed. The derived addresses can receive bitcoin, and spending requires the configured number of signatures.</p>
       </div>
       <section class="key-manager no-print" id="msig-manager" hidden="">
-      <div class="key-tab-strip"><div class="key-tabs" id="msig-tabs" role="tablist" aria-label="Multisigs"></div><div class="add-item-control"><button class="add-key" id="add-msig" type="button" aria-label="Open the lab to derive another multisig" aria-describedby="add-msig-tooltip">+</button><span class="add-item-tooltip" id="add-msig-tooltip" role="tooltip">Open the lab to derive another multisig</span></div><div class="add-item-control"><button class="add-key remove-key" id="delete-msig" type="button" aria-label="Delete current multisig" aria-describedby="delete-msig-tooltip" disabled>−</button><span class="add-item-tooltip" id="delete-msig-tooltip" role="tooltip">Delete this multisig</span></div></div>
+      <div class="key-tab-strip"><div class="key-tabs" id="msig-tabs" role="tablist" aria-label="Multisigs"></div><div class="add-item-control"><button class="add-key" id="add-msig" type="button" aria-label="Open MS Station to derive another multisig" aria-describedby="add-msig-tooltip">+</button><span class="add-item-tooltip" id="add-msig-tooltip" role="tooltip">Open MS Station</span></div><div class="add-item-control"><button class="add-key remove-key" id="delete-msig" type="button" aria-label="Delete current multisig" aria-describedby="delete-msig-tooltip" disabled>−</button><span class="add-item-tooltip" id="delete-msig-tooltip" role="tooltip">Delete this multisig</span></div></div>
     </section>
     <section class="card no-print" id="msig-card" role="tabpanel" hidden="">
       <div class="key-summary" id="msig-summary" hidden>
@@ -360,15 +379,23 @@ words, pick one of the checksum words.</span></span>
         <h2>Silent Payments</h2>
         <p class="muted tool-intro-note">A calculator, not a chain scanner. Derive a reusable <code>sp1q…</code> address from your seed, compute the unique taproot output a sender must pay, or check pasted outputs against your scan key. Nothing here talks to the network.</p>
       </div>
+      <section class="key-manager no-print" id="sp-manager" hidden>
+        <div class="key-tab-strip"><div class="key-tabs" id="sp-tabs" role="tablist" aria-label="Silent Payments"></div></div>
+      </section>
       <section class="card no-print" id="sp-card" role="tabpanel" hidden>
       <div class="row no-print segmented-control" id="sp-modes">
         <button class="tab active" type="button" data-sp-mode="receive" aria-pressed="true">Receive</button>
         <button class="tab" type="button" data-sp-mode="send" aria-pressed="false">Send</button>
         <button class="tab" type="button" data-sp-mode="verify" aria-pressed="false">Verify</button>
       </div>
+      <div class="station-key-source">
+        <p class="label">Bring in a key from Key Station</p>
+        <div class="session-key-picker" id="sp-session-keys" role="group" aria-label="Compatible Key Station keys" hidden></div>
+        <p class="field-note">Choose a compatible HD-root key from this session, or enter a seed phrase or root extended private key below.</p>
+      </div>
       <div class="psbt-grid">
         <label class="field">Session key (BIP39 seed phrase or root xprv/tprv)
-          <textarea id="sp-key" placeholder="Leave blank and use the active key, or paste a seed / root xprv" spellcheck="false" autocomplete="off" autocapitalize="off"></textarea>
+          <textarea id="sp-key" placeholder="Enter a seed phrase or root xprv/tprv" spellcheck="false" autocomplete="off" autocapitalize="off"></textarea>
         </label>
         <div>
           <label class="field">Optional BIP39 passphrase
@@ -383,7 +410,6 @@ words, pick one of the checksum words.</span></span>
         </div>
       </div>
       <div class="row psbt-actions">
-        <button class="btn secondary" id="sp-use-calc" type="button">Use active key this session</button>
         <button class="btn secondary" id="sp-wipe" type="button">End session / clear fields</button>
       </div>
       <p class="muted" id="sp-session" aria-live="polite">No session key. Receive and verify need a seed or root xprv.</p>

--- a/src/index.html
+++ b/src/index.html
@@ -287,6 +287,16 @@ words, pick one of the checksum words.</span></span>
         <button class="btn secondary" id="msig-edit-inputs" type="button">Edit input</button>
       </div>
       <div class="msig-lab" id="msig-lab">
+      <div class="station-key-source msig-station-key-source">
+        <p class="label">Bring in a key from Key Station</p>
+        <div class="session-key-picker" id="msig-session-keys" role="group" aria-label="Compatible Key Station keys" hidden></div>
+        <p class="field-note">Choose a compatible HD-root key from this session, or paste a co-signer extended public key below.</p>
+        <label class="choice msig-key-reuse-toggle">
+          <input id="msig-reuse-session-keys" type="checkbox">
+          <span><strong>Allow key reuse</strong><span class="desc">Keep selected Key Station keys available for more than one co-signer input.</span></span>
+        </label>
+        <p class="field-note" id="msig-session-key-status" aria-live="polite"></p>
+      </div>
       <div class="msig-threshold-labels">
         <label for="msig-m-number"><span>Signatures needed to spend (m)</span><input class="msig-threshold-number" id="msig-m-number" type="number" min="1" max="15" step="1" value="2" inputmode="numeric" aria-describedby="msig-threshold-help"></label>
         <label for="msig-n-number"><span>Total signing keys (n)</span><input class="msig-threshold-number" id="msig-n-number" type="number" min="1" max="15" step="1" value="3" inputmode="numeric" aria-describedby="msig-threshold-help"></label>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -8267,7 +8267,9 @@ function hodlPickBip85SessionKey(state) {
   if (error) error.textContent = "";
   try {
     hodlUseKeyForBip85(state);
-    document.getElementById("bip85-key").value = "";
+    let rootXprv = state.result?.rootXprv || hodlBip85Root?.privateExtendedKey;
+    if (!rootXprv) throw new Error("This Key Station key does not expose a BIP32 root xprv/tprv.");
+    document.getElementById("bip85-key").value = rootXprv;
     document.getElementById("bip85-session").textContent = hodlBip85Note;
   } catch (exception) {
     if (error) error.textContent = exception.message || String(exception);
@@ -8454,8 +8456,7 @@ function hodlRunBip85() {
   if (error) error.textContent = "";
   try {
     if (manual.trim()) {
-      hodlBip85LoadXprv(manual);
-      document.getElementById("bip85-key").value = "";
+      if (!hodlBip85Root || !hodlBip85Source.startsWith("key:")) hodlBip85LoadXprv(manual);
     } else if (!hodlBip85Root) throw new Error("Choose a compatible Key Station key, or paste a root xprv/tprv.");
     result = deriveApplication(hodlBip85Root, hodlBip85Spec());
     let fingerprint = hodlBip85ChildFingerprint(result);
@@ -8487,6 +8488,13 @@ function hodlInitBip85() {
   hodlRenderBip85Tabs();
   hodlSyncBip85View();
   hodlRefreshStationKeyPickers();
+  document.getElementById("bip85-key").addEventListener("input", () => {
+    if (!hodlBip85Source.startsWith("key:")) return;
+    hodlBip85WipeParent();
+    hodlBip85Source = document.getElementById("bip85-key").value.trim() ? "manual" : "";
+    document.getElementById("bip85-session").textContent = hodlBip85Source ? "Manual root key entered. It will be validated when you derive a child." : hodlBip85Note;
+    hodlRefreshStationKeyPickers();
+  });
   go.onclick = hodlRunBip85;
   // Entry point beside Derive Wallet (idea adopted from PR #150): jump to the
   // BIP-85 tab with the active key loaded as parent. Errors land in the tab's
@@ -8610,8 +8618,8 @@ function hodlPickSpSessionKey(state) {
   if (error) error.textContent = "";
   try {
     hodlSpUseKey(state);
-    document.getElementById("sp-key").value = "";
-    document.getElementById("sp-pass").value = "";
+    document.getElementById("sp-key").value = state.result?.mnemonic || state.result?.rootXprv || "";
+    document.getElementById("sp-pass").value = state.result?.mnemonic ? state.fields?.pass || "" : "";
     document.getElementById("sp-session").textContent = hodlSpNote;
   } catch (exception) {
     if (error) error.textContent = exception.message || String(exception);
@@ -8621,9 +8629,7 @@ function hodlPickSpSessionKey(state) {
 function hodlSpEnsureHd() {
   let manual = document.getElementById("sp-key")?.value;
   if (manual && manual.trim()) {
-    hodlSpLoadKey(manual, document.getElementById("sp-pass")?.value);
-    document.getElementById("sp-key").value = "";
-    document.getElementById("sp-pass").value = "";
+    if (!hodlSpHd || !hodlSpSource.startsWith("key:")) hodlSpLoadKey(manual, document.getElementById("sp-pass")?.value);
     hodlRefreshStationKeyPickers();
   }
   if (!hodlSpHd || !hodlSpHd.privateKey) throw new Error("Choose a compatible Key Station key, or enter a BIP39 seed or root xprv.");
@@ -8807,6 +8813,15 @@ function hodlRunSp() {
 function hodlInitSp() {
   if (!document.getElementById("sp-card")) return;
   hodlRefreshStationKeyPickers();
+  let detachStationKey = () => {
+    if (!hodlSpSource.startsWith("key:")) return;
+    hodlSpWipeKeys();
+    hodlSpSource = document.getElementById("sp-key").value.trim() ? "manual" : "";
+    document.getElementById("sp-session").textContent = hodlSpSource ? "Manual session key entered. It will be validated when you use this Station." : hodlSpNote;
+    hodlRefreshStationKeyPickers();
+  };
+  document.getElementById("sp-key").addEventListener("input", detachStationKey);
+  document.getElementById("sp-pass").addEventListener("input", detachStationKey);
   document.querySelectorAll("#sp-modes [data-sp-mode]").forEach((button) => {
     button.onclick = () => { hodlSpSetMode(button.dataset.spMode); document.getElementById("sp-out").innerHTML = ""; document.getElementById("sp-error").textContent = ""; };
   });

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -7066,8 +7066,15 @@ function hodlSyncMsigKeyAvatar(row) {
   }
 }
 var hodlMsigKeyTarget = null;
-function hodlMsigUsedSessionFingerprints() {
-  return new Set([...document.querySelectorAll("#msig-keys textarea")].map((textarea) => hodlMsigKeyOriginFingerprint(textarea.value)).filter(Boolean));
+function hodlMsigCanonicalSessionKey(value) {
+  try {
+    return hodlCanonicalMultisigKey(hodlParseMultisigCosigner(String(value || "").trim()));
+  } catch {
+    return "";
+  }
+}
+function hodlMsigUsedSessionKeys() {
+  return new Set([...document.querySelectorAll("#msig-keys textarea")].map((textarea) => hodlMsigCanonicalSessionKey(textarea.value)).filter(Boolean));
 }
 function hodlMsigNextKeyTarget() {
   let inputs = [...document.querySelectorAll("#msig-keys textarea")];
@@ -7095,11 +7102,18 @@ function hodlPickMsigSessionKey(state) {
 function hodlRefreshMsigSessionPickers() {
   let box = document.getElementById("msig-session-keys"), status = document.getElementById("msig-session-key-status");
   if (!box) return;
-  let keys = hodlSessionMsigKeys(), reuse = document.getElementById("msig-reuse-session-keys")?.checked, used = hodlMsigUsedSessionFingerprints(), available = reuse ? keys : keys.filter((state) => !used.has(state.result?.masterFingerprint || ""));
+  let keys = hodlSessionMsigKeys(), reuse = document.getElementById("msig-reuse-session-keys")?.checked, used = hodlMsigUsedSessionKeys(), options = keys.map((state) => {
+    let value = "";
+    try {
+      value = hodlMatchingMsigExport(state.result);
+    } catch {
+    }
+    return { state, canonical: hodlMsigCanonicalSessionKey(value) };
+  }), available = reuse ? options : options.filter((option) => !option.canonical || !used.has(option.canonical));
   box.replaceChildren();
   box.hidden = !available.length;
-  available.forEach((state) => {
-    let fingerprint = state.result?.masterFingerprint || state.name, button = document.createElement("button"), image = document.createElement("img"), label = document.createElement("span"), assigned = used.has(fingerprint);
+  available.forEach(({ state, canonical }) => {
+    let fingerprint = state.result?.masterFingerprint || state.name, button = document.createElement("button"), image = document.createElement("img"), label = document.createElement("span"), assigned = Boolean(canonical) && used.has(canonical);
     button.type = "button";
     button.className = "session-key-option" + (assigned ? " active" : "");
     button.dataset.keyId = String(state.id);
@@ -8304,9 +8318,6 @@ function hodlUseKeyForBip85(state) {
   else throw new Error("BIP-85 needs an HD root. This Key Station key is a single private key.");
   hodlBip85Source = "key:" + state.id;
 }
-function hodlUseActiveKeyForBip85() {
-  hodlUseKeyForBip85(hodlKeys[hodlActiveKey]);
-}
 function hodlPickBip85SessionKey(state) {
   let error = document.getElementById("bip85-error");
   if (error) error.textContent = "";
@@ -8548,16 +8559,7 @@ function hodlInitBip85() {
   if (open) open.onclick = () => {
     hodlShowWorkspace("bip85");
     hodlSelectBip85Bench();
-    let error = document.getElementById("bip85-error");
-    if (error) error.textContent = "";
-    try {
-      hodlUseActiveKeyForBip85();
-      let session = document.getElementById("bip85-session");
-      if (session) session.textContent = hodlBip85Note;
-    } catch (exception) {
-      if (error) error.textContent = exception.message || String(exception);
-    }
-    hodlRefreshStationKeyPickers();
+    hodlPickBip85SessionKey(hodlKeys[hodlActiveKey]);
   };
   document.getElementById("bip85-wipe").onclick = () => {
     hodlBip85WipeParent();

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -642,6 +642,16 @@ hodlRootEl.innerHTML = `
         <button class="btn secondary" id="msig-edit-inputs" type="button">Edit input</button>
       </div>
       <div class="msig-lab" id="msig-lab">
+      <div class="station-key-source msig-station-key-source">
+        <p class="label">Bring in a key from Key Station</p>
+        <div class="session-key-picker" id="msig-session-keys" role="group" aria-label="Compatible Key Station keys" hidden></div>
+        <p class="field-note">Choose a compatible HD-root key from this session, or paste a co-signer extended public key below.</p>
+        <label class="choice msig-key-reuse-toggle">
+          <input id="msig-reuse-session-keys" type="checkbox">
+          <span><strong>Allow key reuse</strong><span class="desc">Keep selected Key Station keys available for more than one co-signer input.</span></span>
+        </label>
+        <p class="field-note" id="msig-session-key-status" aria-live="polite"></p>
+      </div>
       <div class="msig-threshold-labels">
         <label for="msig-m-number"><span>Signatures needed to spend (m)</span><input class="msig-threshold-number" id="msig-m-number" type="number" min="1" max="15" step="1" value="2" inputmode="numeric" aria-describedby="msig-threshold-help"></label>
         <label for="msig-n-number"><span>Total signing keys (n)</span><input class="msig-threshold-number" id="msig-n-number" type="number" min="1" max="15" step="1" value="3" inputmode="numeric" aria-describedby="msig-threshold-help"></label>
@@ -7047,10 +7057,6 @@ function hodlMsigKeyOriginFingerprint(value) {
 function hodlSyncMsigKeyAvatar(row) {
   if (!row) return;
   let ta = row.querySelector("textarea"), ident = row.querySelector(".msig-key-ident"), image = ident?.querySelector("img"), code = ident?.querySelector("code"), fingerprint = hodlMsigKeyOriginFingerprint(ta?.value);
-  row.querySelectorAll(".msig-session-key").forEach((button) => {
-    button.classList.toggle("active", Boolean(fingerprint) && button.dataset.fingerprint === fingerprint);
-    button.setAttribute("aria-pressed", String(button.classList.contains("active")));
-  });
   if (ident) ident.hidden = !fingerprint;
   if (code) code.textContent = fingerprint;
   if (image) {
@@ -7059,44 +7065,68 @@ function hodlSyncMsigKeyAvatar(row) {
     if (fingerprint) hodlFillKeyTabLifehash(image, fingerprint);
   }
 }
+var hodlMsigKeyTarget = null;
+function hodlMsigUsedSessionFingerprints() {
+  return new Set([...document.querySelectorAll("#msig-keys textarea")].map((textarea) => hodlMsigKeyOriginFingerprint(textarea.value)).filter(Boolean));
+}
+function hodlMsigNextKeyTarget() {
+  let inputs = [...document.querySelectorAll("#msig-keys textarea")];
+  if (hodlMsigKeyTarget?.isConnected && inputs.includes(hodlMsigKeyTarget)) return hodlMsigKeyTarget;
+  return inputs.find((textarea) => !textarea.value.trim()) || null;
+}
+function hodlPickMsigSessionKey(state) {
+  let target = hodlMsigNextKeyTarget(), status = document.getElementById("msig-session-key-status");
+  if (!target) {
+    if (status) status.textContent = "All co-signer inputs are filled. Focus or clear an input before choosing another key.";
+    return;
+  }
+  let value = hodlMatchingMsigExport(state.result);
+  if (!value) {
+    if (status) status.textContent = "That Key Station key has no compatible multisig export for the selected script type.";
+    return;
+  }
+  target.value = value;
+  target.dispatchEvent(new Event("input"));
+  let position = [...document.querySelectorAll("#msig-keys textarea")].indexOf(target) + 1;
+  if (status) status.textContent = `Added ${state.result?.masterFingerprint || state.name} to co-signer ${position}.`;
+  hodlMsigKeyTarget = [...document.querySelectorAll("#msig-keys textarea")].find((textarea) => !textarea.value.trim()) || null;
+  hodlRefreshMsigSessionPickers();
+}
 function hodlRefreshMsigSessionPickers() {
-  let keys = hodlSessionMsigKeys();
-  document.querySelectorAll(".msig-key-row").forEach((row) => {
-    let box = row.querySelector(".msig-session-keys"), ta = row.querySelector("textarea");
-    if (!box) return;
-    box.innerHTML = "";
-    box.hidden = !keys.length;
-    keys.forEach((state) => {
-      let fingerprint = state.result?.masterFingerprint || state.name, button = document.createElement("button"), image = document.createElement("img"), label = document.createElement("span");
-      button.type = "button";
-      button.className = "msig-session-key";
-      button.dataset.keyId = String(state.id);
-      button.dataset.fingerprint = fingerprint;
-      button.setAttribute("aria-pressed", "false");
-      button.setAttribute("aria-label", "Use session key " + fingerprint);
-      image.className = "key-tab-lifehash";
-      image.width = 22;
-      image.height = 22;
-      image.alt = "";
-      image.hidden = true;
-      if (fingerprint) hodlFillKeyTabLifehash(image, fingerprint);
-      label.textContent = fingerprint;
-      button.append(image, label);
-      button.onclick = () => {
-        if (!ta) return;
-        ta.value = hodlMatchingMsigExport(state.result);
-        ta.dispatchEvent(new Event("input"));
-      };
-      box.appendChild(button);
-    });
-    hodlSyncMsigKeyAvatar(row);
+  let box = document.getElementById("msig-session-keys"), status = document.getElementById("msig-session-key-status");
+  if (!box) return;
+  let keys = hodlSessionMsigKeys(), reuse = document.getElementById("msig-reuse-session-keys")?.checked, used = hodlMsigUsedSessionFingerprints(), available = reuse ? keys : keys.filter((state) => !used.has(state.result?.masterFingerprint || ""));
+  box.replaceChildren();
+  box.hidden = !available.length;
+  available.forEach((state) => {
+    let fingerprint = state.result?.masterFingerprint || state.name, button = document.createElement("button"), image = document.createElement("img"), label = document.createElement("span"), assigned = used.has(fingerprint);
+    button.type = "button";
+    button.className = "session-key-option" + (assigned ? " active" : "");
+    button.dataset.keyId = String(state.id);
+    button.dataset.fingerprint = fingerprint;
+    button.setAttribute("aria-pressed", String(assigned));
+    button.setAttribute("aria-label", `Add Key Station key ${fingerprint} to ${hodlMsigNextKeyTarget()?.id?.replace("msig-x-", "co-signer ") || "a co-signer input"}`);
+    image.className = "key-tab-lifehash";
+    image.width = 22;
+    image.height = 22;
+    image.alt = "";
+    image.hidden = true;
+    if (fingerprint) hodlFillKeyTabLifehash(image, fingerprint);
+    label.textContent = fingerprint;
+    button.append(image, label);
+    button.onclick = () => hodlPickMsigSessionKey(state);
+    box.appendChild(button);
   });
+  document.querySelectorAll(".msig-key-row").forEach(hodlSyncMsigKeyAvatar);
+  if (status && !status.textContent && keys.length && !available.length) status.textContent = "All compatible Key Station keys are assigned. Enable key reuse to keep them available.";
+  if (status && (!keys.length || available.length) && status.textContent.startsWith("All compatible")) status.textContent = "";
 }
 function hodlFillKeys(values) {
   let n = Number(document.getElementById("msig-n").value || 3),
     saved = Array.isArray(values) ? values : hodlReadMsigXpubs(),
     box = document.getElementById("msig-keys"),
     listed = !hodlMsigKeysSorted();
+  hodlMsigKeyTarget = null;
   box.classList.toggle("msig-keys-listed", listed);
   box.innerHTML = "";
   for (let i = 0; i < n; i++) {
@@ -7132,9 +7162,6 @@ function hodlFillKeys(values) {
     ta.autocomplete = "off";
     ta.spellcheck = false;
     ta.value = saved[i] || "";
-    let chips = document.createElement("div");
-    chips.className = "msig-session-keys";
-    chips.hidden = true;
     let ident = document.createElement("div");
     ident.className = "msig-key-ident";
     ident.hidden = true;
@@ -7148,7 +7175,7 @@ function hodlFillKeys(values) {
     identFp.className = "msig-key-ident-fp";
     ident.append(identImage, identFp);
     lab.append(ident, ta);
-    row.append(chips, lab);
+    row.append(lab);
     box.appendChild(row);
     ta.oninput = () => {
       ta.value = hodlFilterXpub(ta.value);
@@ -7157,7 +7184,14 @@ function hodlFillKeys(values) {
       hodlUpdateMsigKeyOrderStatus();
       hodlInvalidateMsig();
       hodlSyncMsigKeyAvatar(row);
+      hodlRefreshMsigSessionPickers();
     }
+    ta.addEventListener("focus", () => {
+      hodlMsigKeyTarget = ta;
+      let status = document.getElementById("msig-session-key-status");
+      if (status) status.textContent = `The next selected Key Station key will fill co-signer ${i + 1}.`;
+      hodlRefreshMsigSessionPickers();
+    });
   }
   hodlBindMsigKeyReorder(box);
   hodlSyncMsigKeyMoveButtons();
@@ -7168,6 +7202,7 @@ function hodlFillKeys(values) {
   hodlUpdateMsigHint();
   hodlUpdateMsigAccount();
   hodlUpdateMsigKeyOrderStatus();
+  hodlMsigKeyTarget = [...box.querySelectorAll("textarea")].find((textarea) => !textarea.value.trim()) || null;
   hodlRefreshMsigSessionPickers();
 }
 function hodlMultisigPrefixCompatible(parsed, kind, purpose) {
@@ -7248,6 +7283,9 @@ function hodlResetMsigForm() {
   hodlSetMsigPurpose(48);
   let legacy = document.getElementById("msig-legacy-bip87");
   if (legacy) legacy.checked = false;
+  let reuseSessionKeys = document.getElementById("msig-reuse-session-keys"), sessionStatus = document.getElementById("msig-session-key-status");
+  if (reuseSessionKeys) reuseSessionKeys.checked = false;
+  if (sessionStatus) sessionStatus.textContent = "";
   hodlUpdateMsigLegacyControls();
   hodlSyncSelect(document.getElementById("msig-key-order"), "sorted");
   let advanced = document.getElementById("msig-advanced");
@@ -7281,7 +7319,14 @@ function hodlInitMsig() {
     branchStartInput = document.getElementById("msig-branch-start"),
     addressStartInput = document.getElementById("msig-address-start"),
     legacy = document.getElementById("msig-legacy-bip87"),
+    reuseSessionKeys = document.getElementById("msig-reuse-session-keys"),
     keyOrder = document.getElementById("msig-key-order");
+  reuseSessionKeys?.addEventListener("change", () => {
+    let status = document.getElementById("msig-session-key-status");
+    if (status) status.textContent = reuseSessionKeys.checked ? "Selected Key Station keys remain available for every co-signer input." : "Each selected Key Station key is removed from the available list.";
+    hodlRefreshMsigSessionPickers();
+    hodlSyncMsigClearButton(true);
+  });
   script.addEventListener("change", () => {
     if (script.value !== "mixed") script.dataset.lastConcrete = script.value;
     hodlSetMsigPurpose(hodlStandardMsigPurpose(script.value));
@@ -10011,6 +10056,7 @@ function hodlNewMsigState(name, msigId, msigNumber) {
       purposeHarden: true,
       legacyBip87: !1,
       keyOrder: "sorted",
+      reuseSessionKeys: false,
       xpubs: ["", "", ""],
       coinType: "0",
       coinTypeHarden: true,
@@ -10156,7 +10202,7 @@ function hodlMsigStateNeedsClear(state) {
   let fields = state.fields || {},
     xpubs = Array.isArray(fields.xpubs) ? fields.xpubs : [];
   return Boolean(state.result) || String(state.error ?? "").length > 0 || xpubs.some(value => String(value ?? "").length > 0) ||
-    String(fields.m ?? "2") !== "2" || String(fields.n ?? "3") !== "3" || String(fields.script ?? "p2wsh") !== "p2wsh" || String(fields.purpose ?? "48") !== "48" || fields.purposeHarden === false || Boolean(fields.legacyBip87) || String(fields.keyOrder ?? "sorted") !== "sorted" || String(fields.coinType ?? (fields.network === "testnet" ? "1" : "0")) !== "0" || fields.coinTypeHarden === false || fields.accountHarden === false || String(fields.branchStart ?? "0") !== "0" || Boolean(fields.branchHarden) || String(fields.branchRange ?? "2") !== "2" || String(fields.addressStart ?? "0") !== "0" || Boolean(fields.addressHarden) || String(fields.addressRange ?? fields.count ?? "5") !== "5"
+    String(fields.m ?? "2") !== "2" || String(fields.n ?? "3") !== "3" || String(fields.script ?? "p2wsh") !== "p2wsh" || String(fields.purpose ?? "48") !== "48" || fields.purposeHarden === false || Boolean(fields.legacyBip87) || String(fields.keyOrder ?? "sorted") !== "sorted" || Boolean(fields.reuseSessionKeys) || String(fields.coinType ?? (fields.network === "testnet" ? "1" : "0")) !== "0" || fields.coinTypeHarden === false || fields.accountHarden === false || String(fields.branchStart ?? "0") !== "0" || Boolean(fields.branchHarden) || String(fields.branchRange ?? "2") !== "2" || String(fields.addressStart ?? "0") !== "0" || Boolean(fields.addressHarden) || String(fields.addressRange ?? fields.count ?? "5") !== "5"
 }
 
 function hodlSyncMsigClearButton(capture = !1) {
@@ -10175,6 +10221,7 @@ function hodlCaptureMsig() {
   state.fields.purpose = document.getElementById("msig-purpose")?.value || "48";
   state.fields.legacyBip87 = hodlSelectedLegacyMultisigStandard() === "bip87";
   state.fields.keyOrder = hodlMsigKeysSorted() ? "sorted" : "listed";
+  state.fields.reuseSessionKeys = Boolean(document.getElementById("msig-reuse-session-keys")?.checked);
   hodlMergeMsigXpubs(state);
   state.fields.coinType = document.getElementById("msig-network")?.value || "0";
   let hardening = hodlReadHardening("msig-");
@@ -10214,6 +10261,9 @@ function hodlRestoreMsig() {
   hodlUpdateMsigLegacyControls();
   state.fields.keyOrder = state.fields.keyOrder === "listed" ? "listed" : "sorted";
   hodlSyncSelect(document.getElementById("msig-key-order"), state.fields.keyOrder);
+  let reuseSessionKeys = document.getElementById("msig-reuse-session-keys"), sessionStatus = document.getElementById("msig-session-key-status");
+  if (reuseSessionKeys) reuseSessionKeys.checked = Boolean(state.fields.reuseSessionKeys);
+  if (sessionStatus) sessionStatus.textContent = "";
   let advanced = document.getElementById("msig-advanced");
   if (advanced) advanced.open = state.fields.keyOrder === "listed";
   state.fields.coinType = String(state.fields.coinType ?? (state.fields.network === "testnet" ? 1 : 0));

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -447,7 +447,7 @@ hodlRootEl.innerHTML = `
         <p class="muted calc-intro">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
       </div>
       <section class="key-manager no-print" id="key-manager">
-      <div class="key-tab-strip"><div class="key-tabs" id="key-tabs" role="tablist" aria-label="Keys"></div><div class="add-item-control"><button class="add-key" id="add-key" type="button" aria-label="Open the lab to derive another key" aria-describedby="add-key-tooltip">+</button><span class="add-item-tooltip" id="add-key-tooltip" role="tooltip">Open the lab to derive another key</span></div><div class="add-item-control"><button class="add-key remove-key" id="delete-key" type="button" aria-label="Delete current key" aria-describedby="delete-key-tooltip" disabled>−</button><span class="add-item-tooltip" id="delete-key-tooltip" role="tooltip">Delete this key</span></div></div>
+      <div class="key-tab-strip"><div class="key-tabs" id="key-tabs" role="tablist" aria-label="Keys"></div><div class="add-item-control"><button class="add-key" id="add-key" type="button" aria-label="Open Key Station to derive another key" aria-describedby="add-key-tooltip">+</button><span class="add-item-tooltip" id="add-key-tooltip" role="tooltip">Open Key Station to derive another key</span></div><div class="add-item-control"><button class="add-key remove-key" id="delete-key" type="button" aria-label="Delete current key" aria-describedby="delete-key-tooltip" disabled>−</button><span class="add-item-tooltip" id="delete-key-tooltip" role="tooltip">Delete this key</span></div></div>
     </section>
     <section class="card no-print" id="calc-card" role="tabpanel" hidden>
       <div class="row segmented-control" id="modes" role="group" aria-label="Key input mode"></div>
@@ -559,14 +559,23 @@ hodlRootEl.innerHTML = `
       </div>
       <div id="out"></div>
     </section>
-    <div class="tool-intro" id="bip85-tool-intro" hidden>
+      <div class="tool-intro" id="bip85-tool-intro" hidden>
         <div class="kicker">One seed. Many children.</div>
         <h2>Derive BIP-85 child entropy</h2>
-        <p class="muted bip85-intro">Deterministic child seeds, keys, and passwords from the active key's BIP32 root. Same parent, application, and index always reproduce the same child. This does not invent entropy \u2014 it is a calculator. English BIP-39 children match COLDCARD.</p>
+        <p class="muted bip85-intro">Deterministic child seeds, keys, and passwords from a Key Station BIP32 root. Same parent, application, and index always reproduce the same child. This does not invent entropy \u2014 it is a calculator. English BIP-39 children match COLDCARD.</p>
       </div>
+      <section class="key-manager no-print" id="bip85-manager" hidden>
+        <div class="key-tab-strip"><div class="key-tabs" id="bip85-tabs" role="tablist" aria-label="BIP-85 child seeds"></div><div class="add-item-control"><button class="add-key" id="add-bip85" type="button" aria-label="Open BIP-85 Station to derive another child" aria-describedby="add-bip85-tooltip">+</button><span class="add-item-tooltip" id="add-bip85-tooltip" role="tooltip">Open BIP-85 Station</span></div><div class="add-item-control"><button class="add-key remove-key" id="delete-bip85" type="button" aria-label="Delete current BIP-85 child" aria-describedby="delete-bip85-tooltip" disabled>\u2212</button><span class="add-item-tooltip" id="delete-bip85-tooltip" role="tooltip">Delete this BIP-85 child</span></div></div>
+      </section>
       <section class="card no-print" id="bip85-card" role="tabpanel" hidden>
-      <label class="field">Optional root xprv (leave blank to use the active key)
-        <textarea id="bip85-key" placeholder="xprv\u2026 or leave blank to use the active key" spellcheck="false" autocomplete="off" autocapitalize="off"></textarea>
+      <div class="bip85-bench" id="bip85-bench">
+      <div class="station-key-source">
+        <p class="label">Bring in a key from Key Station</p>
+        <div class="session-key-picker" id="bip85-session-keys" role="group" aria-label="Compatible Key Station keys" hidden></div>
+        <p class="field-note">Choose a compatible HD-root key from this session, or paste a root extended private key below.</p>
+      </div>
+      <label class="field">Root xprv (optional)
+        <textarea id="bip85-key" placeholder="Paste a root xprv or tprv" spellcheck="false" autocomplete="off" autocapitalize="off"></textarea>
       </label>
       <div class="bip85-grid">
         <label class="field">Application
@@ -607,11 +616,11 @@ hodlRootEl.innerHTML = `
       <p class="muted bip85-path-row">Path <code id="bip85-path">m/83696968'/39'/0'/24'/0'</code></p>
       <div class="row bip85-actions">
         <button class="btn primary" id="bip85-go" type="button">Derive child</button>
-        <button class="btn secondary" id="bip85-use-calc" type="button">Use active key</button>
-        <button class="btn secondary" id="bip85-wipe" type="button">Clear derived child</button>
+        <button class="btn secondary" id="bip85-wipe" type="button">Clear parent session</button>
       </div>
-      <p class="muted" id="bip85-session" aria-live="polite">No parent loaded. Derive a key first, or paste a root xprv.</p>
+      <p class="muted" id="bip85-session" aria-live="polite">No parent loaded. Choose a Key Station key, or paste a root xprv.</p>
       <p class="err" id="bip85-error" role="alert"></p>
+      </div>
       <div id="bip85-out" aria-live="polite"></div>
       <p class="muted">Derived children remain in this page only. Anyone with the parent seed, passphrase, application, and index can reproduce them. Memory clearing is best-effort; close the page before reconnecting the computer.</p>
     </section>
@@ -621,7 +630,7 @@ hodlRootEl.innerHTML = `
         <p class="muted msig-intro">Combine extended public keys into a multisignature wallet. Paste each key origin and extended public key as exported by its signer: <span class="mono">[fingerprint/48h/0h/0h/2h]xpub\u2026</span>. Private keys are not needed. The derived addresses can receive bitcoin, and spending requires the configured number of signatures.</p>
       </div>
       <section class="key-manager no-print" id="msig-manager" hidden>
-      <div class="key-tab-strip"><div class="key-tabs" id="msig-tabs" role="tablist" aria-label="Multisigs"></div><div class="add-item-control"><button class="add-key" id="add-msig" type="button" aria-label="Open the lab to derive another multisig" aria-describedby="add-msig-tooltip">+</button><span class="add-item-tooltip" id="add-msig-tooltip" role="tooltip">Open the lab to derive another multisig</span></div><div class="add-item-control"><button class="add-key remove-key" id="delete-msig" type="button" aria-label="Delete current multisig" aria-describedby="delete-msig-tooltip" disabled>−</button><span class="add-item-tooltip" id="delete-msig-tooltip" role="tooltip">Delete this multisig</span></div></div>
+      <div class="key-tab-strip"><div class="key-tabs" id="msig-tabs" role="tablist" aria-label="Multisigs"></div><div class="add-item-control"><button class="add-key" id="add-msig" type="button" aria-label="Open MS Station to derive another multisig" aria-describedby="add-msig-tooltip">+</button><span class="add-item-tooltip" id="add-msig-tooltip" role="tooltip">Open MS Station</span></div><div class="add-item-control"><button class="add-key remove-key" id="delete-msig" type="button" aria-label="Delete current multisig" aria-describedby="delete-msig-tooltip" disabled>−</button><span class="add-item-tooltip" id="delete-msig-tooltip" role="tooltip">Delete this multisig</span></div></div>
     </section>
     <section class="card no-print" id="msig-card" role="tabpanel" hidden>
       <div class="key-summary" id="msig-summary" hidden>
@@ -725,15 +734,23 @@ hodlRootEl.innerHTML = `
         <h2>Silent Payments</h2>
         <p class="muted tool-intro-note">A calculator, not a chain scanner. Derive a reusable <code>sp1q…</code> address from your seed, compute the unique taproot output a sender must pay, or check pasted outputs against your scan key. Nothing here talks to the network.</p>
       </div>
+      <section class="key-manager no-print" id="sp-manager" hidden>
+        <div class="key-tab-strip"><div class="key-tabs" id="sp-tabs" role="tablist" aria-label="Silent Payments"></div></div>
+      </section>
       <section class="card no-print" id="sp-card" role="tabpanel" hidden>
       <div class="row no-print segmented-control" id="sp-modes">
         <button class="tab active" type="button" data-sp-mode="receive" aria-pressed="true">Receive</button>
         <button class="tab" type="button" data-sp-mode="send" aria-pressed="false">Send</button>
         <button class="tab" type="button" data-sp-mode="verify" aria-pressed="false">Verify</button>
       </div>
+      <div class="station-key-source">
+        <p class="label">Bring in a key from Key Station</p>
+        <div class="session-key-picker" id="sp-session-keys" role="group" aria-label="Compatible Key Station keys" hidden></div>
+        <p class="field-note">Choose a compatible HD-root key from this session, or enter a seed phrase or root extended private key below.</p>
+      </div>
       <div class="psbt-grid">
         <label class="field">Session key (BIP39 seed phrase or root xprv/tprv)
-          <textarea id="sp-key" placeholder="Leave blank and use the active key, or paste a seed / root xprv" spellcheck="false" autocomplete="off" autocapitalize="off"></textarea>
+          <textarea id="sp-key" placeholder="Enter a seed phrase or root xprv/tprv" spellcheck="false" autocomplete="off" autocapitalize="off"></textarea>
         </label>
         <div>
           <label class="field">Optional BIP39 passphrase
@@ -748,7 +765,6 @@ hodlRootEl.innerHTML = `
         </div>
       </div>
       <div class="row psbt-actions">
-        <button class="btn secondary" id="sp-use-calc" type="button">Use active key this session</button>
         <button class="btn secondary" id="sp-wipe" type="button">End session / clear fields</button>
       </div>
       <p class="muted" id="sp-session" aria-live="polite">No session key. Receive and verify need a seed or root xprv.</p>
@@ -6983,6 +6999,38 @@ function hodlMsigScriptOrder(keyTokens) {
 function hodlSessionMsigKeys() {
   return hodlKeys.filter((state) => !state.isLab && state.result?.multisigCosignerExports?.length);
 }
+function hodlSessionHdRootKeys() {
+  return hodlKeys.filter((state) => !state.isLab && state.result?.kind === "hd" && (state.result.mnemonic || state.result.rootXprv));
+}
+function hodlFillStationKeyPicker(id, selectedSource, onSelect) {
+  let box = document.getElementById(id);
+  if (!box) return;
+  let keys = hodlSessionHdRootKeys();
+  box.replaceChildren();
+  box.hidden = !keys.length;
+  keys.forEach((state) => {
+    let fingerprint = state.result?.masterFingerprint || state.name || "Key " + state.number, button = document.createElement("button"), image = document.createElement("img"), label = document.createElement("span"), selected = selectedSource === "key:" + state.id;
+    button.type = "button";
+    button.className = "session-key-option" + (selected ? " active" : "");
+    button.dataset.keyId = String(state.id);
+    button.setAttribute("aria-pressed", String(selected));
+    button.setAttribute("aria-label", "Bring in Key Station key " + fingerprint);
+    image.className = "key-tab-lifehash";
+    image.width = 22;
+    image.height = 22;
+    image.alt = "";
+    image.hidden = true;
+    hodlFillKeyTabLifehash(image, fingerprint);
+    label.textContent = fingerprint;
+    button.append(image, label);
+    button.onclick = () => onSelect(state);
+    box.appendChild(button);
+  });
+}
+function hodlRefreshStationKeyPickers() {
+  hodlFillStationKeyPicker("bip85-session-keys", hodlBip85Source, hodlPickBip85SessionKey);
+  hodlFillStationKeyPicker("sp-session-keys", hodlSpSource, hodlPickSpSessionKey);
+}
 function hodlMatchingMsigExport(result) {
   if (!result?.multisigCosignerExports?.length) return "";
   let kind = hodlScriptKind(), purpose = hodlReadMsigPurpose(), exports = result.multisigCosignerExports;
@@ -8053,11 +8101,8 @@ function hodlInitPsbt() {
     if (event.persisted) clearSecretFields();
   });
 }
-var hodlBip85Root = null, hodlBip85Note = "No parent loaded. Derive a key first, or paste a root xprv.", hodlBip85Source = "", hodlBip85Result = null, hodlBip85Reveal = false, hodlBip85Testnet = false;
-function hodlBip85WipeMem() {
-  wipeBip85Result(hodlBip85Result);
-  hodlBip85Result = null;
-  hodlBip85Reveal = false;
+var hodlBip85Root = null, hodlBip85Note = "No parent loaded. Choose a Key Station key, or paste a root xprv.", hodlBip85Source = "", hodlBip85Result = null, hodlBip85Reveal = false, hodlBip85Testnet = false, hodlBip85Children = [], hodlActiveBip85 = -1, hodlNextBip85ChildId = 1;
+function hodlBip85WipeParent() {
   if (hodlBip85Root) try {
     hodlBip85Root.wipePrivateData();
   } catch {
@@ -8065,7 +8110,75 @@ function hodlBip85WipeMem() {
   hodlBip85Root = null;
   hodlBip85Source = "";
   hodlBip85Testnet = false;
-  hodlBip85Note = "No parent loaded. Derive a key first, or paste a root xprv.";
+  hodlBip85Note = "No parent loaded. Choose a Key Station key, or paste a root xprv.";
+}
+function hodlBip85WipeMem() {
+  let wiped = /* @__PURE__ */ new Set();
+  for (let state of hodlBip85Children) {
+    if (!state.result || wiped.has(state.result)) continue;
+    wipeBip85Result(state.result);
+    wiped.add(state.result);
+  }
+  if (hodlBip85Result && !wiped.has(hodlBip85Result)) wipeBip85Result(hodlBip85Result);
+  hodlBip85Result = null;
+  hodlBip85Reveal = false;
+  hodlBip85Children = [hodlNewBip85BenchState()];
+  hodlActiveBip85 = 0;
+  hodlNextBip85ChildId = 1;
+  if (hodlBip85Root) try {
+    hodlBip85Root.wipePrivateData();
+  } catch {
+  }
+  hodlBip85Root = null;
+  hodlBip85Source = "";
+  hodlBip85Testnet = false;
+  hodlBip85Note = "No parent loaded. Choose a Key Station key, or paste a root xprv.";
+}
+function hodlNewBip85BenchState() {
+  return { isLab: true, id: 0, name: "BIP-85 Station", result: null, reveal: false, fingerprint: "", fingerprintKind: "" };
+}
+function hodlBip85ActiveState() {
+  return hodlBip85Children[hodlActiveBip85] || null;
+}
+function hodlBip85AppLabel(app) {
+  if (app === "bip39") return "BIP-39";
+  if (app === "wif") return "WIF";
+  if (app === "xprv") return "XPRV";
+  if (app === "hex") return "HEX";
+  if (app === "pwd-base64") return "Base64 password";
+  if (app === "pwd-base85") return "Base85 password";
+  return "BIP-85 child";
+}
+function hodlBip85ChildFingerprint(result) {
+  let seed = null, node = null, payload = null, privateKey = null, digest = null;
+  try {
+    if (result.app === "bip39") {
+      seed = hodlMnemonicToSeed(result.secret, "");
+      node = hodlHDKey.fromMasterSeed(seed);
+      return { value: hodlFingerprintHex(node.fingerprint), kind: "master" };
+    }
+    if (result.app === "xprv") {
+      node = hodlHDKey.fromExtendedKey(hodlParseExtendedKey(result.secret).xkey);
+      return { value: hodlFingerprintHex(node.fingerprint), kind: "master" };
+    }
+    if (result.app === "wif") {
+      payload = hodlBase58Check.decode(result.secret);
+      privateKey = payload.slice(1, 33);
+      node = new hodlHDKey({ privateKey });
+      return { value: hodlFingerprintHex(node.fingerprint), kind: "key" };
+    }
+    digest = hodlSha256(result.entropy);
+    return { value: hodlHex.encode(digest.slice(0, 4)), kind: "child" };
+  } finally {
+    if (node) try {
+      node.wipePrivateData();
+    } catch {
+    }
+    hodlWipeBytes(seed);
+    hodlWipeBytes(payload);
+    hodlWipeBytes(privateKey);
+    hodlWipeBytes(digest);
+  }
 }
 function hodlBip85PrivateValue(value) {
   let mask = "************", text = String(value ?? "\u2014");
@@ -8119,17 +8232,16 @@ function hodlBip85LoadXprv(text) {
   if (!isPrivate) throw new Error("BIP-85 needs a private root (xprv/tprv), not an extended public key.");
   let node = hodlHDKey.fromExtendedKey(xkey);
   if (node.depth !== 0) throw new Error("BIP-85 starts at the BIP32 root. This extended key is not depth 0.");
-  hodlBip85WipeMem();
+  hodlBip85WipeParent();
   hodlBip85Root = node;
   hodlBip85Testnet = /^[tuvn]prv/i.test(value);
   hodlBip85Source = "manual";
   hodlBip85Note = "Parent: pasted root " + (hodlBip85Testnet ? "tprv" : "xprv") + ". Kept in page memory only.";
 }
-function hodlUseActiveKeyForBip85() {
-  let state = hodlKeys[hodlActiveKey];
-  if (!state || !state.result) throw new Error("Derive an active key first, then return to BIP-85.");
+function hodlUseKeyForBip85(state) {
+  if (!state || !state.result) throw new Error("Derive a key in Key Station first, then return to BIP-85 Station.");
   let result = state.result;
-  hodlBip85WipeMem();
+  hodlBip85WipeParent();
   if (result.kind === "hd" && result.mnemonic) {
     let seed = hodlMnemonicToSeed(result.mnemonic, state.fields.pass || "");
     try {
@@ -8138,14 +8250,29 @@ function hodlUseActiveKeyForBip85() {
       hodlWipeBytes(seed);
     }
     hodlBip85Testnet = false;
-    hodlBip85Note = "Parent: " + (state.name || "the active key") + (result.passphraseUsed || (state.fields.pass || "").length ? " with BIP-39 passphrase (COLDCARD does the same \u2014 children differ without it)." : ".") + " Kept in page memory only.";
+    hodlBip85Note = "Parent: " + (state.name || "Key Station key") + (result.passphraseUsed || (state.fields.pass || "").length ? " with BIP-39 passphrase (COLDCARD does the same \u2014 children differ without it)." : ".") + " Kept in page memory only.";
   } else if (result.kind === "hd" && result.rootXprv) {
     hodlBip85Root = hodlHDKey.fromExtendedKey(hodlParseExtendedKey(result.rootXprv).xkey);
     hodlBip85Testnet = result.network === "testnet";
-    hodlBip85Note = "Parent: root xprv from " + (state.name || "the active key") + ". Kept in page memory only.";
-  } else if (result.kind === "hd") throw new Error("The active key is not a BIP32 root. Import the original seed or root xprv.");
-  else throw new Error("BIP-85 needs an HD root. The active key is a single private key.");
-  hodlBip85Source = "active";
+    hodlBip85Note = "Parent: root xprv from " + (state.name || "Key Station key") + ". Kept in page memory only.";
+  } else if (result.kind === "hd") throw new Error("This Key Station key is not a BIP32 root. Import the original seed or root xprv.");
+  else throw new Error("BIP-85 needs an HD root. This Key Station key is a single private key.");
+  hodlBip85Source = "key:" + state.id;
+}
+function hodlUseActiveKeyForBip85() {
+  hodlUseKeyForBip85(hodlKeys[hodlActiveKey]);
+}
+function hodlPickBip85SessionKey(state) {
+  let error = document.getElementById("bip85-error");
+  if (error) error.textContent = "";
+  try {
+    hodlUseKeyForBip85(state);
+    document.getElementById("bip85-key").value = "";
+    document.getElementById("bip85-session").textContent = hodlBip85Note;
+  } catch (exception) {
+    if (error) error.textContent = exception.message || String(exception);
+  }
+  hodlRefreshStationKeyPickers();
 }
 function hodlCopyBip85Child(button) {
   let phrase = button?.dataset.phrase;
@@ -8178,11 +8305,14 @@ function hodlCopyBip85Child(button) {
 function hodlRenderBip85Out() {
   let box = document.getElementById("bip85-out");
   if (!box) return;
-  if (!hodlBip85Result) {
+  let state = hodlBip85ActiveState();
+  hodlBip85Result = state?.result || null;
+  if (!hodlBip85Result || state?.isLab) {
     box.innerHTML = "";
     return;
   }
   let derived = hodlBip85Result, notes = [...derived.notes || [], ...derived.warnings || []].map((message) => `<li>${hodlEscapeHtml(message)}</li>`).join("");
+  let fingerprintLabel = state.fingerprintKind === "master" ? "Master fingerprint" : state.fingerprintKind === "key" ? "Key fingerprint" : "Child fingerprint";
   box.innerHTML = `<section class="wallet-data-section wallet-private-section" aria-labelledby="bip85-private-heading">
       <div class="wallet-data-section-head">
         <h3 id="bip85-private-heading">Derived child</h3>
@@ -8197,6 +8327,7 @@ function hodlRenderBip85Out() {
       </div>
       <div class="wallet-data-fields">
         ${hodlPublicFieldHtml("Path", derived.path)}
+        ${hodlPublicFieldHtml(fingerprintLabel, state.fingerprint)}
         ${hodlBip85SecretField(derived.secretLabel, derived.secret)}
         ${hodlBip85SecretField("Derived entropy", derived.entropyHex)}
       </div>
@@ -8204,6 +8335,7 @@ function hodlRenderBip85Out() {
     </section>`;
   document.getElementById("bip85-reveal")?.addEventListener("change", (event) => {
     hodlBip85Reveal = event.target.checked;
+    state.reveal = hodlBip85Reveal;
     hodlRenderBip85Out();
     requestAnimationFrame(() => document.getElementById("bip85-reveal")?.focus({ preventScroll: true }));
   });
@@ -8213,26 +8345,148 @@ function hodlRenderBip85Out() {
     copy.onclick = () => hodlCopyBip85Child(copy);
   }
 }
+function hodlCreateBip85Tab(index) {
+  let state = hodlBip85Children[index], active = index === hodlActiveBip85, button = document.createElement("button"), label = document.createElement("span"), name = state.isLab ? "BIP-85 Station" : state.fingerprint;
+  button.type = "button";
+  button.id = state.isLab ? "bip85-tab-lab" : "bip85-tab-" + state.id;
+  button.className = "tab key-tab bip85-tab" + (state.isLab ? " is-lab" : "") + (active ? " active" : "");
+  label.className = "key-tab-label";
+  label.textContent = name;
+  if (state.isLab) button.append(hodlCreateBip85BenchIcon(), label);
+  else {
+    let image = document.createElement("img");
+    image.className = "key-tab-lifehash";
+    image.width = 22;
+    image.height = 22;
+    image.alt = "";
+    image.hidden = true;
+    hodlFillKeyTabLifehash(image, state.fingerprint);
+    button.append(image, label);
+  }
+  button.setAttribute("role", "tab");
+  button.setAttribute("aria-controls", "bip85-card");
+  button.setAttribute("aria-selected", String(active));
+  if (state.isLab) {
+    button.setAttribute("aria-label", "BIP-85 Station" + (active ? ", selected" : ". Activate to derive a BIP-85 child."));
+    button.title = "Derive a BIP-85 child";
+  } else {
+    let kind = state.fingerprintKind === "master" ? "master fingerprint" : state.fingerprintKind === "key" ? "key fingerprint" : "child fingerprint";
+    button.setAttribute("aria-label", `${hodlBip85AppLabel(state.result?.app)} ${kind} ${name}${active ? ", selected" : ". Activate to select."}`);
+    button.title = `${hodlBip85AppLabel(state.result?.app)} · ${state.result?.path || ""}`;
+  }
+  button.onclick = () => hodlSelectBip85(index);
+  button.tabIndex = active ? 0 : -1;
+  button.onkeydown = (event) => hodlBip85TabKeydown(event, index);
+  return button;
+}
+function hodlSyncBip85DeleteButton() {
+  let button = document.getElementById("delete-bip85"), state = hodlBip85ActiveState();
+  if (!button) return;
+  button.disabled = !state || state.isLab;
+  button.setAttribute("aria-disabled", String(button.disabled));
+}
+function hodlRenderBip85Tabs() {
+  let box = document.getElementById("bip85-tabs"), panel = document.getElementById("bip85-card");
+  if (!box || !panel) return;
+  box.innerHTML = "";
+  panel.removeAttribute("aria-labelledby");
+  hodlBip85Children.forEach((state, index) => {
+    let button = hodlCreateBip85Tab(index);
+    box.appendChild(button);
+    if (index === hodlActiveBip85) panel.setAttribute("aria-labelledby", button.id);
+  });
+  hodlRevealTab(box, hodlActiveBip85);
+  hodlSyncBip85DeleteButton();
+}
+function hodlSyncBip85View() {
+  let state = hodlBip85ActiveState(), bench = document.getElementById("bip85-bench"), card = document.getElementById("bip85-card");
+  if (bench) bench.hidden = !state?.isLab;
+  if (card) card.classList.toggle("is-result-view", Boolean(state && !state.isLab));
+  hodlBip85Result = state?.result || null;
+  hodlBip85Reveal = Boolean(state?.reveal);
+  hodlRenderBip85Out();
+}
+function hodlSelectBip85(index) {
+  if (!hodlBip85Children[index]) return;
+  hodlActiveBip85 = index;
+  hodlRenderBip85Tabs();
+  hodlSyncBip85View();
+}
+function hodlSelectBip85Bench() {
+  let index = hodlBip85Children.findIndex((state) => state.isLab);
+  if (index < 0) {
+    hodlBip85Children.unshift(hodlNewBip85BenchState());
+    index = 0;
+    if (hodlActiveBip85 >= 0) hodlActiveBip85 += 1;
+  }
+  hodlSelectBip85(index);
+}
+function hodlDeleteActiveBip85() {
+  let state = hodlBip85ActiveState();
+  if (!state || state.isLab) {
+    hodlSyncBip85DeleteButton();
+    return;
+  }
+  let deletedIndex = hodlActiveBip85;
+  hodlBip85Result = null;
+  wipeBip85Result(state.result);
+  hodlBip85Children.splice(deletedIndex, 1);
+  if (!hodlBip85Children.length) hodlBip85Children.push(hodlNewBip85BenchState());
+  hodlActiveBip85 = Math.min(deletedIndex, hodlBip85Children.length - 1);
+  hodlRenderBip85Tabs();
+  hodlSyncBip85View();
+  document.getElementById("bip85-tabs")?.children[hodlActiveBip85]?.focus();
+}
+function hodlBip85TabKeydown(event, index) {
+  let next = null, length = hodlBip85Children.length;
+  if (event.key === "ArrowRight") next = (index + 1) % length;
+  else if (event.key === "ArrowLeft") next = (index - 1 + length) % length;
+  else if (event.key === "Home") next = 0;
+  else if (event.key === "End") next = length - 1;
+  if (next === null) return;
+  event.preventDefault();
+  hodlSelectBip85(next);
+  document.getElementById("bip85-tabs")?.children[next]?.focus();
+}
 function hodlRunBip85() {
   let error = document.getElementById("bip85-error"), session = document.getElementById("bip85-session"), manual = document.getElementById("bip85-key")?.value || "";
+  let result = null;
   if (error) error.textContent = "";
   try {
     if (manual.trim()) {
       hodlBip85LoadXprv(manual);
       document.getElementById("bip85-key").value = "";
-    } else if (!hodlBip85Root) hodlUseActiveKeyForBip85();
-    wipeBip85Result(hodlBip85Result);
-    hodlBip85Result = deriveApplication(hodlBip85Root, hodlBip85Spec());
+    } else if (!hodlBip85Root) throw new Error("Choose a compatible Key Station key, or paste a root xprv/tprv.");
+    result = deriveApplication(hodlBip85Root, hodlBip85Spec());
+    let fingerprint = hodlBip85ChildFingerprint(result);
+    let state = { isLab: false, id: hodlNextBip85ChildId++, name: fingerprint.value, result, reveal: false, fingerprint: fingerprint.value, fingerprintKind: fingerprint.kind };
+    hodlBip85Children.push(state);
+    hodlActiveBip85 = hodlBip85Children.length - 1;
+    hodlBip85Result = state.result;
+    result = null;
     hodlBip85Reveal = false;
     if (session) session.textContent = hodlBip85Note;
-    hodlRenderBip85Out();
+    hodlRenderBip85Tabs();
+    hodlSyncBip85View();
   } catch (exception) {
+    wipeBip85Result(result);
     if (error) error.textContent = exception.message || String(exception);
   }
+  hodlRefreshStationKeyPickers();
 }
 function hodlInitBip85() {
   let go = document.getElementById("bip85-go");
   if (!go) return;
+  if (!hodlBip85Children.length) {
+    hodlBip85Children.push(hodlNewBip85BenchState());
+    hodlActiveBip85 = 0;
+  }
+  document.getElementById("add-bip85").onclick = hodlSelectBip85Bench;
+  document.getElementById("delete-bip85").onclick = hodlDeleteActiveBip85;
+  hodlInitTabDrag(document.getElementById("bip85-tabs"));
+  hodlRenderBip85Tabs();
+  hodlSyncBip85View();
+  hodlRefreshStationKeyPickers();
   go.onclick = hodlRunBip85;
   // Entry point beside Derive Wallet (idea adopted from PR #150): jump to the
   // BIP-85 tab with the active key loaded as parent. Errors land in the tab's
@@ -8240,6 +8494,7 @@ function hodlInitBip85() {
   let open = document.getElementById("bip85-open");
   if (open) open.onclick = () => {
     hodlShowWorkspace("bip85");
+    hodlSelectBip85Bench();
     let error = document.getElementById("bip85-error");
     if (error) error.textContent = "";
     try {
@@ -8249,24 +8504,14 @@ function hodlInitBip85() {
     } catch (exception) {
       if (error) error.textContent = exception.message || String(exception);
     }
-  };
-  document.getElementById("bip85-use-calc").onclick = () => {
-    let error = document.getElementById("bip85-error");
-    if (error) error.textContent = "";
-    try {
-      hodlUseActiveKeyForBip85();
-      document.getElementById("bip85-key").value = "";
-      document.getElementById("bip85-session").textContent = hodlBip85Note;
-    } catch (exception) {
-      if (error) error.textContent = exception.message || String(exception);
-    }
+    hodlRefreshStationKeyPickers();
   };
   document.getElementById("bip85-wipe").onclick = () => {
-    hodlBip85WipeMem();
+    hodlBip85WipeParent();
     document.getElementById("bip85-key").value = "";
-    document.getElementById("bip85-out").innerHTML = "";
     document.getElementById("bip85-error").textContent = "";
-    document.getElementById("bip85-session").textContent = "Derived child and parent session were cleared (best effort).";
+    document.getElementById("bip85-session").textContent = "Parent session cleared (best effort). Derived child tabs remain until deleted.";
+    hodlRefreshStationKeyPickers();
   };
   for (let id of ["bip85-app", "bip85-index", "bip85-words", "bip85-bytes", "bip85-pwdlen"]) {
     document.getElementById(id)?.addEventListener("input", hodlBip85SyncOptions);
@@ -8293,7 +8538,7 @@ function hodlRunPsbt() {
   }
 }
 
-var hodlSpHd = null, hodlSpKeys = null, hodlSpNote = "No session key. Receive and verify need a seed or root xprv.", hodlSpMode = "receive", hodlSpReveal = false;
+var hodlSpHd = null, hodlSpKeys = null, hodlSpNote = "No session key. Receive and verify need a seed or root xprv.", hodlSpMode = "receive", hodlSpReveal = false, hodlSpSource = "";
 function hodlSpWipeKeys() {
   if (hodlSpKeys) {
     try { hodlSpKeys.scanPriv && hodlSpKeys.scanPriv.fill(0); } catch {}
@@ -8304,6 +8549,7 @@ function hodlSpWipeKeys() {
     try { hodlSpHd.wipePrivateData(); } catch {}
   }
   hodlSpHd = null;
+  hodlSpSource = "";
   hodlSpNote = "No session key. Receive and verify need a seed or root xprv.";
 }
 function hodlSpWipeMem() {
@@ -8330,6 +8576,7 @@ function hodlSpLoadKey(text, passphrase) {
     if (!parsed.isPrivate) throw new Error("Watch-only extended keys cannot derive BIP-352 scan/spend paths.");
     if (parsed.node.depth !== 0) throw new Error("Silent Payments needs a BIP32 root private key (depth 0), not an account xprv.");
     hodlSpHd = parsed.node;
+    hodlSpSource = "manual";
     hodlSpNote = `Session key: root ${parsed.prefix}. Kept in page memory only.`;
     return;
   }
@@ -8341,21 +8588,35 @@ function hodlSpLoadKey(text, passphrase) {
   } finally {
     seed.fill(0);
   }
+  hodlSpSource = "manual";
   hodlSpNote = "Session key: BIP39 seed" + (passphrase ? " + passphrase" : "") + ". Kept in page memory only.";
 }
-function hodlSpUseActiveKey() {
-  let state = hodlKeys[hodlActiveKey];
-  if (!state || !state.result) throw new Error("Generate an active key first, then return to Silent Payments.");
+function hodlSpUseKey(state) {
+  if (!state || !state.result) throw new Error("Derive a key in Key Station first, then return to SP Station.");
   let result = state.result;
   hodlSpWipeKeys();
   if (result.kind === "hd" && result.mnemonic) {
     let seed = hodlMnemonicToSeed(result.mnemonic, state.fields.pass || "");
     try { hodlSpHd = hodlHDKey.fromMasterSeed(seed); } finally { seed.fill(0); }
-    hodlSpNote = "Session key from " + (state.name || "the active key") + " (BIP39 seed). Kept in page memory only.";
+    hodlSpNote = "Session key from " + (state.name || "Key Station key") + " (BIP39 seed). Kept in page memory only.";
   } else if (result.kind === "hd" && result.rootXprv) {
     hodlSpHd = hodlHDKey.fromExtendedKey(hodlParseExtendedKey(result.rootXprv).xkey);
-    hodlSpNote = "Session key from " + (state.name || "the active key") + " (root xprv). Kept in page memory only.";
-  } else throw new Error("Silent Payments needs the active key's seed or root xprv. Account-level and single keys cannot derive m/352'.");
+    hodlSpNote = "Session key from " + (state.name || "Key Station key") + " (root xprv). Kept in page memory only.";
+  } else throw new Error("SP Station needs the Key Station key's seed or root xprv. Account-level and single keys cannot derive m/352'.");
+  hodlSpSource = "key:" + state.id;
+}
+function hodlPickSpSessionKey(state) {
+  let error = document.getElementById("sp-error");
+  if (error) error.textContent = "";
+  try {
+    hodlSpUseKey(state);
+    document.getElementById("sp-key").value = "";
+    document.getElementById("sp-pass").value = "";
+    document.getElementById("sp-session").textContent = hodlSpNote;
+  } catch (exception) {
+    if (error) error.textContent = exception.message || String(exception);
+  }
+  hodlRefreshStationKeyPickers();
 }
 function hodlSpEnsureHd() {
   let manual = document.getElementById("sp-key")?.value;
@@ -8363,8 +8624,9 @@ function hodlSpEnsureHd() {
     hodlSpLoadKey(manual, document.getElementById("sp-pass")?.value);
     document.getElementById("sp-key").value = "";
     document.getElementById("sp-pass").value = "";
+    hodlRefreshStationKeyPickers();
   }
-  if (!hodlSpHd || !hodlSpHd.privateKey) throw new Error("Load a BIP39 seed or root xprv first (or use the active key).");
+  if (!hodlSpHd || !hodlSpHd.privateKey) throw new Error("Choose a compatible Key Station key, or enter a BIP39 seed or root xprv.");
   document.getElementById("sp-session").textContent = hodlSpNote;
 }
 function hodlSpDeriveSessionKeys() {
@@ -8544,23 +8806,13 @@ function hodlRunSp() {
 }
 function hodlInitSp() {
   if (!document.getElementById("sp-card")) return;
+  hodlRefreshStationKeyPickers();
   document.querySelectorAll("#sp-modes [data-sp-mode]").forEach((button) => {
     button.onclick = () => { hodlSpSetMode(button.dataset.spMode); document.getElementById("sp-out").innerHTML = ""; document.getElementById("sp-error").textContent = ""; };
   });
   document.getElementById("sp-derive").onclick = () => { hodlSpMode = "receive"; hodlRunSp(); };
   document.getElementById("sp-send-go").onclick = () => { hodlSpMode = "send"; hodlRunSp(); };
   document.getElementById("sp-verify-go").onclick = () => { hodlSpMode = "verify"; hodlRunSp(); };
-  document.getElementById("sp-use-calc").onclick = () => {
-    document.getElementById("sp-error").textContent = "";
-    try {
-      hodlSpUseActiveKey();
-      document.getElementById("sp-key").value = "";
-      document.getElementById("sp-pass").value = "";
-      document.getElementById("sp-session").textContent = hodlSpNote;
-    } catch (exception) {
-      document.getElementById("sp-error").textContent = exception.message || String(exception);
-    }
-  };
   document.getElementById("sp-wipe").onclick = () => {
     hodlSpWipeMem();
     ["sp-key", "sp-pass", "sp-recipients", "sp-send-vins", "sp-verify-vins", "sp-verify-outputs", "sp-label"].forEach((id) => {
@@ -8574,6 +8826,7 @@ function hodlInitSp() {
     document.getElementById("sp-out").innerHTML = "";
     document.getElementById("sp-error").textContent = "";
     document.getElementById("sp-session").textContent = "Session ended and accessible fields were cleared (best effort).";
+    hodlRefreshStationKeyPickers();
   };
   document.getElementById("sp-out").addEventListener("click", (event) => {
     let button = event.target.closest?.("[data-sp-copy]");
@@ -9009,7 +9262,7 @@ function hodlNewKeyState(name, keyId, keyNumber) {
   return { id, number, color: hodlKeyColor(id), name: name || hodlDefaultKeyName(number), mode: "dice", diceMethod: "coldcard", cardMethod: "hashed", seedMethod: "words", seedZeroIndexed: false, cardColemanSymbols: false, entropyFormat: "bin", globalSync: false, globalSyncSource: "", globalSyncBitCount: 0, seedAutocomplete: true, passphraseBip39Words: false, brainWalletOutput: "scalar", passphraseAutocomplete: true, brainWalletTrim: false, showCards: false, showDiceFairness: false, targetWords: 24, diceCoinPositions: [], lastWord: "", dplusLastWord: "", result: null, reveal: false, accountId: "bip84", error: "", fields: { pass: "", script: "bip84", derivationPath: "m/84'/0'/0'/0/0", derivationAccountPath: "m/84'/0'/0'", purpose: "84'", purposeHarden: true, coinType: "0'", coinTypeHarden: true, network: "mainnet", account: "0'", accountHarden: true, branchStart: "0", branchHarden: false, branchRange: "1", addressStart: "0", addressHarden: false, addressRange: "1", dice: "", bitboxDice: "", dplusDice: "", hex: "", bin: "", base4: "", base8: "", base32: "", base64: "", cards: "", directCards: "", seed: "", seedNumbers: "", brainLab: "", key: "", keyKind: "wif", privateKeys: { wif: "", "hex-key": "", minikey: "", brain: "" } } };
 }
 function hodlNewLabState() {
-  let state = hodlNewKeyState("Key Lab", 0, 0);
+  let state = hodlNewKeyState("Key Station", 0, 0);
   state.isLab = true;
   return state;
 }
@@ -9089,7 +9342,7 @@ function hodlFillLabFromKey(source) {
   let labIndex = hodlKeys.findIndex((state) => state.isLab);
   let existing = labIndex >= 0 ? hodlKeys[labIndex] : hodlNewLabState();
   let lab = hodlCloneDerivedKey(source, existing);
-  Object.assign(lab, { isLab: true, name: "Key Lab", result: null, error: "", reveal: false, createdScript: "", createdPath: "" });
+  Object.assign(lab, { isLab: true, name: "Key Station", result: null, error: "", reveal: false, createdScript: "", createdPath: "" });
   if (labIndex < 0) {
     hodlKeys.unshift(lab);
     labIndex = 0;
@@ -9441,9 +9694,9 @@ function hodlKeyTabKeydown(event, index) {
   hodlElement("#key-tabs").children[next]?.focus();
 }
 var hodlKeySilhouette = "M512 176c0 97.2-78.8 176-176 176-11.2 0-22.2-1.1-32.8-3.1l-24 27c-4.4 4.9-10.8 8.1-17.9 8.1H224v40c0 13.3-10.7 24-24 24h-40v40c0 13.3-10.7 24-24 24H24c-13.3 0-24-10.7-24-24v-78.1c0-6.4 2.5-12.5 7-17l161.8-161.8c-5.7-17.4-8.8-35.9-8.8-55.2C160 78.8 238.8 0 336 0s176 78.8 176 176zM374 112a54 54 0 1 0 0 108 54 54 0 1 0 0-108z";
-function hodlCreateMsigIcon() {
-  let ns = "http://www.w3.org/2000/svg", darkest = "#4b4f55", middle = "#888d94", span = document.createElement("span"), svg = document.createElementNS(ns, "svg");
-  span.className = "multisig-tab-icon";
+function hodlCreateMsigIcon(monochrome = false) {
+  let ns = "http://www.w3.org/2000/svg", darkest = monochrome ? "currentColor" : "#4b4f55", middle = monochrome ? "currentColor" : "#888d94", span = document.createElement("span"), svg = document.createElementNS(ns, "svg");
+  span.className = "multisig-tab-icon" + (monochrome ? " bench-tab-icon" : "");
   span.setAttribute("aria-hidden", "true");
   svg.setAttribute("viewBox", "0 -4 49 40");
   svg.setAttribute("focusable", "false");
@@ -9460,13 +9713,14 @@ function hodlCreateMsigIcon() {
   ring.setAttribute("stroke-linecap", "round");
   ring.setAttribute("stroke-linejoin", "round");
   svg.appendChild(ring);
-  [["key-back", darkest, -28], ["key-middle", middle, 0], ["key-front", "#d1d4d8", 28]].forEach(([part, fill, angle]) => {
+  [["key-back", darkest, -28, monochrome ? ".52" : "1"], ["key-middle", middle, 0, monochrome ? ".76" : "1"], ["key-front", monochrome ? "currentColor" : "#d1d4d8", 28, "1"]].forEach(([part, fill, angle, opacity]) => {
     let path = document.createElementNS(ns, "path");
     path.setAttribute("data-part", part);
     path.setAttribute("d", hodlKeySilhouette);
     path.setAttribute("fill", fill);
     path.setAttribute("fill-rule", "evenodd");
     path.setAttribute("clip-rule", "evenodd");
+    path.setAttribute("opacity", opacity);
     path.setAttribute("transform", "translate(34 10.5) rotate(" + angle + ") scale(.052) translate(-374 -166)");
     svg.appendChild(path);
   });
@@ -9483,14 +9737,93 @@ function hodlCreateMsigIcon() {
   return span;
 }
 function hodlCreateLabIcon() {
-  let span = document.createElement("span"), source = document.querySelector(".site-logo");
-  span.className = "key-tab-icon key-tab-lab-icon";
+  let ns = "http://www.w3.org/2000/svg", span = document.createElement("span"), svg = document.createElementNS(ns, "svg"), path = document.createElementNS(ns, "path");
+  span.className = "key-tab-icon key-tab-lab-icon bench-tab-icon";
   span.setAttribute("aria-hidden", "true");
-  if (source) source.querySelectorAll("svg").forEach((svg) => span.appendChild(svg.cloneNode(true)));
+  svg.setAttribute("viewBox", "0 0 512 512");
+  svg.setAttribute("fill", "currentColor");
+  svg.setAttribute("focusable", "false");
+  svg.setAttribute("aria-hidden", "true");
+  path.setAttribute("fill-rule", "evenodd");
+  path.setAttribute("clip-rule", "evenodd");
+  path.setAttribute("d", hodlKeySilhouette);
+  svg.appendChild(path);
+  span.appendChild(svg);
+  return span;
+}
+function hodlCreateBip85BenchIcon() {
+  let ns = "http://www.w3.org/2000/svg", span = document.createElement("span"), svg = document.createElementNS(ns, "svg");
+  span.className = "key-tab-icon key-tab-lab-icon bip85-bench-icon bench-tab-icon";
+  span.setAttribute("aria-hidden", "true");
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.setAttribute("fill", "currentColor");
+  svg.setAttribute("focusable", "false");
+  svg.setAttribute("aria-hidden", "true");
+  [
+    ["seed", "M12 1.75c1.78 0 3.22 1.5 3.22 3.35S13.78 8.45 12 8.45 8.78 6.95 8.78 5.1 10.22 1.75 12 1.75Z"],
+    ["left-leaf", "M10.92 21.75C5.47 20.99 2.25 17.03 2.25 9.2c5.48.85 8.67 4.89 8.67 12.55Z"],
+    ["right-leaf", "M13.08 21.75c5.45-.76 8.67-4.72 8.67-12.55-5.48.85-8.67 4.89-8.67 12.55Z"]
+  ].forEach(([part, data]) => {
+    let path = document.createElementNS(ns, "path");
+    path.setAttribute("data-part", part);
+    path.setAttribute("d", data);
+    svg.appendChild(path);
+  });
+  span.appendChild(svg);
+  return span;
+}
+function hodlCreateSilentPaymentsIcon() {
+  let ns = "http://www.w3.org/2000/svg", span = document.createElement("span"), svg = document.createElementNS(ns, "svg");
+  span.className = "key-tab-icon key-tab-lab-icon silent-payments-icon bench-tab-icon";
+  span.setAttribute("aria-hidden", "true");
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.setAttribute("fill", "none");
+  svg.setAttribute("focusable", "false");
+  svg.setAttribute("aria-hidden", "true");
+  let coin = document.createElementNS(ns, "g");
+  coin.setAttribute("data-part", "coin");
+  coin.setAttribute("transform", "rotate(14 8 14.5)");
+  let rim = document.createElementNS(ns, "path");
+  rim.setAttribute("data-part", "coin-rim");
+  rim.setAttribute("d", "M1.85 14.4v1.65c0 2.4 2.75 4.35 6.15 4.35s6.15-1.95 6.15-4.35V14.4c0 2.4-2.75 4.35-6.15 4.35S1.85 16.8 1.85 14.4Z");
+  rim.setAttribute("fill", "currentColor");
+  rim.setAttribute("fill-opacity", ".45");
+  rim.setAttribute("stroke", "currentColor");
+  rim.setAttribute("stroke-width", "1.1");
+  coin.appendChild(rim);
+  ["M3.35 17.3v1.25", "M5.45 18.15v1.4", "M7.8 18.45v1.45", "M10.15 18.15v1.35", "M12.2 17.3v1.15"].forEach((data) => {
+    let ridge = document.createElementNS(ns, "path");
+    ridge.setAttribute("data-part", "coin-ridge");
+    ridge.setAttribute("d", data);
+    ridge.setAttribute("stroke", "currentColor");
+    ridge.setAttribute("stroke-width", ".8");
+    ridge.setAttribute("stroke-linecap", "round");
+    coin.appendChild(ridge);
+  });
+  let face = document.createElementNS(ns, "ellipse");
+  face.setAttribute("cx", "8");
+  face.setAttribute("cy", "14.4");
+  face.setAttribute("rx", "6.15");
+  face.setAttribute("ry", "4.2");
+  face.setAttribute("fill", "currentColor");
+  face.setAttribute("stroke", "currentColor");
+  face.setAttribute("stroke-width", "1.25");
+  coin.appendChild(face);
+  svg.appendChild(coin);
+  [["signal-inner", "M14.25 9.15a4.65 4.65 0 0 1 3.55 3.6"], ["signal-outer", "M14.7 4.25a9.2 9.2 0 0 1 7.05 7.2"]].forEach(([part, data]) => {
+    let path = document.createElementNS(ns, "path");
+    path.setAttribute("data-part", part);
+    path.setAttribute("d", data);
+    path.setAttribute("stroke", "currentColor");
+    path.setAttribute("stroke-width", "1.8");
+    path.setAttribute("stroke-linecap", "round");
+    svg.appendChild(path);
+  });
+  span.appendChild(svg);
   return span;
 }
 function hodlCreateKeyTab(index) {
-  let state = hodlKeys[index], active = index === hodlActiveKey, button = document.createElement("button"), fingerprint = state.result?.masterFingerprint || "", name = state.isLab ? "Key Lab" : state.name || fingerprint || "Key " + state.number, label = document.createElement("span");
+  let state = hodlKeys[index], active = index === hodlActiveKey, button = document.createElement("button"), fingerprint = state.result?.masterFingerprint || "", name = state.isLab ? "Key Station" : state.name || fingerprint || "Key " + state.number, label = document.createElement("span");
   button.type = "button";
   button.id = state.isLab ? "key-tab-lab" : "key-tab-" + (index + 1);
   button.className = "tab key-tab" + (state.isLab ? " is-lab" : "") + (active ? " active" : "");
@@ -9513,7 +9846,7 @@ function hodlCreateKeyTab(index) {
   button.setAttribute("aria-controls", "calc-card");
   button.setAttribute("aria-selected", String(active));
   if (state.isLab) {
-    button.setAttribute("aria-label", "Key Lab" + (active ? ", selected" : ". Activate to derive a key."));
+    button.setAttribute("aria-label", "Key Station" + (active ? ", selected" : ". Activate to derive a key."));
     button.title = "Derive a key";
     button.onclick = () => hodlSelectKey(index);
   } else {
@@ -9615,6 +9948,8 @@ function hodlRenderKeyTabs() {
   });
   hodlRevealTab(box, hodlActiveKey);
   hodlSyncKeyDeleteButton();
+  hodlRefreshMsigSessionPickers();
+  hodlRefreshStationKeyPickers();
 }
 function hodlSelectKey(index) {
   if (index === hodlActiveKey || !hodlKeys[index]) return;
@@ -9676,7 +10011,7 @@ function hodlNewMsigState(name, msigId, msigNumber) {
   }
 }
 function hodlNewMsigLabState() {
-  let state = hodlNewMsigState("Multisig Lab", 0, 0);
+  let state = hodlNewMsigState("MS Station", 0, 0);
   state.isLab = true;
   return state;
 }
@@ -9784,7 +10119,7 @@ function hodlFillMsigLabFromWallet(source) {
   let labIndex = hodlMsigs.findIndex((state) => state.isLab);
   let existing = labIndex >= 0 ? hodlMsigs[labIndex] : hodlNewMsigLabState();
   let lab = hodlCloneDerivedMsig(source, existing);
-  Object.assign(lab, { isLab: true, name: "Multisig Lab", result: null, error: "", createdPolicy: "", createdScript: "", createdNetwork: "" });
+  Object.assign(lab, { isLab: true, name: "MS Station", result: null, error: "", createdPolicy: "", createdScript: "", createdNetwork: "" });
   if (labIndex < 0) {
     hodlMsigs.unshift(lab);
     labIndex = 0;
@@ -9913,19 +10248,19 @@ function hodlMsigTabKeydown(event, index) {
   hodlElement("#msig-tabs").children[next]?.focus();
 }
 function hodlCreateMsigTab(index) {
-  let state = hodlMsigs[index], active = index === hodlActiveMsig, button = document.createElement("button"), name = state.isLab ? "Multisig Lab" : state.createdPolicy || state.name || "Multisig " + state.number, label = document.createElement("span");
+  let state = hodlMsigs[index], active = index === hodlActiveMsig, button = document.createElement("button"), name = state.isLab ? "MS Station" : state.createdPolicy || state.name || "Multisig " + state.number, label = document.createElement("span");
   button.type = "button";
   button.id = state.isLab ? "msig-tab-lab" : "msig-tab-" + (index + 1);
   button.className = "tab key-tab msig-tab" + (state.isLab ? " is-lab" : "") + (active ? " active" : "");
   button.dataset.msigNumber = String(state.number);
   label.className = "key-tab-label";
   label.textContent = name;
-  button.append(state.isLab ? hodlCreateLabIcon() : hodlCreateMsigIcon(), label);
+  button.append(hodlCreateMsigIcon(state.isLab), label);
   button.setAttribute("role", "tab");
   button.setAttribute("aria-controls", "msig-card");
   button.setAttribute("aria-selected", String(active));
   if (state.isLab) {
-    button.setAttribute("aria-label", "Multisig Lab" + (active ? ", selected" : ". Activate to derive a multisig."));
+    button.setAttribute("aria-label", "MS Station" + (active ? ", selected" : ". Activate to derive a multisig."));
     button.title = "Derive a multisig";
     button.onclick = () => hodlSelectMsig(index);
   } else {
@@ -10053,7 +10388,9 @@ function hodlShowWorkspace(id) {
     if (active) hodlRevealTab(hodlElement("#workspace-tabs"), [...hodlElement("#workspace-tabs").children].indexOf(button));
   });
   document.getElementById("key-manager").hidden = id !== "calc";
+  document.getElementById("bip85-manager").hidden = id !== "bip85";
   document.getElementById("msig-manager").hidden = id !== "msig";
+  document.getElementById("sp-manager").hidden = id !== "sp";
   document.getElementById("calc-card").hidden = true;
   document.getElementById("msig-card").hidden = true;
   document.getElementById("psbt-card").hidden = id !== "psbt";
@@ -10074,7 +10411,11 @@ function hodlShowWorkspace(id) {
   } else if (id === "msig") {
     hodlRenderMsigTabs();
     hodlRestoreMsig();
-  } else if (id === "bip85") hodlBip85SyncOptions();
+  } else if (id === "bip85") {
+    hodlRenderBip85Tabs();
+    hodlSyncBip85View();
+    hodlBip85SyncOptions();
+  }
   if (hodlWorkspaceScrollFrame) cancelAnimationFrame(hodlWorkspaceScrollFrame);
   window.scrollTo(preservedLeft, preservedTop);
   hodlWorkspaceScrollFrame = requestAnimationFrame(() => {
@@ -10146,6 +10487,22 @@ function hodlInitMsigManager() {
   if (hodlWorkspace === "msig") hodlRestoreMsig();
   else document.getElementById("msig-card").hidden = true;
 }
+function hodlInitSpBench() {
+  let tabs = document.getElementById("sp-tabs");
+  if (!tabs) return;
+  let button = document.createElement("button"), label = document.createElement("span");
+  button.type = "button";
+  button.id = "sp-tab-bench";
+  button.className = "tab key-tab is-lab active";
+  button.setAttribute("role", "tab");
+  button.setAttribute("aria-selected", "true");
+  button.setAttribute("aria-controls", "sp-card");
+  button.setAttribute("aria-label", "SP Station, selected");
+  label.className = "key-tab-label";
+  label.textContent = "SP Station";
+  button.append(hodlCreateSilentPaymentsIcon(), label);
+  tabs.replaceChildren(button);
+}
 function hodlInitDefaultTabStates() {
   if (!hodlKeys.length) {
     hodlKeys.push(hodlNewLabState());
@@ -10203,9 +10560,12 @@ function hodlInitWorkspace() {
     button.dataset.workspace = id;
     button.setAttribute("role", "tab");
     button.setAttribute("aria-selected", String(active));
-    button.innerHTML = `<span class="workspace-tab-full"></span><span class="workspace-tab-short"></span>`;
-    button.firstChild.textContent = label;
-    button.lastChild.textContent = short;
+    let fullLabel = document.createElement("span"), shortLabel = document.createElement("span");
+    fullLabel.className = "workspace-tab-full";
+    shortLabel.className = "workspace-tab-short";
+    fullLabel.textContent = label;
+    shortLabel.textContent = short;
+    button.append(fullLabel, shortLabel);
     // The short form is display:none at wide widths and the full one is hidden
     // at narrow ones, and hidden text is not in the accessibility tree — so the
     // name is stated outright rather than left to whichever span is showing.
@@ -10412,6 +10772,8 @@ function hodlInitSecretFieldAutoClear() {
     if (bip85Out) bip85Out.innerHTML = "";
     if (bip85Error) bip85Error.textContent = "";
     if (bip85Session) bip85Session.textContent = hodlBip85Note;
+    hodlRenderBip85Tabs();
+    hodlSyncBip85View();
     let spKey = document.getElementById("sp-key"), spPass = document.getElementById("sp-pass");
     if (spKey) spKey.value = "";
     if (spPass) spPass.value = "";
@@ -10476,6 +10838,7 @@ function hodlBoot() {
   hodlInitDefaultTabStates();
   hodlInitKeyManager();
   hodlInitMsigManager();
+  hodlInitSpBench();
   hodlInitClearActionState();
   hodlInitSecretFieldAutoClear();
   hodlInitTheme();

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -550,8 +550,8 @@ hodlRootEl.innerHTML = `
       </div>
       <p class="field-note address-estimate derivation-estimate" id="address-estimate" role="status">Measuring this device\u2026</p>
       <div class="row key-action-row current-item-actions">
-        <button class="btn primary" id="go" disabled aria-disabled="true">Derive Wallet</button>
-        <div class="derive-progress" id="derive-progress" role="progressbar" aria-label="Wallet derivation progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-valuetext="0% complete" hidden><span class="derive-progress-track"><span class="derive-progress-bar"></span></span><span class="derive-progress-label">0%</span></div>
+        <button class="btn primary" id="go" disabled aria-disabled="true">Derive Key</button>
+        <div class="derive-progress" id="derive-progress" role="progressbar" aria-label="Key derivation progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-valuetext="0% complete" hidden><span class="derive-progress-track"><span class="derive-progress-bar"></span></span><span class="derive-progress-label">0%</span></div>
         <button class="btn secondary" id="bip85-open" type="button">Derive BIP-85 child</button>
         <button class="btn clear-current-action" id="wipe" type="button" disabled aria-disabled="true">Clear Current Key</button>
       </div>
@@ -2165,16 +2165,16 @@ function hodlSetDerivationButtonState(kind, state) {
     button.textContent = "Stop";
     button.disabled = false;
     button.setAttribute("aria-disabled", "false");
-    button.setAttribute("aria-label", kind === "msig" ? "Stop deriving multisig" : "Stop deriving wallet");
+    button.setAttribute("aria-label", kind === "msig" ? "Stop deriving multisig" : "Stop deriving key");
     button.dataset.derivationState = "running";
   } else if (state === "stopping") {
     button.textContent = "Stopping…";
     button.disabled = true;
     button.setAttribute("aria-disabled", "true");
-    button.setAttribute("aria-label", kind === "msig" ? "Stopping multisig derivation" : "Stopping wallet derivation");
+    button.setAttribute("aria-label", kind === "msig" ? "Stopping multisig derivation" : "Stopping key derivation");
     button.dataset.derivationState = "stopping";
   } else {
-    button.textContent = kind === "msig" ? "Derive Multisig" : "Derive Wallet";
+    button.textContent = kind === "msig" ? "Derive Multisig" : "Derive Key";
     button.removeAttribute("aria-label");
     delete button.dataset.derivationState;
     delete button.dataset.derivationWidth;
@@ -4133,8 +4133,8 @@ function hodlBrainOutputMarkup(output = "scalar", acked = Boolean(hodlBrainLabAc
     </div>
     <label class="choice"><input type="checkbox" id="brain-lab-ack" ${acked ? "checked" : ""} /><span><strong>I understand</strong><span class="desc">Required once this session, in page memory only. Derive is still required.</span></span></label>
     <div id="brain-lab-zone" ${hd ? "" : "hidden"}>
-      <p class="muted" id="brain-lab-help">UTF-8 text is hashed with SHA-256. The 32-byte digest is BIP39 entropy for a 24-word seed. Nothing is derived until you press Derive Wallet.</p>
-      <p class="muted" id="brain-lab-hex" aria-live="polite">SHA-256 hex appears here. 24 words appear only after Derive Wallet.</p>
+      <p class="muted" id="brain-lab-help">UTF-8 text is hashed with SHA-256. The 32-byte digest is BIP39 entropy for a 24-word seed. Nothing is derived until you press Derive Key.</p>
+      <p class="muted" id="brain-lab-hex" aria-live="polite">SHA-256 hex appears here. 24 words appear only after Derive Key.</p>
     </div>
   </div>`;
 }
@@ -4153,17 +4153,17 @@ function hodlSyncBrainOutput() {
   let hex = document.getElementById("brain-lab-hex");
   if (!hex || !brain || output !== "hd") return;
   if (!hodlBrainLabAck) {
-    hex.textContent = "Acknowledge the lab warning, then enter text. Derive Wallet is still required.";
+    hex.textContent = "Acknowledge the lab warning, then enter text. Derive Key is still required.";
     hex.className = "muted";
     return;
   }
   if (!input.value.length) {
-    hex.textContent = "SHA-256 hex appears here. 24 words appear only after Derive Wallet.";
+    hex.textContent = "SHA-256 hex appears here. 24 words appear only after Derive Key.";
     hex.className = "muted";
     return;
   }
   let entropy = hodlBrainLabEntropy(hodlBrainWalletText(input.value));
-  hex.textContent = entropy.ok ? `SHA-256 ${entropy.hex} \xB7 24 words appear only after Derive Wallet.` : entropy.error;
+  hex.textContent = entropy.ok ? `SHA-256 ${entropy.hex} \xB7 24 words appear only after Derive Key.` : entropy.error;
   hex.className = "muted" + (entropy.ok ? " ok" : " err");
 }
 function hodlUpdatePrivateKeyInputPresentation() {
@@ -6331,7 +6331,7 @@ async function hodlCalculateKey(progress) {
   } catch (error) {
     if (error instanceof HodlDerivationCancelledError) throw error;
     hodlWalletResult = null;
-    hodlElement("#error").textContent = error instanceof Error ? error.message : "Could not derive wallet";
+    hodlElement("#error").textContent = error instanceof Error ? error.message : "Could not derive key";
     hodlOutEl.innerHTML = "";
     hodlCaptureKey();
     return false;
@@ -8496,7 +8496,7 @@ function hodlInitBip85() {
     hodlRefreshStationKeyPickers();
   });
   go.onclick = hodlRunBip85;
-  // Entry point beside Derive Wallet (idea adopted from PR #150): jump to the
+  // Entry point beside Derive Key (idea adopted from PR #150): jump to the
   // BIP-85 tab with the active key loaded as parent. Errors land in the tab's
   // own error line; secrets stay behind the existing reveal/wipe flow.
   let open = document.getElementById("bip85-open");

--- a/test/brain-wallet.test.mjs
+++ b/test/brain-wallet.test.mjs
@@ -103,7 +103,7 @@ test("the brain-wallet HD output has no silent fingerprint or mnemonic preview p
   // The private-key mode never previews a fingerprint or mnemonic, which now
   // covers the HD brain output too.
   assert.match(app, /if \(hodlKeyMode === "key"\) \{\s*preview\.hidden = true;/);
-  assert.match(app, /24 words appear only after Derive Wallet/);
+  assert.match(app, /24 words appear only after Derive Key/);
   assert.match(app, /Acknowledge the lab warning before deriving/);
   assert.doesNotMatch(loadSlice("hodlBrainLabEntropy"), /localStorage/);
 });

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -1618,6 +1618,37 @@
     await until(() => !document.getElementById("key-manager").hidden, "key workspace after SP Station test");
   });
 
+  await test("MS Station assigns Key Station keys globally and only reuses them when opted in", async () => {
+    document.querySelector('#workspace [data-workspace="msig"]').click();
+    await until(() => !document.getElementById("msig-manager").hidden, "MS Station");
+    const reuse = document.getElementById("msig-reuse-session-keys");
+    assert(reuse && !reuse.checked, "MS Station key reuse was not opt in");
+    let option = document.querySelector("#msig-session-keys .session-key-option");
+    assert(option, "MS Station did not offer the compatible Key Station key in its global picker");
+    const first = document.getElementById("msig-x-0");
+    first.focus();
+    option.click();
+    assert(first.value.trim(), "The global MS Station picker did not populate the focused co-signer input");
+    assert(!first.closest(".msig-key-row").querySelector(".msig-key-ident").hidden, "The selected key identity was not shown above its co-signer input");
+    assert(!document.querySelector("#msig-session-keys .session-key-option"), "An assigned key remained available while reuse was off");
+
+    reuse.click();
+    option = document.querySelector("#msig-session-keys .session-key-option");
+    assert(option, "Enabling reuse did not restore the assigned key to the global picker");
+    const second = document.getElementById("msig-x-1");
+    second.focus();
+    option.click();
+    assert(second.value.trim(), "Reuse did not populate a second co-signer input");
+    assert(!second.closest(".msig-key-row").querySelector(".msig-key-ident").hidden, "The reused key identity was not shown above the second input");
+    assert(document.querySelector("#msig-session-keys .session-key-option"), "The key disappeared from the global picker while reuse was on");
+
+    input(first, "");
+    input(second, "");
+    reuse.click();
+    document.querySelector('#workspace [data-workspace="calc"]').click();
+    await until(() => !document.getElementById("key-manager").hidden, "key workspace after MS Station picker test");
+  });
+
   await test("a custom arbitrary-depth account path drives the derived addresses and descriptors", async () => {
     input(document.getElementById("branch-range"), "1");
     input(document.getElementById("address-range"), "1");

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -784,6 +784,7 @@
     tabs.forEach((tab, i) => {
       assert(tab.getAttribute("aria-label") === names[i], `Tab ${i} should be named "${names[i]}"`);
     });
+    assert(!document.querySelector('#workspace [data-workspace="sp"] .silent-payments-icon'), "Silent Payments icon should not be in the workspace tab");
     const start = document.querySelector('#workspace [data-workspace="calc"]');
     try {
       start.focus();
@@ -805,6 +806,20 @@
       document.querySelector('#workspace [data-workspace="calc"]').click();
       await until(() => !document.getElementById("key-manager").hidden, "key workspace");
     }
+  });
+  await test("Silent Payments opens a connected SP Station with its monochrome icon", async () => {
+    document.querySelector('#workspace [data-workspace="sp"]').click();
+    await until(() => !document.getElementById("sp-card").hidden, "Silent Payments workspace");
+    const manager = document.getElementById("sp-manager"), bench = document.getElementById("sp-tab-bench");
+    assert(manager && !manager.hidden, "SP Station manager should be visible");
+    assert(bench && bench.textContent.includes("SP Station"), "SP Station tab is missing or mislabeled");
+    const icon = bench.querySelector(".silent-payments-icon");
+    assert(icon, "SP Station tab is missing its icon");
+    equal(icon.querySelectorAll('[data-part^="signal-"]').length, 2, "SP Station icon should have two signal arcs");
+    equal(icon.querySelectorAll('[data-part="coin-ridge"]').length, 5, "SP Station coin should have a restrained ridged rim");
+    assert(!icon.querySelector('ellipse[fill="none"]'), "SP Station coin face should not have a hole");
+    document.querySelector('#workspace [data-workspace="calc"]').click();
+    await until(() => !document.getElementById("key-manager").hidden, "key workspace");
   });
   await test("the tool strip advertises tools that are off its right edge", async () => {
     const strip = document.getElementById("workspace-tabs");
@@ -1547,6 +1562,58 @@
       () => document.querySelectorAll('#acct [data-address-table="hd-receive"] tbody tr').length === 5,
       "restored unhardened wallet result",
     );
+  });
+
+  await test("BIP-85 keeps its Station and opens each child in a LifeHash fingerprint tab", async () => {
+    const bip85Workspace = document.querySelector('#workspace [data-workspace="bip85"]');
+    const keyWorkspace = document.querySelector('#workspace [data-workspace="calc"]');
+    bip85Workspace.click();
+    await until(() => !document.getElementById("bip85-manager").hidden, "BIP-85 Station");
+    const tabs = document.getElementById("bip85-tabs");
+    equal(tabs.children.length, 1, "BIP-85 did not start with only its Station");
+    assert(tabs.children[0].textContent.includes("BIP-85 Station"), "BIP-85 Station tab is mislabeled");
+    assert(tabs.children[0].querySelector(".bip85-bench-icon"), "BIP-85 bench tab is missing its seedling icon");
+    equal(tabs.children[0].querySelectorAll(".bip85-bench-icon [data-part=seed]").length, 1, "BIP-85 bench icon should have one seed");
+
+    const parentKey = document.querySelector("#bip85-session-keys .session-key-option");
+    assert(parentKey, "BIP-85 Station did not offer the compatible Key Station key");
+    parentKey.click();
+    assert(!document.getElementById("bip85-error").textContent, "The active key could not be loaded for BIP-85");
+    document.getElementById("bip85-index").value = "0";
+    document.getElementById("bip85-go").click();
+    await until(() => tabs.children.length === 2 && document.querySelector("#bip85-out #bip85-private-heading"), "first BIP-85 child tab");
+    const firstTab = tabs.children[1];
+    assert(/^[0-9a-f]{8}$/.test(firstTab.querySelector(".key-tab-label")?.textContent || ""), "The first BIP-85 child tab did not show an XFP");
+    await until(() => !firstTab.querySelector(".key-tab-lifehash")?.hidden, "first BIP-85 child LifeHash");
+    assert(document.querySelector("#bip85-out .wallet-data-fields")?.textContent.includes("Master fingerprint"), "The BIP39 child did not identify its master fingerprint");
+    assert(!document.getElementById("delete-bip85").disabled, "The child delete control did not become available");
+
+    document.getElementById("add-bip85").click();
+    await until(() => !document.getElementById("bip85-bench").hidden, "BIP-85 bench after plus");
+    assert(!document.getElementById("bip85-out").textContent.trim(), "Returning to the bench left a child result visible");
+    input(document.getElementById("bip85-index"), "1");
+    document.getElementById("bip85-go").click();
+    await until(() => tabs.children.length === 3 && document.querySelector("#bip85-out #bip85-private-heading"), "second BIP-85 child tab");
+    assert(tabs.children[2].querySelector(".key-tab-lifehash"), "The second BIP-85 child tab is missing its LifeHash target");
+    document.getElementById("delete-bip85").click();
+    await until(() => tabs.children.length === 2, "selected BIP-85 child deletion");
+    assert(!document.getElementById("delete-bip85").disabled, "The remaining child was not selected after deletion");
+
+    keyWorkspace.click();
+    await until(() => !document.getElementById("key-manager").hidden, "key workspace after BIP-85 test");
+  });
+
+  await test("SP Station can bring in a compatible Key Station root", async () => {
+    document.querySelector('#workspace [data-workspace="sp"]').click();
+    await until(() => !document.getElementById("sp-manager").hidden, "SP Station");
+    const key = document.querySelector("#sp-session-keys .session-key-option");
+    assert(key, "SP Station did not offer the compatible Key Station key");
+    key.click();
+    assert(document.querySelector("#sp-session-keys .session-key-option.active"), "The selected SP Station key was not marked active");
+    assert(document.getElementById("sp-session").textContent.includes("Session key from"), "SP Station did not load the selected key");
+    assert(!document.getElementById("sp-error").textContent, "SP Station rejected a compatible Key Station key");
+    document.querySelector('#workspace [data-workspace="calc"]').click();
+    await until(() => !document.getElementById("key-manager").hidden, "key workspace after SP Station test");
   });
 
   await test("a custom arbitrary-depth account path drives the derived addresses and descriptors", async () => {

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -1579,6 +1579,7 @@
     assert(parentKey, "BIP-85 Station did not offer the compatible Key Station key");
     parentKey.click();
     assert(!document.getElementById("bip85-error").textContent, "The active key could not be loaded for BIP-85");
+    assert(/^[xt]prv/.test(document.getElementById("bip85-key").value), "BIP-85 Station did not populate the selected root xprv/tprv");
     document.getElementById("bip85-index").value = "0";
     document.getElementById("bip85-go").click();
     await until(() => tabs.children.length === 2 && document.querySelector("#bip85-out #bip85-private-heading"), "first BIP-85 child tab");
@@ -1610,6 +1611,7 @@
     assert(key, "SP Station did not offer the compatible Key Station key");
     key.click();
     assert(document.querySelector("#sp-session-keys .session-key-option.active"), "The selected SP Station key was not marked active");
+    assert(document.getElementById("sp-key").value.trim(), "SP Station did not populate the selected session key");
     assert(document.getElementById("sp-session").textContent.includes("Session key from"), "SP Station did not load the selected key");
     assert(!document.getElementById("sp-error").textContent, "SP Station rejected a compatible Key Station key");
     document.querySelector('#workspace [data-workspace="calc"]').click();

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -1693,8 +1693,8 @@
     derive.click();
     equal(derive.textContent.trim(), "Stopping…", "The Stop button did not acknowledge the cancellation request");
     assert(Math.abs(derive.getBoundingClientRect().width - deriveWidth) < 0.5, "The Stopping button changed width");
-    await until(() => derive.textContent.trim() === "Derive Wallet", "restored Derive Wallet button");
-    assert(!derive.disabled, "Derive Wallet did not become available again after stopping");
+    await until(() => derive.textContent.trim() === "Derive Key", "restored Derive Key button");
+    assert(!derive.disabled, "Derive Key did not become available again after stopping");
     const stoppedProgress = document.getElementById("derive-progress");
     assert(stoppedProgress.hidden, "The progress indicator remained visible after cancellation");
     equal(stoppedProgress.getAttribute("aria-valuenow"), "0", "Cancellation did not reset progress");
@@ -1738,7 +1738,7 @@
     equal(multisigDerive.title, "A derivation is already running.", "The disabled multisig derive button did not explain why");
     await until(() => Number(document.getElementById("derive-progress").getAttribute("aria-valuenow")) > 0, "derivation progress before editing");
     input(start, "8");
-    await until(() => derive.textContent.trim() === "Derive Wallet", "restored Derive Wallet button after editing");
+    await until(() => derive.textContent.trim() === "Derive Key", "restored Derive Key button after editing");
     assert(!document.getElementById("error").textContent, "Cancelling via an edit was shown as a derivation error");
     assert(!document.querySelector("#acct .account-result-card"), "An edited derivation published a stale wallet");
     const progress = document.getElementById("derive-progress");

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -1347,9 +1347,9 @@ test("PSBT Editor tab follows PSBT / Nonce and wires the rust-bitcoin editor", (
   assert.match(css, /#psbted-card\[hidden\]/);
 });
 
-test("BIP-85 entry point sits beside Derive Wallet and opens the BIP-85 tab", () => {
+test("BIP-85 entry point sits beside Derive Key and opens the BIP-85 tab", () => {
   for (const markup of [template, appSource]) {
-    assert.match(markup, /id="go"[^>]*>Derive Wallet<\/button>[\s\S]*?id="bip85-open"[^>]*>Derive BIP-85 child<\/button>[\s\S]*?id="wipe"/);
+    assert.match(markup, /id="go"[^>]*>Derive Key<\/button>[\s\S]*?id="bip85-open"[^>]*>Derive BIP-85 child<\/button>[\s\S]*?id="wipe"/);
   }
   assert.match(appSource, /getElementById\("bip85-open"\)/);
   assert.match(appSource, /open\.onclick = \(\) => \{\s*hodlShowWorkspace\("bip85"\)/);

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -1563,6 +1563,11 @@ test("BIP-85 and SP Stations can bring in compatible Key Station roots", () => {
   assert.match(appSource, /hodlFillKeyTabLifehash\(image, fingerprint\)/);
   assert.match(appSource, /function hodlPickBip85SessionKey\(state\) \{/);
   assert.match(appSource, /function hodlPickSpSessionKey\(state\) \{/);
+  assert.match(appSource, /document\.getElementById\("bip85-key"\)\.value = rootXprv;/);
+  assert.match(appSource, /document\.getElementById\("sp-key"\)\.value = state\.result\?\.mnemonic \|\| state\.result\?\.rootXprv \|\| "";/);
+  assert.match(appSource, /document\.getElementById\("sp-pass"\)\.value = state\.result\?\.mnemonic \? state\.fields\?\.pass \|\| "" : "";/);
+  assert.match(appSource, /document\.getElementById\("bip85-key"\)\.addEventListener\("input"/);
+  assert.match(appSource, /document\.getElementById\("sp-key"\)\.addEventListener\("input", detachStationKey\)/);
   assert.match(css, /\.session-key-picker \{ display: flex; flex-wrap: wrap; gap: 8px; \}/);
   assert.match(css, /\.session-key-option\.active \{ border-color: var\(--accent\); \}/);
 });

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -779,17 +779,17 @@ test("multisig consistently uses derive for its heading and action", () => {
   assert.match(app, /let\{network,coinType,count,addressStart,branchStart,branchRange,n,m,kind,purpose,hardening,legacyStandard,nodes,xpubs,keyTokens,accountSummary,accountWarning\}=hodlValidatedMsigInputs\(\)/);
 });
 
-test("key and multisig add controls stay pinned to the right of their tab strips", () => {
+test("Station add controls stay pinned to the right of their tab strips", () => {
   assert.match(css, /\.key-tab-strip \{ display: flex; align-items: flex-end; min-width: 0; margin-top: 12px; \}/);
   assert.match(css, /\.key-tabs \{\s*display: flex;[^}]*flex: 1 1 auto; min-width: 0;/s);
   assert.match(css, /\.add-item-control \{ position: relative; display: inline-flex; flex: 0 0 auto; \}/);
 });
 
-test("the delete control reads as unavailable on the Lab tab", () => {
-  // Both strips ship it disabled: a fresh page holds only Lab, and app.js
-  // keeps minus unavailable while Lab is selected.
+test("the delete control reads as unavailable on a Station tab", () => {
+  // All three strips ship it disabled: a fresh page holds only the bench,
+  // and app.js keeps minus unavailable while that bench is selected.
   for (const markup of [template, appSource]) {
-    for (const id of ["delete-key", "delete-msig"]) {
+    for (const id of ["delete-key", "delete-bip85", "delete-msig"]) {
       assert.match(
         markup,
         new RegExp(`<button class="add-key remove-key" id="${id}"[^>]*disabled`),
@@ -1372,6 +1372,23 @@ test("Silent Payments sits between Multi Signature and PSBT / Nonce", () => {
   assert.match(css, /#sp-card\[hidden\]/);
 });
 
+test("Silent Payments has a connected SP Station with a monochrome coin-and-signal icon", () => {
+  assert.match(appSource, /function hodlCreateSilentPaymentsIcon\(\) \{/);
+  assert.match(appSource, /span\.className = "key-tab-icon key-tab-lab-icon silent-payments-icon bench-tab-icon"/);
+  assert.match(appSource, /\[\["signal-inner",[\s\S]*?\["signal-outer",/);
+  assert.match(appSource, /rim\.setAttribute\("data-part", "coin-rim"\)/);
+  assert.match(appSource, /ridge\.setAttribute\("data-part", "coin-ridge"\)/);
+  assert.doesNotMatch(appSource, /let inset = document\.createElementNS/);
+  assert.match(appSource, /function hodlInitSpBench\(\) \{/);
+  assert.match(appSource, /label\.textContent = "SP Station";/);
+  assert.match(appSource, /button\.append\(hodlCreateSilentPaymentsIcon\(\), label\);/);
+  for (const markup of [template, appSource]) {
+    assert.match(markup, /id="sp-manager"/);
+    assert.match(markup, /id="sp-tabs"/);
+  }
+  assert.doesNotMatch(template, /aria-label="Silent Payments"><span class="workspace-tab-icon/);
+});
+
 test("the workspace switcher keeps every tool on screen as a tab strip", () => {
   // The switcher is a nav holding one scrollable strip of tabs; it is neither
   // a segmented control nor a dropdown. Every tool is visible without asking.
@@ -1391,12 +1408,12 @@ test("the workspace switcher keeps every tool on screen as a tab strip", () => {
   // One swaps for the other at the width the header drops its own labels.
   assert.match(css, /\.workspace-tab-short \{ display: none; \}/);
   assert.match(css, /@media \(max-width: 719px\) \{[\s\S]*?\.workspace-tab-full \{ display: none; \}\s*\.workspace-tab-short \{ display: inline; \}/);
-  assert.match(appSource, /button\.firstChild\.textContent = label;\s*button\.lastChild\.textContent = short;/);
+  assert.match(appSource, /fullLabel\.textContent = label;\s*shortLabel\.textContent = short;/);
   // Hidden text leaves the accessibility tree, so the full name is stated on
   // the tab itself and assistive tech hears it at every width.
   assert.match(appSource, /button\.setAttribute\("aria-label", label\);/);
   for (const full of ["Keys", "BIP-85", "Multi Signature", "Silent Payments", "PSBT / Nonce"]) {
-    assert.ok(template.includes(`aria-label="${full}"><span class="workspace-tab-full">${full}</span>`), `${full} tab needs its accessible name`);
+    assert.match(template, new RegExp(`aria-label="${full.replace("/", "\\/")}">[\\s\\S]*?<span class="workspace-tab-full">${full.replace("/", "\\/")}</span>`), `${full} tab needs its accessible name`);
   }
   // A tablist owes arrow keys; the key and multisig strips already answer them.
   assert.match(appSource, /function hodlWorkspaceTabKeydown\(event, index\) \{/);
@@ -1475,11 +1492,12 @@ test("the workspace switcher keeps every tool on screen as a tab strip", () => {
   assert.match(css, /\.workspace-more\[hidden\] \{ display: none; \}/);
 });
 
-test("Lab stays put and a derived key opens a fingerprint tab with a summary", () => {
+test("Key Station stays put and a derived key opens a fingerprint tab with a summary", () => {
   assert.match(appSource, /function hodlNewLabState\(\) \{/);
-  assert.match(appSource, /hodlNewKeyState\("Key Lab", 0, 0\)/);
-  assert.match(appSource, /name = state\.isLab \? "Key Lab"/);
-  assert.match(appSource, /source\.querySelectorAll\("svg"\)\.forEach\(\(svg\) => span\.appendChild\(svg\.cloneNode\(true\)\)\)/);
+  assert.match(appSource, /hodlNewKeyState\("Key Station", 0, 0\)/);
+  assert.match(appSource, /name = state\.isLab \? "Key Station"/);
+  assert.match(appSource, /path\.setAttribute\("d", hodlKeySilhouette\)/);
+  assert.match(css, /\.key-tab-icon\.key-tab-lab-icon \{[^}]*color: var\(--muted\);/s);
   assert.match(appSource, /function hodlCommitDerivedKey\(\) \{/);
   assert.match(appSource, /function hodlSelectLab\(\) \{/);
   assert.match(appSource, /function hodlSyncKeyResultView\(\) \{/);
@@ -1493,7 +1511,7 @@ test("Lab stays put and a derived key opens a fingerprint tab with a summary", (
     assert.match(markup, /id="key-lab"/);
     assert.match(markup, /id="key-edit-inputs"/);
     assert.match(markup, /id="key-summary-path"/);
-    assert.match(markup, /Open the lab to derive another key/);
+    assert.match(markup, /Open Key Station to derive another key/);
   }
   assert.match(appSource, /function hodlSnapshotKeySummary\(/);
   assert.match(appSource, /state\.createdScript = hodlKeySummaryScript\(state\)/);
@@ -1531,11 +1549,29 @@ test("multisig co-signer rows can pick a session key or paste a public key", () 
   assert.match(css, /\.msig-key-ident \{/);
 });
 
-test("Multisig Lab stays put and a derived wallet opens its own results tab", () => {
+test("BIP-85 and SP Stations can bring in compatible Key Station roots", () => {
+  for (const markup of [template, appSource]) {
+    assert.match(markup, /id="bip85-session-keys"/);
+    assert.match(markup, /id="sp-session-keys"/);
+    assert.match(markup, /Bring in a key from Key Station/);
+    assert.doesNotMatch(markup, /id="bip85-use-calc"/);
+    assert.doesNotMatch(markup, /id="sp-use-calc"/);
+  }
+  assert.match(appSource, /function hodlSessionHdRootKeys\(\) \{/);
+  assert.match(appSource, /state\.result\?\.kind === "hd" && \(state\.result\.mnemonic \|\| state\.result\.rootXprv\)/);
+  assert.match(appSource, /function hodlFillStationKeyPicker\(id, selectedSource, onSelect\) \{/);
+  assert.match(appSource, /hodlFillKeyTabLifehash\(image, fingerprint\)/);
+  assert.match(appSource, /function hodlPickBip85SessionKey\(state\) \{/);
+  assert.match(appSource, /function hodlPickSpSessionKey\(state\) \{/);
+  assert.match(css, /\.session-key-picker \{ display: flex; flex-wrap: wrap; gap: 8px; \}/);
+  assert.match(css, /\.session-key-option\.active \{ border-color: var\(--accent\); \}/);
+});
+
+test("MS Station stays put and a derived wallet opens its own results tab", () => {
   assert.match(appSource, /function hodlNewMsigLabState\(\) \{/);
-  assert.match(appSource, /hodlNewMsigState\("Multisig Lab", 0, 0\)/);
-  assert.match(appSource, /name = state\.isLab \? "Multisig Lab"/);
-  assert.match(appSource, /button\.append\(state\.isLab \? hodlCreateLabIcon\(\) : hodlCreateMsigIcon\(\), label\)/);
+  assert.match(appSource, /hodlNewMsigState\("MS Station", 0, 0\)/);
+  assert.match(appSource, /name = state\.isLab \? "MS Station"/);
+  assert.match(appSource, /button\.append\(hodlCreateMsigIcon\(state\.isLab\), label\)/);
   assert.match(appSource, /function hodlCommitDerivedMsig\(\) \{/);
   assert.match(appSource, /function hodlSelectMsigLab\(\) \{/);
   assert.match(appSource, /hodlMsigs\.push\(hodlNewMsigLabState\(\)\)/);
@@ -1556,11 +1592,35 @@ test("Multisig Lab stays put and a derived wallet opens its own results tab", ()
   assert.match(css, /#msig-card\.is-result-view \.msig-lab/);
 });
 
+test("BIP-85 Station retains each child in a LifeHash fingerprint tab", () => {
+  for (const markup of [template, appSource]) {
+    assert.match(markup, /id="bip85-manager"/);
+    assert.match(markup, /id="bip85-tabs"/);
+    assert.match(markup, /id="add-bip85"/);
+    assert.match(markup, /id="delete-bip85"/);
+    assert.match(markup, /id="bip85-bench"/);
+  }
+  assert.match(appSource, /function hodlNewBip85BenchState\(\) \{/);
+  assert.match(appSource, /name: "BIP-85 Station"/);
+  assert.match(appSource, /function hodlCreateBip85Tab\(index\) \{/);
+  assert.match(appSource, /if \(state\.isLab\) button\.append\(hodlCreateBip85BenchIcon\(\), label\)/);
+  assert.match(appSource, /function hodlCreateBip85BenchIcon\(\) \{/);
+  assert.match(appSource, /\["seed", "M12 1\.75/);
+  assert.match(appSource, /\["left-leaf",/);
+  assert.match(appSource, /\["right-leaf",/);
+  assert.match(css, /\.bench-tab-icon,[\s\S]*?width: 18px; height: 18px;[\s\S]*?color: var\(--muted\);/);
+  assert.match(appSource, /hodlFillKeyTabLifehash\(image, state\.fingerprint\)/);
+  assert.match(appSource, /hodlBip85Children\.push\(state\)/);
+  assert.match(appSource, /function hodlDeleteActiveBip85\(\) \{[\s\S]*wipeBip85Result\(state\.result\)/);
+  assert.match(appSource, /state\.reveal = hodlBip85Reveal/);
+  assert.match(css, /#bip85-card:not\(\[hidden\]\)/);
+});
+
 test("session wallets use folder tabs that merge into the card", () => {
   assert.match(css, /\.key-manager \{ margin: 14px 0 -1px;/);
   assert.match(css, /\.key-tab \{[^}]*border-radius: 10px 10px 0 0;/s);
   assert.match(css, /\.key-tab\.active, \.key-tab-editing \{[^}]*border-bottom-color: var\(--surface\);/s);
-  assert.match(css, /#calc-card:not\(\[hidden\]\), #msig-card:not\(\[hidden\]\) \{[^}]*border-radius: 0 0 20px 20px;/s);
+  assert.match(css, /#calc-card:not\(\[hidden\]\), #msig-card:not\(\[hidden\]\), #bip85-card:not\(\[hidden\]\), #sp-card:not\(\[hidden\]\) \{[^}]*border-radius: 0 0 20px 20px;/s);
   assert.match(css, /\.workspace-tab \{[^}]*border-radius: 10px 10px 0 0;/s);
   assert.match(appSource, /let lifehash = tab\.querySelector\("\.key-tab-lifehash"\);/);
   assert.doesNotMatch(appSource, /editor\.append\(hodlCreateKeyIcon\(state\.color\), input\)/);

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -1353,7 +1353,7 @@ test("BIP-85 entry point sits beside Derive Key and opens the BIP-85 tab", () =>
   }
   assert.match(appSource, /getElementById\("bip85-open"\)/);
   assert.match(appSource, /open\.onclick = \(\) => \{\s*hodlShowWorkspace\("bip85"\)/);
-  assert.match(appSource, /open\.onclick[\s\S]*?hodlUseActiveKeyForBip85\(\)/);
+  assert.match(appSource, /open\.onclick[\s\S]*?hodlPickBip85SessionKey\(hodlKeys\[hodlActiveKey\]\)/);
 });
 
 test("Silent Payments sits between Multi Signature and PSBT / Nonce", () => {
@@ -1547,8 +1547,10 @@ test("MS Station assigns keys from one session picker and makes reuse opt in", (
   assert.match(appSource, /function hodlMatchingMsigExport\(result\) \{/);
   assert.match(appSource, /function hodlSyncMsigKeyAvatar\(row\) \{/);
   assert.match(appSource, /function hodlPickMsigSessionKey\(state\) \{/);
-  assert.match(appSource, /function hodlMsigUsedSessionFingerprints\(\) \{/);
-  assert.match(appSource, /reuse \? keys : keys\.filter/);
+  assert.match(appSource, /function hodlMsigCanonicalSessionKey\(value\) \{/);
+  assert.match(appSource, /return hodlCanonicalMultisigKey\(hodlParseMultisigCosigner/);
+  assert.match(appSource, /function hodlMsigUsedSessionKeys\(\) \{/);
+  assert.match(appSource, /available = reuse \? options : options\.filter/);
   assert.match(appSource, /hodlMsigKeyTarget = \[\.\.\.document\.querySelectorAll\("#msig-keys textarea"\)\]\.find/);
   assert.doesNotMatch(appSource, /chips\.className = "msig-session-keys"/);
   assert.match(appSource, /hodlFillKeyTabLifehash\(image, fingerprint\)/);

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -1537,15 +1537,25 @@ test("derived key results put private recovery before script type and addresses"
   assert.match(appSource, /hodlBindWalletResultActions\(\);/);
 });
 
-test("multisig co-signer rows can pick a session key or paste a public key", () => {
+test("MS Station assigns keys from one session picker and makes reuse opt in", () => {
+  for (const markup of [template, appSource]) {
+    assert.match(markup, /class="station-key-source msig-station-key-source"[\s\S]*id="msig-session-keys"[\s\S]*id="msig-reuse-session-keys"/);
+    assert.match(markup, /Choose a compatible HD-root key from this session, or paste a co-signer extended public key below/);
+    assert.match(markup, /id="msig-reuse-session-keys" type="checkbox"/);
+  }
   assert.match(appSource, /function hodlSessionMsigKeys\(\) \{/);
   assert.match(appSource, /function hodlMatchingMsigExport\(result\) \{/);
   assert.match(appSource, /function hodlSyncMsigKeyAvatar\(row\) \{/);
-  assert.match(appSource, /chips\.className = "msig-session-keys"/);
-  assert.match(appSource, /button\.className = "msig-session-key"/);
+  assert.match(appSource, /function hodlPickMsigSessionKey\(state\) \{/);
+  assert.match(appSource, /function hodlMsigUsedSessionFingerprints\(\) \{/);
+  assert.match(appSource, /reuse \? keys : keys\.filter/);
+  assert.match(appSource, /hodlMsigKeyTarget = \[\.\.\.document\.querySelectorAll\("#msig-keys textarea"\)\]\.find/);
+  assert.doesNotMatch(appSource, /chips\.className = "msig-session-keys"/);
   assert.match(appSource, /hodlFillKeyTabLifehash\(image, fingerprint\)/);
   assert.match(appSource, /hodlRefreshMsigSessionPickers\(\)/);
-  assert.match(css, /\.msig-session-key \{/);
+  assert.match(appSource, /reuseSessionKeys: false/);
+  assert.match(appSource, /state\.fields\.reuseSessionKeys = Boolean/);
+  assert.match(css, /\.msig-key-reuse-toggle/);
   assert.match(css, /\.msig-key-ident \{/);
 });
 


### PR DESCRIPTION
## Summary

- rename the persistent work tabs to Key Station, BIP-85 Station, MS Station, and SP Station
- add monochrome Station icons, including the solid ridged SP coin and the single-seed BIP-85 sprout
- add a persistent BIP-85 Station with plus/minus child management, LifeHash fingerprints, and per-child result tabs
- let BIP-85 Station and SP Station bring in compatible HD-root keys from Key Station using visible LifeHash/fingerprint selectors
- add one MS Station key picker that fills the next or focused co-signer input, with opt-in key reuse and canonical extended-key identity checks
- keep manual seed/root-key and co-signer entry as explicit fallbacks
- rename the Key Station action to Derive Key

## Verification

- merged cleanly with the latest `rock`
- 828 Node CI tests
- site build and artifact verification
- 59 hosted/offline Chrome integration checks
- hosted Firefox integration checks in GitHub Actions

The generated `entropylab.html` artifact is intentionally excluded from this source PR and is rebuilt after merge.
