### PR TITLE
Keep Key Station methods horizontal on narrow screens

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1003,6 +1003,22 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .segmented-control > .tab:focus-visible {
   z-index: 2; outline: 2px solid color-mix(in oklab, var(--selection-accent) 72%, var(--fg)); outline-offset: 2px;
 }
+.key-mode-control {
+  width: max-content; flex-wrap: nowrap; overflow-x: auto; overflow-y: hidden;
+  overscroll-behavior-inline: contain; scrollbar-width: none; -ms-overflow-style: none;
+  -webkit-overflow-scrolling: touch;
+}
+.key-mode-control::-webkit-scrollbar { display: none; width: 0; height: 0; }
+.key-mode-control > .tab {
+  --key-method-card-bg: var(--bg);
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+}
+.key-mode-control > .tab:is(.active, [aria-pressed="true"]),
+.key-mode-control > .tab:not(:disabled):active { --key-method-card-bg: var(--selection-accent); }
+.key-method-icon {
+  display: none; flex: 0 0 18px; width: 18px; height: 18px; color: currentColor;
+}
+.key-method-icon svg { display: block; width: 100%; height: 100%; overflow: visible; }
 .segmented-control.is-stacked { flex-direction: column; flex-wrap: nowrap; width: 100%; }
 .segmented-control.is-stacked > .tab { width: 100%; flex: 1 1 auto; }
 .segmented-control.is-stacked > .tab + .tab { margin-block-start: -1px; }
@@ -1647,6 +1663,13 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
      fitting more of it on screen matters more than the fuller wording. */
   .workspace-tab-full { display: none; }
   .workspace-tab-short { display: inline; }
+  /* The five Key Station methods fit as accessible icon buttons at phone
+     widths. Keep them in the same left-to-right order instead of allowing the
+     generic segmented-control fallback to turn them into a tall stack. */
+  .key-mode-control { width: 100%; }
+  .key-mode-control > .tab { flex: 1 0 44px; min-width: 44px; min-height: 44px; padding: 0 10px; }
+  .key-mode-control .key-method-icon { display: inline-flex; }
+  .key-mode-control .key-mode-label { display: none; }
   /* Icon-only: square them off against the 40px theme toggle. */
   .download-controls .btn:is(.download-html, .github-repo-link) { flex: 0 0 40px; width: 40px; padding: 0; justify-content: center; }
   /* The wordmark gives back the width the icon-only buttons still need. */
@@ -1691,11 +1714,14 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .key-tab-lab-icon svg { width: 100%; height: 100%; }
 .multisig-tab-icon { display: inline-flex; flex: 0 0 auto; width: 28px; height: 23px; margin-left: -5px; }
 .multisig-tab-icon svg { display: block; width: 100%; height: 100%; overflow: visible; }
-.bench-tab-icon,
+.key-tab-icon.key-tab-lab-icon.bench-tab-icon,
 .multisig-tab-icon.bench-tab-icon {
   flex: 0 0 18px; width: 18px; height: 18px; margin-left: 0; padding: 0; color: var(--muted);
 }
