### PR TITLE
Fix D++ narrow progress wrapping

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -5746,7 +5746,10 @@ function hodlUpdateDice() {
     if (rollPhrase) {
       let emphasis = document.createElement("strong");
       emphasis.textContent = rollPhrase;
-      meta.append(document.createTextNode(" \xB7 "), emphasis, document.createTextNode(rollRange))
+      let accessibleRange = document.createElement("span");
+      accessibleRange.className = "sr-only";
+      accessibleRange.textContent = rollRange;
+      meta.append(document.createTextNode(" \xB7 "), emphasis, accessibleRange)
     }
     meta.append(document.createTextNode(statusTail + invalidStatus));
     meta.className = "muted" + (complete && !result.invalidCount ? " ok" : result.invalidCount ? " err" : "");

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -581,6 +581,11 @@
 
     await chooseMode("Dice rolls");
     document.querySelector('input[name="dm"][value="dplus"]').click();
+    const dplusProgress = document.getElementById("dice-meta");
+    const dplusRange = dplusProgress.querySelector(".sr-only");
+    assert(/D8 roll|D16 roll/.test(dplusProgress.textContent) && /^ \([01]–[8F]\)$/.test(dplusRange?.textContent || ""), "D++ progress lost its accessible next-roll range");
+    assert([...dplusProgress.childNodes].filter((node) => node.nodeType === Node.TEXT_NODE).every((node) => !/[01]–[8F]/.test(node.textContent)), "D++ progress left the face range in the visible narrow-screen line");
+    assert(document.getElementById("dice-help").textContent.includes("D8 face from 1–8") && document.getElementById("dice-help").textContent.includes("D16 faces from 0–F"), "D++ input guidance lost its face ranges");
     equal(document.getElementById("dice").value, "1", "Three bits did not emit the first complete D++ D8 result");
     document.querySelector('input[name="dm"][value="bitbox"]').click();
     equal(document.getElementById("dice").value, "1", "BitBox emitted a second die before four bits were available");

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -1350,6 +1350,8 @@ test("D++ uses the published hexadecimal D16 transcript without a notation toggl
   assert.match(appSource, /let dplusFaces = \["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F"\]/);
   assert.match(appSource, /D\+\+ rolls \(D8, D16, D16; then/);
   assert.doesNotMatch(appSource, /D\+\+ rolls \(D8 1\\u20138, D16 0\\u2013F/);
+  assert.match(appSource, /accessibleRange\.className = "sr-only";\s*accessibleRange\.textContent = rollRange;/);
+  assert.doesNotMatch(appSource, /meta\.append\(document\.createTextNode\(" \\xB7 "\), emphasis, document\.createTextNode\(rollRange\)\)/);
   assert.match(appSource, /D8 labeled 1\\u20138 and two hexadecimal D16 dice labeled 0\\u2013F/);
   assert.match(appSource, /100 selects abandon and 8FF selects zoo/);
   assert.doesNotMatch(appSource, /data-dplus-die|hodlDPlusNumberedD16|dplusNumberedD16|Decimal D16/);


### PR DESCRIPTION
Fixes #231.

The previous heading-only change did not address the wrapping shown in the issue attachment. The wrapping comes from the live D++ progress line, where the face range can be stranded on its own line at narrow widths.

This keeps the visible progress line focused on the next roll while retaining the valid face range in screen-reader-only live-region content. The visible help text and keypad accessibility labels continue to explain the accepted D8 and hexadecimal D16 faces.

Regression coverage checks that:
- face ranges are not visible in the progress line;
- live progress still exposes the range to assistive technology;
- the D++ help text retains the input guidance.

Verification:
- `npm run test:ci` (839 passed)
- `npm run build`
- `npm run verify`
- `npm run test:browser` (all 60 Chrome/Chromium checks passed; the host snap Firefox could not start because its runtime paths are read-only; Edge is not installed)