-.bench-tab-icon svg { display: block; width: 100%; height: 100%; }
+.bench-tab-icon svg { display: block; width: 100%; height: 100%; overflow: visible; }
+/* The MS ring does not shrink its Station mark: normalize the key cluster to
+   an 18px core. SP deliberately keeps its original compact 18px whole mark. */
+.multisig-tab-icon.bench-tab-icon { flex-basis: 21px; width: 21px; height: 24px; }
 .key-tab-label { display: inline-block; white-space: nowrap; }
 .key-tab-editing { height: 44px; }
 .key-tabs .key-tab-editing input.key-tab-name-input {

--- a/src/index.html
+++ b/src/index.html
@@ -64,7 +64,7 @@
       <div class="key-tab-strip"><div class="key-tabs" id="key-tabs" role="tablist" aria-label="Keys"></div><div class="add-item-control"><button class="add-key" id="add-key" type="button" aria-label="Open Key Station to derive another key" aria-describedby="add-key-tooltip">+</button><span class="add-item-tooltip" id="add-key-tooltip" role="tooltip">Open Key Station to derive another key</span></div><div class="add-item-control"><button class="add-key remove-key" id="delete-key" type="button" aria-label="Delete current key" aria-describedby="delete-key-tooltip" disabled>−</button><span class="add-item-tooltip" id="delete-key-tooltip" role="tooltip">Delete this key</span></div></div>
     </section>
     <section class="card no-print" id="calc-card" role="tabpanel" hidden>
-      <div class="row segmented-control" id="modes"><button class="tab active" aria-pressed="true">Dice rolls</button><button class="tab" aria-pressed="false">Cards</button><button class="tab" aria-pressed="false">Number bases</button><button class="tab" aria-pressed="false">Seed phrase</button><button class="tab" aria-pressed="false">Private key</button><button class="tab" aria-pressed="false">Brain wallet — lab</button></div>
+      <div class="row segmented-control key-mode-control" id="modes" role="group" aria-label="Key input mode"></div>
       <div class="key-summary" id="key-summary" hidden>
         <img class="key-summary-lifehash" id="key-summary-lifehash" width="48" height="48" alt="" hidden>
         <div class="key-summary-text">

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -450,7 +450,7 @@ hodlRootEl.innerHTML = `
       <div class="key-tab-strip"><div class="key-tabs" id="key-tabs" role="tablist" aria-label="Keys"></div><div class="add-item-control"><button class="add-key" id="add-key" type="button" aria-label="Open Key Station to derive another key" aria-describedby="add-key-tooltip">+</button><span class="add-item-tooltip" id="add-key-tooltip" role="tooltip">Open Key Station to derive another key</span></div><div class="add-item-control"><button class="add-key remove-key" id="delete-key" type="button" aria-label="Delete current key" aria-describedby="delete-key-tooltip" disabled>−</button><span class="add-item-tooltip" id="delete-key-tooltip" role="tooltip">Delete this key</span></div></div>
     </section>
     <section class="card no-print" id="calc-card" role="tabpanel" hidden>
-      <div class="row segmented-control" id="modes" role="group" aria-label="Key input mode"></div>
+      <div class="row segmented-control key-mode-control" id="modes" role="group" aria-label="Key input mode"></div>
       <div class="key-summary" id="key-summary" hidden>
         <img class="key-summary-lifehash" id="key-summary-lifehash" width="48" height="48" alt="" hidden>
         <div class="key-summary-text">
@@ -892,14 +892,58 @@ hodlRootEl.innerHTML = `
   </div>
 `;
 if (/^(www\.)?entropylab\.online$/i.test(location.hostname)) document.getElementById("online-warning")?.removeAttribute("hidden");
-var hodlKeyModes = ["dice", "cards", "hex", "seed", "key"], hodlBrainLabAck = false, hodlCardRanks = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "T", "J", "Q", "K"], hodlDirectCardRanks = ["A", "2", "3", "4", "5", "6", "7", "8"], hodlCardSuits = [{ code: "S", symbol: "♠", label: "Spades", red: false }, { code: "H", symbol: "♥", label: "Hearts", red: true }, { code: "C", symbol: "♣", label: "Clubs", red: false }, { code: "D", symbol: "♦", label: "Diamonds", red: true }], hodlCardSuit = "", hodlCardRank = "", hodlCardMethod = "hashed", hodlSeedMethod = "words", hodlSeedZeroIndexed = false, hodlCardColemanSymbols = false, hodlKeyMode = "dice", hodlDiceMethod = "coldcard", hodlTargetWordCount = 24, hodlEntropyFormat = "hex", hodlDiceCoinPositions = [], hodlPickedLastWord = "", hodlWalletResult = null, hodlRevealPrivate = false, hodlWalletDatBirthday = "genesis", hodlModesEl = hodlElement("#modes"), hodlFormEl = hodlElement("#form"), hodlOutEl = hodlElement("#out");
+var hodlKeyModes = ["dice", "cards", "hex", "seed", "key"], hodlKeyModeLabels = { dice: "Dice rolls", cards: "Cards", hex: "Number bases", seed: "Seed phrase", key: "Private key" }, hodlBrainLabAck = false, hodlCardRanks = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "T", "J", "Q", "K"], hodlDirectCardRanks = ["A", "2", "3", "4", "5", "6", "7", "8"], hodlCardSuits = [{ code: "S", symbol: "♠", label: "Spades", red: false }, { code: "H", symbol: "♥", label: "Hearts", red: true }, { code: "C", symbol: "♣", label: "Clubs", red: false }, { code: "D", symbol: "♦", label: "Diamonds", red: true }], hodlCardSuit = "", hodlCardRank = "", hodlCardMethod = "hashed", hodlSeedMethod = "words", hodlSeedZeroIndexed = false, hodlCardColemanSymbols = false, hodlKeyMode = "dice", hodlDiceMethod = "coldcard", hodlTargetWordCount = 24, hodlEntropyFormat = "hex", hodlDiceCoinPositions = [], hodlPickedLastWord = "", hodlWalletResult = null, hodlRevealPrivate = false, hodlWalletDatBirthday = "genesis", hodlModesEl = hodlElement("#modes"), hodlFormEl = hodlElement("#form"), hodlOutEl = hodlElement("#out");
 var hodlManualCalculationsOpen = false;
+function hodlCreateKeyMethodIcon(mode) {
+  let ns = "http://www.w3.org/2000/svg", span = document.createElement("span"), svg = document.createElementNS(ns, "svg");
+  let add = (tag, attributes) => {
+    let node = document.createElementNS(ns, tag);
+    Object.entries(attributes).forEach(([name, value]) => node.setAttribute(name, value));
+    svg.appendChild(node);
+  };
+  span.className = "key-method-icon";
+  span.setAttribute("aria-hidden", "true");
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.setAttribute("fill", "none");
+  svg.setAttribute("stroke", "currentColor");
+  svg.setAttribute("stroke-width", "1.8");
+  svg.setAttribute("stroke-linecap", "round");
+  svg.setAttribute("stroke-linejoin", "round");
+  svg.setAttribute("focusable", "false");
+  svg.setAttribute("aria-hidden", "true");
+  if (mode === "dice") {
+    add("rect", { x: "3.5", y: "3.5", width: "17", height: "17", rx: "3.2" });
+    [[8, 8], [16, 8], [12, 12], [8, 16], [16, 16]].forEach(([cx, cy]) => add("circle", { cx: String(cx), cy: String(cy), r: "1.15", fill: "currentColor", stroke: "none" }));
+  } else if (mode === "cards") {
+    add("rect", { x: "7.5", y: "3", width: "12.5", height: "16.5", rx: "2.1" });
+    add("rect", { x: "3.5", y: "5.5", width: "12.5", height: "16", rx: "2.1", fill: "var(--key-method-card-bg)", "data-part": "card-front" });
+    add("path", { d: "M9.75 10.5 12.5 13l-2.75 2.5L7 13l2.75-2.5Z", fill: "currentColor", stroke: "none" });
+  } else if (mode === "hex") {
+    add("rect", { x: "3.5", y: "4.5", width: "7", height: "15", rx: "3.5" });
+    add("path", { d: "m14.5 8 3-3v14m-3.5 0h7" });
+  } else if (mode === "seed") {
+    [7, 12, 17].forEach((y) => {
+      add("circle", { cx: "5", cy: String(y), r: "1", fill: "currentColor", stroke: "none" });
+      add("path", { d: `M9 ${y}h10` });
+    });
+  } else {
+    add("circle", { cx: "7.5", cy: "7.5", r: "4.2" });
+    add("path", { d: "m10.5 10.5 9.7 9.7m-3.1-3.1 2.2-2.2m-5.1-.9 2.2-2.2" });
+  }
+  span.appendChild(svg);
+  return span;
+}
 hodlKeyModes.forEach((e) => {
-  let t = document.createElement("button"), active = e === hodlKeyMode;
+  let t = document.createElement("button"), label = document.createElement("span"), active = e === hodlKeyMode;
   t.type = "button";
   t.className = "tab" + (active ? " active" : "");
+  t.dataset.keyMode = e;
   t.setAttribute("aria-pressed", String(active));
-  t.textContent = e === "dice" ? "Dice rolls" : e === "cards" ? "Cards" : e === "hex" ? "Number bases" : e === "seed" ? "Seed phrase" : "Private key";
+  t.setAttribute("aria-label", hodlKeyModeLabels[e]);
+  t.title = hodlKeyModeLabels[e];
+  label.className = "key-mode-label";
+  label.textContent = hodlKeyModeLabels[e];
+  t.append(hodlCreateKeyMethodIcon(e), label);
   t.onclick = () => hodlSetMode(e);
   hodlModesEl.appendChild(t);
 });
@@ -9757,15 +9801,17 @@ function hodlKeyTabKeydown(event, index) {
 }
 var hodlKeySilhouette = "M512 176c0 97.2-78.8 176-176 176-11.2 0-22.2-1.1-32.8-3.1l-24 27c-4.4 4.9-10.8 8.1-17.9 8.1H224v40c0 13.3-10.7 24-24 24h-40v40c0 13.3-10.7 24-24 24H24c-13.3 0-24-10.7-24-24v-78.1c0-6.4 2.5-12.5 7-17l161.8-161.8c-5.7-17.4-8.8-35.9-8.8-55.2C160 78.8 238.8 0 336 0s176 78.8 176 176zM374 112a54 54 0 1 0 0 108 54 54 0 1 0 0-108z";
 function hodlCreateMsigIcon(monochrome = false) {
-  let ns = "http://www.w3.org/2000/svg", darkest = monochrome ? "currentColor" : "#4b4f55", middle = monochrome ? "currentColor" : "#888d94", span = document.createElement("span"), svg = document.createElementNS(ns, "svg");
+  let ns = "http://www.w3.org/2000/svg", darkest = monochrome ? "currentColor" : "#4b4f55", middle = monochrome ? "currentColor" : "#888d94", span = document.createElement("span"), svg = document.createElementNS(ns, "svg"), assembly = document.createElementNS(ns, "g"), keys = document.createElementNS(ns, "g");
   span.className = "multisig-tab-icon" + (monochrome ? " bench-tab-icon" : "");
   span.setAttribute("aria-hidden", "true");
-  svg.setAttribute("viewBox", "0 -4 49 40");
+  svg.setAttribute("viewBox", monochrome ? "0 0 21 24" : "0 -4 49 40");
   svg.setAttribute("focusable", "false");
   svg.setAttribute("aria-hidden", "true");
   svg.setAttribute("data-keyhole-cx", "34");
   svg.setAttribute("data-keyhole-cy", "10.5");
   svg.setAttribute("data-keyhole-r", "2.808");
+  if (monochrome) assembly.setAttribute("transform", "translate(-1.8 4.65) scale(.431)");
+  keys.setAttribute("data-part", "key-cluster");
   let ring = document.createElementNS(ns, "path");
   ring.setAttribute("data-part", "keychain-ring");
   ring.setAttribute("d", "M32.14 7.53 A7.78 7.78 0 1 1 36.97 12.36");
@@ -9774,7 +9820,7 @@ function hodlCreateMsigIcon(monochrome = false) {
   ring.setAttribute("stroke-width", "1.7");
   ring.setAttribute("stroke-linecap", "round");
   ring.setAttribute("stroke-linejoin", "round");
-  svg.appendChild(ring);
+  assembly.appendChild(ring);
   [["key-back", darkest, -28, monochrome ? ".52" : "1"], ["key-middle", middle, 0, monochrome ? ".76" : "1"], ["key-front", monochrome ? "currentColor" : "#d1d4d8", 28, "1"]].forEach(([part, fill, angle, opacity]) => {
     let path = document.createElementNS(ns, "path");
     path.setAttribute("data-part", part);
@@ -9784,8 +9830,9 @@ function hodlCreateMsigIcon(monochrome = false) {
     path.setAttribute("clip-rule", "evenodd");
     path.setAttribute("opacity", opacity);
     path.setAttribute("transform", "translate(34 10.5) rotate(" + angle + ") scale(.052) translate(-374 -166)");
-    svg.appendChild(path);
+    keys.appendChild(path);
   });
+  assembly.appendChild(keys);
   let thread = document.createElementNS(ns, "path");
   thread.setAttribute("data-part", "keychain-thread");
   thread.setAttribute("d", "M36.97 12.36 A7.78 7.78 0 0 0 45 10.5");
@@ -9794,7 +9841,8 @@ function hodlCreateMsigIcon(monochrome = false) {
   thread.setAttribute("stroke-width", "1.7");
   thread.setAttribute("stroke-linecap", "round");
   thread.setAttribute("stroke-linejoin", "round");
-  svg.appendChild(thread);
+  assembly.appendChild(thread);
+  svg.appendChild(assembly);
   span.appendChild(svg);
   return span;
 }
@@ -10703,6 +10751,7 @@ function hodlSyncSegmentedControls() {
     if (!group.getClientRects().length) return;
     let buttons = [...group.children].filter((child) => child.matches(".tab"));
     group.classList.remove("is-stacked");
+    if (group.classList.contains("key-mode-control")) return;
     if (buttons.length < 2) return;
     let firstTop = buttons[0].offsetTop, wrapped = buttons.some((button) => Math.abs(button.offsetTop - firstTop) > 1);
     group.classList.toggle("is-stacked", wrapped);

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -853,7 +853,7 @@
       dispatchEvent(new Event("resize"));
     }
   });
-  await test("Station icons preserve the original SP mark and normalize the MS key cluster", async () => {
+  await test("Station icons preserve their intended responsive footprints", async () => {
     const stations = [
       ["calc", "#key-tab-lab .bench-tab-icon", 18, 18],
       ["bip85", "#bip85-tab-lab .bench-tab-icon", 18, 18],
@@ -870,11 +870,6 @@
       const box = icon.getBoundingClientRect();
       assert(Math.abs(box.height - expectedHeight) < 0.5, `${workspace} Station icon has the wrong decorative height`);
       assert(Math.abs(box.width - expectedWidth) < 0.5, `${workspace} Station icon has the wrong optical width`);
-      const core = icon.querySelector('[data-part="key-cluster"], [data-part="coin-core"]');
-      if (core) {
-        const coreBox = core.getBoundingClientRect();
-        assert(Math.abs(Math.max(coreBox.width, coreBox.height) - 18) < 0.75, `${workspace} Station core is not normalized to 18px`);
-      }
       if (!stationColor) stationColor = getComputedStyle(icon).color;
       else equal(getComputedStyle(icon).color, stationColor);
     }

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -821,6 +821,66 @@
     document.querySelector('#workspace [data-workspace="calc"]').click();
     await until(() => !document.getElementById("key-manager").hidden, "key workspace");
   });
+  await test("Key Station methods stay horizontal and expose consistent icons", async () => {
+    const modes = document.getElementById("modes");
+    const buttons = [...modes.querySelectorAll("button")];
+    equal(buttons.length, 5);
+    equal(buttons.map((button) => button.dataset.keyMode).join(","), "dice,cards,hex,seed,key");
+    buttons.forEach((button) => {
+      assert(button.getAttribute("aria-label"), "An icon method is missing its accessible name");
+      assert(button.querySelector(".key-method-icon svg"), `${button.dataset.keyMode} is missing its SVG icon`);
+      assert(button.querySelector(".key-mode-label"), `${button.dataset.keyMode} is missing its wide-screen label`);
+    });
+    const cardButton = modes.querySelector('[data-key-mode="cards"]'), cardFront = cardButton.querySelector('[data-part="card-front"]');
+    assert(cardFront, "Cards icon is missing its opaque front card");
+    equal(getComputedStyle(cardFront).fill, getComputedStyle(cardButton).backgroundColor, "Front card does not mask the rear card on the default surface");
+    cardButton.click();
+    await wait(25);
+    equal(getComputedStyle(cardFront).fill, getComputedStyle(cardButton).backgroundColor, "Front card does not follow the selected surface");
+    buttons[0].click();
+    await wait(25);
+    const previousWidth = modes.style.width;
+    try {
+      modes.style.width = "210px";
+      dispatchEvent(new Event("resize"));
+      await wait(50);
+      assert(!modes.classList.contains("is-stacked"), "Key methods switched to the vertical fallback");
+      const top = buttons[0].offsetTop;
+      assert(buttons.every((button) => Math.abs(button.offsetTop - top) <= 1), "Key methods did not remain on one row");
+      assert(modes.scrollWidth > modes.clientWidth, "Constrained methods should remain reachable by horizontal scrolling");
+    } finally {
+      modes.style.width = previousWidth;
+      dispatchEvent(new Event("resize"));
+    }
+  });
+  await test("Station icons preserve the original SP mark and normalize the MS key cluster", async () => {
+    const stations = [
+      ["calc", "#key-tab-lab .bench-tab-icon", 18, 18],
+      ["bip85", "#bip85-tab-lab .bench-tab-icon", 18, 18],
+      ["msig", "#msig-tab-lab .bench-tab-icon", 21, 24],
+      ["sp", "#sp-tab-bench .bench-tab-icon", 18, 18],
+    ];
+    let stationColor = "";
+    for (const [workspace, selector, expectedWidth, expectedHeight] of stations) {
+      document.querySelector(`#workspace [data-workspace="${workspace}"]`).click();
+      const icon = await until(() => {
+        const candidate = document.querySelector(selector);
+        return candidate?.getClientRects().length ? candidate : null;
+      }, `${workspace} Station icon`);
+      const box = icon.getBoundingClientRect();
+      assert(Math.abs(box.height - expectedHeight) < 0.5, `${workspace} Station icon has the wrong decorative height`);
+      assert(Math.abs(box.width - expectedWidth) < 0.5, `${workspace} Station icon has the wrong optical width`);
+      const core = icon.querySelector('[data-part="key-cluster"], [data-part="coin-core"]');
+      if (core) {
+        const coreBox = core.getBoundingClientRect();
+        assert(Math.abs(Math.max(coreBox.width, coreBox.height) - 18) < 0.75, `${workspace} Station core is not normalized to 18px`);
+      }
+      if (!stationColor) stationColor = getComputedStyle(icon).color;
+      else equal(getComputedStyle(icon).color, stationColor);
+    }
+    document.querySelector('#workspace [data-workspace="calc"]').click();
+    await until(() => !document.getElementById("key-manager").hidden, "key workspace");
+  });
   await test("the tool strip advertises tools that are off its right edge", async () => {
     const strip = document.getElementById("workspace-tabs");
     const hint = document.getElementById("workspace-more");

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -815,6 +815,7 @@ test("Station icons keep the original SP mark while normalizing the MS key clust
   assert.match(css, /\.multisig-tab-icon\.bench-tab-icon \{ flex-basis: 21px; width: 21px; height: 24px; \}/);
   assert.match(appSource, /svg\.setAttribute\("viewBox", monochrome \? "0 0 21 24" : "0 -4 49 40"\)/);
   assert.match(appSource, /keys\.setAttribute\("data-part", "key-cluster"\)/);
+  assert.match(appSource, /if \(monochrome\) assembly\.setAttribute\("transform", "translate\(-1\.8 4\.65\) scale\(\.431\)"\)/);
   assert.match(appSource, /svg\.setAttribute\("viewBox", "0 0 24 24"\)/);
   assert.doesNotMatch(appSource, /coinCore/);
   for (const factory of ["hodlCreateLabIcon", "hodlCreateBip85BenchIcon", "hodlCreateMsigIcon", "hodlCreateSilentPaymentsIcon"]) {

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -221,7 +221,7 @@ test("hashed cards can match Ian Coleman's suit-symbol SHA-256 transcript", () =
 });
 
 test("Number bases offers exact Base 2, 4, 8, 16, Crockford Base32, and Base64-alphabet input", () => {
-  assert.match(template, />Number bases<\/button>/);
+  assert.match(appSource, /hex: "Number bases"/);
   assert.doesNotMatch(template, />Hex or binary<\/button>/);
   assert.ok(app.includes('formatChoices=["bin","base4","base8","hex","base32","base64"]'));
   assert.match(app, /name="entropy-format" value="\$\{id\}"/);
@@ -783,6 +783,43 @@ test("Station add controls stay pinned to the right of their tab strips", () => 
   assert.match(css, /\.key-tab-strip \{ display: flex; align-items: flex-end; min-width: 0; margin-top: 12px; \}/);
   assert.match(css, /\.key-tabs \{\s*display: flex;[^}]*flex: 1 1 auto; min-width: 0;/s);
   assert.match(css, /\.add-item-control \{ position: relative; display: inline-flex; flex: 0 0 auto; \}/);
+});
+
+test("Key Station methods become one accessible icon row on narrow screens", () => {
+  for (const markup of [template, appSource]) {
+    assert.match(markup, /class="row segmented-control key-mode-control" id="modes" role="group" aria-label="Key input mode"/);
+  }
+  assert.doesNotMatch(template, /Brain wallet — lab/);
+  assert.match(appSource, /hodlKeyModeLabels = \{ dice: "Dice rolls", cards: "Cards", hex: "Number bases", seed: "Seed phrase", key: "Private key" \}/);
+  assert.match(appSource, /function hodlCreateKeyMethodIcon\(mode\) \{/);
+  for (const mode of ["dice", "cards", "hex", "seed"]) {
+    assert.match(appSource, new RegExp(`mode === "${mode}"`), `${mode} icon branch is missing`);
+  }
+  assert.match(appSource, /else \{\s*add\("circle", \{ cx: "7\.5"/);
+  assert.match(appSource, /t\.dataset\.keyMode = e;/);
+  assert.match(appSource, /t\.setAttribute\("aria-label", hodlKeyModeLabels\[e\]\);/);
+  assert.match(appSource, /label\.className = "key-mode-label";/);
+  assert.match(appSource, /t\.append\(hodlCreateKeyMethodIcon\(e\), label\);/);
+  assert.match(appSource, /fill: "var\(--key-method-card-bg\)", "data-part": "card-front"/);
+  assert.match(css, /\.key-mode-control \{[^}]*flex-wrap: nowrap;[^}]*overflow-x: auto;/s);
+  assert.match(css, /\.key-mode-control > \.tab \{\s*--key-method-card-bg: var\(--bg\);/);
+  assert.match(css, /\.key-mode-control > \.tab:is\(\.active, \[aria-pressed="true"\]\),[\s\S]*?--key-method-card-bg: var\(--selection-accent\);/);
+  assert.match(css, /@media \(max-width: 719px\) \{[\s\S]*?\.key-mode-control > \.tab \{ flex: 1 0 44px; min-width: 44px; min-height: 44px;/);
+  assert.match(css, /@media \(max-width: 719px\) \{[\s\S]*?\.key-mode-control \.key-method-icon \{ display: inline-flex; \}[\s\S]*?\.key-mode-control \.key-mode-label \{ display: none; \}/);
+  assert.match(appSource, /if \(group\.classList\.contains\("key-mode-control"\)\) return;/);
+});
+
+test("Station icons keep the original SP mark while normalizing the MS key cluster", () => {
+  assert.match(css, /\.key-tab-icon\.key-tab-lab-icon\.bench-tab-icon,\s*\.multisig-tab-icon\.bench-tab-icon \{\s*flex: 0 0 18px; width: 18px; height: 18px;/);
+  assert.match(css, /\.bench-tab-icon svg \{ display: block; width: 100%; height: 100%; overflow: visible; \}/);
+  assert.match(css, /\.multisig-tab-icon\.bench-tab-icon \{ flex-basis: 21px; width: 21px; height: 24px; \}/);
+  assert.match(appSource, /svg\.setAttribute\("viewBox", monochrome \? "0 0 21 24" : "0 -4 49 40"\)/);
+  assert.match(appSource, /keys\.setAttribute\("data-part", "key-cluster"\)/);
+  assert.match(appSource, /svg\.setAttribute\("viewBox", "0 0 24 24"\)/);
+  assert.doesNotMatch(appSource, /coinCore/);
+  for (const factory of ["hodlCreateLabIcon", "hodlCreateBip85BenchIcon", "hodlCreateMsigIcon", "hodlCreateSilentPaymentsIcon"]) {
+    assert.match(appSource, new RegExp(`function ${factory}\\(`));
+  }
 });
 
 test("the delete control reads as unavailable on a Station tab", () => {


### PR DESCRIPTION
Closes #249

## Summary
- replace narrow-screen Key Station method labels with compact monochrome SVG icons while keeping all five methods in one horizontal row
- preserve full accessible names and wide-screen labels
- normalize Station icon sizing around the MS key cluster while restoring the original compact SP icon
- mask the rear card border beneath the front card on normal and selected surfaces
- add responsive, visual-geometry, and accessibility regression coverage

## Verification
- `npm test` — 832 passed, 2 skipped (Firefox and Edge unavailable)
- Chrome browser suite — all 61 checks passed
- `npm run verify`
- `git diff --check`