### PR TITLE
Make the Key Station method and seed length dropdowns

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -199,10 +199,20 @@ textarea { display: block; min-height: 96px; letter-spacing: 0.08em; }
 .seed-autocomplete-note { color: var(--muted); font-weight: 400; }
 .seed-entry-tools { display: flex; align-items: stretch; gap: var(--space-control); margin-top: var(--space-component); }
 .seed-entry-tools .seed-autocomplete-toggle { flex: 1 1 auto; margin-top: 0; }
-.global-sync-host { margin-top: var(--space-component); }
+/* Tighter to the dropdown above than to the section below: the control reads
+   as part of the method it qualifies, and the 8px off the top is given back
+   under the explanation. */
+.global-sync-host { margin-top: var(--space-control); padding-bottom: var(--space-control); }
 .global-sync-host[hidden] { display: none; }
-.global-sync-row { display: flex; align-items: stretch; gap: var(--space-control); }
-.global-sync-toggle { flex: 1 1 auto; margin-top: 0; }
+/* Two rows: the switch and its title, then the explanation under both. The
+   shared toggle chrome is a bordered chip elsewhere; here the control reads as
+   part of the card, so it gives up the box and keeps the 44px target. */
+.global-sync-row { display: block; }
+.global-sync-head { display: flex; align-items: center; gap: var(--space-control); }
+.global-sync-toggle { flex: 1 1 auto; min-height: 32px; margin-top: 0; padding: 0; border: 0; background: none; }
+/* The title carries the same weight and colour as the Method label above it. */
+.global-sync-toggle .label { margin: 0; }
+.global-sync-note { display: block; margin: 0; font-size: 13px; line-height: 1.45; }
 .global-sync-status {
   display: inline-flex; align-items: center; gap: 5px; flex: 0 0 auto;
   color: var(--ok); font-size: 13px; font-weight: 600; white-space: nowrap;
@@ -1073,22 +1083,30 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .segmented-control > .tab:focus-visible {
   z-index: 2; outline: 2px solid color-mix(in oklab, var(--selection-accent) 72%, var(--fg)); outline-offset: 2px;
 }
-.key-mode-control {
-  width: max-content; flex-wrap: nowrap; overflow-x: auto; overflow-y: hidden;
-  overscroll-behavior-inline: contain; scrollbar-width: none; -ms-overflow-style: none;
-  -webkit-overflow-scrolling: touch;
-}
-.key-mode-control::-webkit-scrollbar { display: none; width: 0; height: 0; }
-.key-mode-control > .tab {
-  --key-method-card-bg: var(--bg);
-  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
-}
-.key-mode-control > .tab:is(.active, [aria-pressed="true"]),
-.key-mode-control > .tab:not(:disabled):active { --key-method-card-bg: var(--selection-accent); }
+/* The Cards mark's front face masks the rear one, so it has to carry whatever
+   surface it is drawn on: the closed control's ground, the list's, and the
+   tints the selected and hovered rows take. */
+.key-mode-select .custom-select-button { --key-method-card-bg: var(--bg); }
+.key-mode-select .custom-select-list { --key-method-card-bg: var(--surface-2); }
+.key-mode-select .custom-select-option:hover,
+.key-mode-select .custom-select-option:focus-visible { --key-method-card-bg: color-mix(in oklab, var(--accent) 14%, var(--surface-2)); }
+.key-mode-select .custom-select-option[aria-selected="true"] { --key-method-card-bg: color-mix(in oklab, var(--accent) 20%, var(--surface-2)); }
 .key-method-icon {
-  display: none; flex: 0 0 18px; width: 18px; height: 18px; color: currentColor;
+  display: inline-flex; flex: 0 0 18px; width: 18px; height: 18px; color: currentColor;
 }
 .key-method-icon svg { display: block; width: 100%; height: 100%; overflow: visible; }
+/* The method picker, in the Script type control's chrome that
+   enhanced-inputs.js builds: the mark sits ahead of the label in the button
+   and in every option. */
+.key-mode-select > .label { margin: 0 0 8px; }
+.key-mode-select .custom-select, .seed-length-select .custom-select { margin-top: 0; }
+/* Half the card, sharing the right edge with the Script type control below:
+   that field is one of two grid columns, so the gap comes off this width too.
+   Below the header breakpoint these go full width while that row is still two
+   columns, so they part company there. */
+.key-mode-select, .seed-length-select { width: calc(50% - var(--space-component) / 2); }
+.key-mode-select .custom-select-option { display: flex; align-items: center; gap: 8px; }
+.key-mode-select .custom-select-value { display: inline-flex; align-items: center; gap: 8px; min-width: 0; }
 .segmented-control.is-stacked { flex-direction: column; flex-wrap: nowrap; width: 100%; }
 .segmented-control.is-stacked > .tab { width: 100%; flex: 1 1 auto; }
 .segmented-control.is-stacked > .tab + .tab { margin-block-start: -1px; }
@@ -1272,7 +1290,6 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .seed-length-control[hidden] { display: none !important; }
 .seed-length-control .label { margin: 0 0 8px; }
 .seed-length-control .muted { margin: var(--space-control) 0 0; }
-.seed-length-options { align-items: center; }
 .key-form { margin-top: var(--space-section); }
 .key-form > :first-child { margin-top: 0; }
 .key-form > .muted { margin: var(--space-control) 0 0; }
@@ -1729,6 +1746,9 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 @media (max-width: 719px) {
   :root { --site-header-pad: 12px; }
   .control-label { display: none; }
+  /* The Station's dropdowns take the whole card from the same width the bar's
+     controls collapse at, so the page changes shape in one step. */
+  .key-mode-select, .seed-length-select { width: 100%; }
   /* Icon-only in the row, square against the 40px theme toggle it sits
      beside: the picker keeps its place among the header controls rather than
      dropping out of the bar, and the coin's colour still carries the network.
@@ -1740,13 +1760,6 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
      fitting more of it on screen matters more than the fuller wording. */
   .workspace-tab-full { display: none; }
   .workspace-tab-short { display: inline; }
-  /* The five Key Station methods fit as accessible icon buttons at phone
-     widths. Keep them in the same left-to-right order instead of allowing the
-     generic segmented-control fallback to turn them into a tall stack. */
-  .key-mode-control { width: 100%; }
-  .key-mode-control > .tab { flex: 1 0 44px; min-width: 44px; min-height: 44px; padding: 0 10px; }
-  .key-mode-control .key-method-icon { display: inline-flex; }
-  .key-mode-control .key-mode-label { display: none; }
   /* Icon-only: square them off against the 40px theme toggle. */
   .download-controls .download-html { flex: 0 0 40px; width: 40px; padding: 0; justify-content: center; }
   /* The footer link loses its label with the rest, so it squares off against

--- a/src/index.html
+++ b/src/index.html
@@ -72,7 +72,7 @@
       <div class="key-tab-strip"><div class="key-tabs" id="key-tabs" role="tablist" aria-label="Keys"></div><div class="add-item-control"><button class="add-key" id="add-key" type="button" aria-label="Open Key Station to derive another key" aria-describedby="add-key-tooltip">+</button><span class="add-item-tooltip" id="add-key-tooltip" role="tooltip">Open Key Station to derive another key</span></div><div class="add-item-control"><button class="add-key remove-key" id="delete-key" type="button" aria-label="Delete current key" aria-describedby="delete-key-tooltip" disabled>−</button><span class="add-item-tooltip" id="delete-key-tooltip" role="tooltip">Delete this key</span></div></div>
     </section>
     <section class="card no-print" id="calc-card" role="tabpanel" hidden>
-      <div class="row segmented-control key-mode-control" id="modes" role="group" aria-label="Key input mode"></div>
+      <div class="key-mode-select" id="modes"><p class="label" id="key-method-label">Method</p></div>
       <div class="key-summary" id="key-summary" hidden>
         <img class="key-summary-lifehash" id="key-summary-lifehash" width="48" height="48" alt="" hidden>
         <div class="key-summary-text">
@@ -86,12 +86,8 @@
       <div class="key-lab" id="key-lab">
       <section class="seed-length-control" id="seed-length" aria-labelledby="seed-length-label">
         <p class="label" id="seed-length-label">Seed phrase length</p>
-        <div class="row seed-length-options segmented-control" role="group" aria-label="Seed phrase length">
-          <button type="button" class="tab" data-seed-words="12" aria-pressed="false">12 words</button>
-          <button type="button" class="tab" data-seed-words="15" aria-pressed="false">15 words</button>
-          <button type="button" class="tab" data-seed-words="18" aria-pressed="false">18 words</button>
-          <button type="button" class="tab" data-seed-words="21" aria-pressed="false">21 words</button>
-          <button type="button" class="tab active" data-seed-words="24" aria-pressed="true">24 words</button>
+        <div class="seed-length-select">
+          <select id="seed-length-select" aria-labelledby="seed-length-label"><option value="12">12 words</option><option value="15">15 words</option><option value="18">18 words</option><option value="21">21 words</option><option value="24" selected="selected">24 words</option></select>
         </div>
         <p class="muted" id="seed-length-help">24 words use 256 bits of BIP39 entropy.</p>
       </section>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -458,7 +458,7 @@ hodlRootEl.innerHTML = `
       <div class="key-tab-strip"><div class="key-tabs" id="key-tabs" role="tablist" aria-label="Keys"></div><div class="add-item-control"><button class="add-key" id="add-key" type="button" aria-label="Open Key Station to derive another key" aria-describedby="add-key-tooltip">+</button><span class="add-item-tooltip" id="add-key-tooltip" role="tooltip">Open Key Station to derive another key</span></div><div class="add-item-control"><button class="add-key remove-key" id="delete-key" type="button" aria-label="Delete current key" aria-describedby="delete-key-tooltip" disabled>−</button><span class="add-item-tooltip" id="delete-key-tooltip" role="tooltip">Delete this key</span></div></div>
     </section>
     <section class="card no-print" id="calc-card" role="tabpanel" hidden>
-      <div class="row segmented-control key-mode-control" id="modes" role="group" aria-label="Key input mode"></div>
+      <div class="key-mode-select" id="modes"><p class="label" id="key-method-label">Method</p></div>
       <div class="key-summary" id="key-summary" hidden>
         <img class="key-summary-lifehash" id="key-summary-lifehash" width="48" height="48" alt="" hidden>
         <div class="key-summary-text">
@@ -473,12 +473,8 @@ hodlRootEl.innerHTML = `
       <div class="global-sync-host" id="global-sync-host"></div>
       <section class="seed-length-control" id="seed-length" aria-labelledby="seed-length-label">
         <p class="label" id="seed-length-label">Seed phrase length</p>
-        <div class="row seed-length-options segmented-control" role="group" aria-label="Seed phrase length">
-          <button type="button" class="tab" data-seed-words="12" aria-pressed="false">12 words</button>
-          <button type="button" class="tab" data-seed-words="15" aria-pressed="false">15 words</button>
-          <button type="button" class="tab" data-seed-words="18" aria-pressed="false">18 words</button>
-          <button type="button" class="tab" data-seed-words="21" aria-pressed="false">21 words</button>
-          <button type="button" class="tab active" data-seed-words="24" aria-pressed="true">24 words</button>
+        <div class="seed-length-select">
+          <select id="seed-length-select" aria-labelledby="seed-length-label"><option value="12">12 words</option><option value="15">15 words</option><option value="18">18 words</option><option value="21">21 words</option><option value="24" selected="selected">24 words</option></select>
         </div>
         <p class="muted" id="seed-length-help">24 words use 256 bits of BIP39 entropy.</p>
       </section>
@@ -931,23 +927,33 @@ function hodlCreateKeyMethodIcon(mode) {
   span.appendChild(svg);
   return span;
 }
-hodlKeyModes.forEach((e) => {
-  let t = document.createElement("button"), label = document.createElement("span"), active = e === hodlKeyMode;
-  t.type = "button";
-  t.className = "tab" + (active ? " active" : "");
-  t.dataset.keyMode = e;
-  t.setAttribute("aria-pressed", String(active));
-  t.setAttribute("aria-label", hodlKeyModeLabels[e]);
-  t.title = hodlKeyModeLabels[e];
-  label.className = "key-mode-label";
-  label.textContent = hodlKeyModeLabels[e];
-  t.append(hodlCreateKeyMethodIcon(e), label);
-  t.onclick = () => hodlSetMode(e);
-  hodlModesEl.appendChild(t);
+// The method picker is a dropdown at every width, wearing the Script type
+// control's chrome: enhanced-inputs.js upgrades it and asks
+// entropylabOptionIcon for each method's mark.
+var hodlKeyModeSelectEl = document.createElement("select");
+hodlKeyModeSelectEl.id = "key-mode-select";
+hodlKeyModeSelectEl.setAttribute("aria-labelledby", "key-method-label");
+hodlKeyModes.forEach((mode) => {
+  let option = document.createElement("option");
+  option.value = mode;
+  option.textContent = hodlKeyModeLabels[mode];
+  option.selected = mode === hodlKeyMode;
+  hodlKeyModeSelectEl.appendChild(option);
 });
-document.querySelectorAll("#seed-length [data-seed-words]").forEach((button) => {
-  button.onclick = () => hodlSetSeedLength(Number(button.dataset.seedWords));
-});
+hodlKeyModeSelectEl.entropylabOptionIcon = (value) => hodlCreateKeyMethodIcon(value);
+hodlKeyModeSelectEl.onchange = () => {
+  if (hodlKeyModeSelectEl.value !== hodlKeyMode) hodlSetMode(hodlKeyModeSelectEl.value);
+};
+hodlModesEl.appendChild(hodlKeyModeSelectEl);
+// Every path that changes the method moves the control with it. Sync, not
+// change: change would come straight back through onchange.
+function hodlSyncKeyModeSelect() {
+  if (hodlKeyModeSelectEl.value === hodlKeyMode) return;
+  hodlKeyModeSelectEl.value = hodlKeyMode;
+  hodlKeyModeSelectEl.dispatchEvent(new Event("entropylab:sync-select"));
+}
+var hodlSeedLengthSelectEl = hodlElement("#seed-length-select");
+hodlSeedLengthSelectEl.onchange = () => hodlSetSeedLength(Number(hodlSeedLengthSelectEl.value));
 hodlElement("#go").onclick = () => hodlHandleDerivationButton("key", hodlCalculateKey);
 hodlElement("#wipe").onclick = hodlWipeActiveKey;
 function hodlElement(e) {
@@ -5044,7 +5050,10 @@ function hodlGlobalSyncFromCurrentInput() {
   return true;
 }
 function hodlGlobalSyncControlMarkup(state) {
-  return `<div class="global-sync-row"><label class="seed-autocomplete-toggle global-sync-toggle"><input type="checkbox" id="global-entropy-sync" ${state?.globalSync ? "checked" : ""} /><span><strong>Sync entropy across methods</strong> <span class="seed-autocomplete-note">(Keeps non-hashed methods synchronized. Hashed inputs update them one way and are never overwritten.)</span></span></label><span class="global-sync-status" id="global-sync-status" aria-live="polite" ${state?.globalSync && state?.globalSyncBitCount ? "" : "hidden"}>${hodlCopiedIconMarkup()}<span>${state?.globalSyncBitCount || 0} bits synced</span></span></div>`;
+  // Two rows: the switch and its title, then the explanation beneath. The
+  // explanation describes the checkbox rather than naming it, so it stays out
+  // of the accessible name and stays reachable through aria-describedby.
+  return `<div class="global-sync-row"><div class="global-sync-head"><label class="seed-autocomplete-toggle global-sync-toggle"><input type="checkbox" id="global-entropy-sync" aria-describedby="global-sync-note" ${state?.globalSync ? "checked" : ""} /><span class="label">Sync entropy across methods</span></label><span class="global-sync-status" id="global-sync-status" aria-live="polite" ${state?.globalSync && state?.globalSyncBitCount ? "" : "hidden"}>${hodlCopiedIconMarkup()}<span>${state?.globalSyncBitCount || 0} bits synced</span></span></div><p class="seed-autocomplete-note global-sync-note" id="global-sync-note">(Keeps non-hashed methods synchronized. Hashed inputs update them one way and are never overwritten.)</p></div>`;
 }
 function hodlRenderGlobalSyncControl() {
   let host = document.getElementById("global-sync-host"), state = hodlKeys[hodlActiveKey];
@@ -5226,11 +5235,11 @@ function hodlUpdateSeedLengthControl() {
   if (!section) return;
   let config = hodlSeedConfig();
   section.hidden = hodlKeyMode === "key";
-  section.querySelectorAll("[data-seed-words]").forEach((button) => {
-    let active = Number(button.dataset.seedWords) === config.words;
-    button.classList.toggle("active", active);
-    button.setAttribute("aria-pressed", String(active));
-  });
+  // Sync, not change: change would come straight back through onchange.
+  if (hodlSeedLengthSelectEl.value !== String(config.words)) {
+    hodlSeedLengthSelectEl.value = String(config.words);
+    hodlSeedLengthSelectEl.dispatchEvent(new Event("entropylab:sync-select"));
+  }
   let help = document.getElementById("seed-length-help");
   if (!help) return;
   if (hodlKeyMode === "hex") {
@@ -6263,7 +6272,7 @@ function hodlInitMasterFingerprintPreview() {
     hodlQueueMasterFingerprintPreview();
   });
   panel.addEventListener("click", event => {
-    let target = event.target instanceof Element ? event.target.closest("#modes button, [data-seed-words], [data-d], [data-lw], [data-card-suit], [data-card-rank], [data-direct-card-rank], #card-undo") : null;
+    let target = event.target instanceof Element ? event.target.closest("#modes .custom-select-option, #seed-length .custom-select-option, [data-d], [data-lw], [data-card-suit], [data-card-rank], [data-direct-card-rank], #card-undo") : null;
     if (!target) return;
     // Pads and pickers that mutate an input without a bubbling "input" event
     // still re-run the sync: [data-d] writes the dice textarea directly,
@@ -9687,11 +9696,7 @@ function hodlSetMode(mode) {
   hodlSeedMethod = hodlNormalizeSeedMethod(state?.seedMethod);
   hodlSeedZeroIndexed = Boolean(state?.seedZeroIndexed);
   hodlEntropyFormat = hodlNormalizeEntropyFormat(state?.entropyFormat);
-  [...hodlModesEl.children].forEach((button, index) => {
-    let active = hodlKeyModes[index] === hodlKeyMode;
-    button.classList.toggle("active", active);
-    button.setAttribute("aria-pressed", String(active));
-  });
+  hodlSyncKeyModeSelect();
   hodlRenderKeyForm();
   hodlRestoreFormFields(state);
   hodlUpdateSeedLengthControl();
@@ -9806,11 +9811,7 @@ function hodlRestoreKey() {
     hodlWalletResult = null;
     hodlRevealPrivate = false;
     hodlAccountId = "bip84";
-    [...hodlModesEl.children].forEach((button, index) => {
-      let active = index === 0;
-      button.classList.toggle("active", active);
-      button.setAttribute("aria-pressed", String(active));
-    });
+    hodlSyncKeyModeSelect();
     hodlRenderKeyForm();
     let pass2 = document.getElementById("pass");
     if (pass2) {
@@ -9858,11 +9859,7 @@ function hodlRestoreKey() {
   hodlTargetWordCount = hodlSeedLengths[Number(state.targetWords)] ? Number(state.targetWords) : 24;
   hodlDiceCoinPositions = hodlNormalizeDiceCoinPositions(state.diceCoinPositions);
   hodlPickedLastWord = hodlDiceMethod === "dplus" ? state.dplusLastWord || "" : hodlDiceMethod === "bitbox" ? state.lastWord || "" : "";
-  [...hodlModesEl.children].forEach((button, index) => {
-    let active = hodlKeyModes[index] === hodlKeyMode;
-    button.classList.toggle("active", active);
-    button.setAttribute("aria-pressed", String(active));
-  });
+  hodlSyncKeyModeSelect();
   hodlRenderKeyForm();
   let pass = document.getElementById("pass");
   if (pass) {
@@ -10869,7 +10866,6 @@ function hodlSyncSegmentedControls() {
     if (!group.getClientRects().length) return;
     let buttons = [...group.children].filter((child) => child.matches(".tab"));
     group.classList.remove("is-stacked");
-    if (group.classList.contains("key-mode-control")) return;
     if (buttons.length < 2) return;
     let firstTop = buttons[0].offsetTop, wrapped = buttons.some((button) => Math.abs(button.offsetTop - firstTop) > 1);
     group.classList.toggle("is-stacked", wrapped);

--- a/src/js/enhanced-inputs.js
+++ b/src/js/enhanced-inputs.js
@@ -29,6 +29,7 @@
     button.setAttribute("aria-haspopup", "listbox");
     button.setAttribute("aria-expanded", "false");
     const label = document.createElement("span");
+    label.className = "custom-select-value";
     const chevron = document.createElement("span");
     chevron.className = "custom-select-chevron";
     chevron.setAttribute("aria-hidden", "true");
@@ -42,9 +43,24 @@
     select.after(root);
     roots.add(root);
 
+    // A select may hand the list an icon for each value: the option keeps its
+    // plain text for the native control and assistive tech, and the custom
+    // rendering puts the mark in front of it.
+    const iconFor = (option) =>
+      (typeof select.entropylabOptionIcon === "function" && option ? select.entropylabOptionIcon(option.value) : null);
+    // Only the icon path wraps the text, so a plain select keeps the bare
+    // textContent it has always carried.
+    const textSpan = (text) => {
+      const span = document.createElement("span");
+      span.textContent = text;
+      return span;
+    };
+
     const sync = () => {
       const selected = select.options[select.selectedIndex] || select.options[0];
-      label.textContent = selected?.textContent || "Select";
+      const selectedIcon = iconFor(selected);
+      if (selectedIcon) label.replaceChildren(selectedIcon, textSpan(selected?.textContent || "Select"));
+      else label.textContent = selected?.textContent || "Select";
       const visibleOptions = [...select.options].filter((option) => option.dataset.customSelectPlaceholder !== "true");
       list.replaceChildren(...visibleOptions.map((option) => {
         const item = document.createElement("button");
@@ -53,7 +69,9 @@
         item.setAttribute("role", "option");
         item.setAttribute("aria-selected", String(option.value === select.value));
         item.disabled = option.disabled;
-        item.textContent = option.textContent;
+        const optionIcon = iconFor(option);
+        if (optionIcon) item.replaceChildren(optionIcon, textSpan(option.textContent));
+        else item.textContent = option.textContent;
         item.onclick = (event) => {
           event.preventDefault();
           event.stopPropagation();

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -4,6 +4,12 @@
   const state = window.__entropyLabTest;
   const crypto = window.__entropyLabCrypto;
   const wait = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+  // Seed length is a dropdown now, so drive it the way a choice does.
+  const chooseSeedWords = (words) => {
+    const select = document.getElementById("seed-length-select");
+    select.value = String(words);
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+  };
   const until = async (predicate, description, timeout = 15000) => {
     const deadline = Date.now() + timeout;
     while (Date.now() < deadline) {
@@ -504,7 +510,7 @@
   });
 
   await test("all six number bases preserve the same exact entropy", async () => {
-    document.querySelector('[data-seed-words="12"]').click();
+    chooseSeedWords(12);
     await chooseMode("Number bases");
     const cases = [
       ["bin", 128, "0"],
@@ -547,7 +553,7 @@
     input(base32, `o${"0".repeat(27)}`);
     await wait(0);
     assert(base32.value.startsWith("0") && !document.getElementById("go").disabled, "Crockford O alias did not normalize to 0");
-    document.querySelector('[data-seed-words="24"]').click();
+    chooseSeedWords(24);
     const base32For24 = await until(() => document.getElementById("base32"), "24-word Base32 input");
     input(base32For24, "0".repeat(51));
     assert(document.getElementById("entropy-meta").textContent.includes("coin flip 1 of 1 · Heads (0) or Tails (1)"), "Base32 progress did not switch to coin-flip guidance");
@@ -572,7 +578,7 @@
   });
 
   await test("global entropy sync follows partial direct input and supports one-way hashed input", async () => {
-    document.querySelector('[data-seed-words="12"]').click();
+    chooseSeedWords(12);
     await chooseMode("Number bases");
     document.querySelector('input[name="entropy-format"][value="bin"]').click();
     const binary = await until(() => document.getElementById("bin"), "global-sync binary input");
@@ -677,7 +683,7 @@
   });
 
   await test("Base64 uses the shared case, number, and symbol keyboard", async () => {
-    document.querySelector('[data-seed-words="24"]').click();
+    chooseSeedWords(24);
     await chooseMode("Number bases");
     document.querySelector('input[name="entropy-format"][value="base64"]').click();
     const base64 = await until(() => document.getElementById("base64"), "Base64 input");
@@ -883,37 +889,59 @@
     document.querySelector('#workspace [data-workspace="calc"]').click();
     await until(() => !document.getElementById("key-manager").hidden, "key workspace");
   });
-  await test("Key Station methods stay horizontal and expose consistent icons", async () => {
+  await test("Key Station methods are one dropdown carrying every method's mark", async () => {
     const modes = document.getElementById("modes");
-    const buttons = [...modes.querySelectorAll("button")];
-    equal(buttons.length, 5);
-    equal(buttons.map((button) => button.dataset.keyMode).join(","), "dice,cards,hex,seed,key");
-    buttons.forEach((button) => {
-      assert(button.getAttribute("aria-label"), "An icon method is missing its accessible name");
-      assert(button.querySelector(".key-method-icon svg"), `${button.dataset.keyMode} is missing its SVG icon`);
-      assert(button.querySelector(".key-mode-label"), `${button.dataset.keyMode} is missing its wide-screen label`);
+    const select = document.getElementById("key-mode-select");
+    assert(select && modes.contains(select), "The method select is missing from #modes");
+    assert(!modes.querySelector(".tab"), "The segmented method row should be gone at every width");
+    equal([...select.options].map((option) => option.value).join(","), "dice,cards,hex,seed,key");
+    equal(select.getAttribute("aria-labelledby"), "key-method-label");
+    equal(document.getElementById("key-method-label").textContent, "Method");
+    const root = modes.querySelector(".custom-select");
+    assert(root, "The method select was not upgraded to the shared dropdown");
+    const button = root.querySelector(".custom-select-button");
+    const labels = { dice: "Dice rolls", cards: "Cards", hex: "Number bases", seed: "Seed phrase", key: "Private key" };
+    // Earlier tests leave their own method selected, so read the state rather
+    // than assuming the page opened on dice.
+    const opening = select.value;
+    assert(button.querySelector(".key-method-icon svg"), "The closed control is missing the chosen method's mark");
+    assert(button.textContent.includes(labels[opening]), "The closed control does not name the chosen method");
+    button.click();
+    await wait(25);
+    const options = [...root.querySelectorAll(".custom-select-option")];
+    equal(options.length, 5);
+    options.forEach((option, index) => {
+      assert(option.querySelector(".key-method-icon svg"), `Option ${index} is missing its SVG mark`);
+      assert(option.textContent.trim().length > 0, `Option ${index} is missing its label`);
     });
-    const cardButton = modes.querySelector('[data-key-mode="cards"]'), cardFront = cardButton.querySelector('[data-part="card-front"]');
-    assert(cardFront, "Cards icon is missing its opaque front card");
-    equal(getComputedStyle(cardFront).fill, getComputedStyle(cardButton).backgroundColor, "Front card does not mask the rear card on the default surface");
-    cardButton.click();
+    assert(options[1].querySelector('[data-part="card-front"]'), "Cards mark is missing its opaque front card");
+    // Choosing a method drives the same state the button row used to.
+    options[1].click();
+    await wait(60);
+    equal(select.value, "cards");
+    assert(button.textContent.includes(labels.cards), "The closed control did not follow the choice");
+    // The front card masks the rear one against whatever surface it is drawn
+    // on: the closed control's ground, and the selected row's tint.
+    equal(
+      getComputedStyle(button.querySelector('[data-part="card-front"]')).fill,
+      getComputedStyle(button).backgroundColor,
+      "Front card does not mask the rear card on the closed control",
+    );
+    button.click();
     await wait(25);
-    equal(getComputedStyle(cardFront).fill, getComputedStyle(cardButton).backgroundColor, "Front card does not follow the selected surface");
-    buttons[0].click();
+    const selectedRow = root.querySelector('.custom-select-option[aria-selected="true"]');
+    equal(
+      getComputedStyle(selectedRow.querySelector('[data-part="card-front"]')).fill,
+      getComputedStyle(selectedRow).backgroundColor,
+      "Front card does not mask the rear card on the selected row",
+    );
+    button.click();
     await wait(25);
-    const previousWidth = modes.style.width;
-    try {
-      modes.style.width = "210px";
-      dispatchEvent(new Event("resize"));
-      await wait(50);
-      assert(!modes.classList.contains("is-stacked"), "Key methods switched to the vertical fallback");
-      const top = buttons[0].offsetTop;
-      assert(buttons.every((button) => Math.abs(button.offsetTop - top) <= 1), "Key methods did not remain on one row");
-      assert(modes.scrollWidth > modes.clientWidth, "Constrained methods should remain reachable by horizontal scrolling");
-    } finally {
-      modes.style.width = previousWidth;
-      dispatchEvent(new Event("resize"));
-    }
+    // And a change from the application side moves the control back.
+    select.value = opening;
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+    await wait(60);
+    assert(button.textContent.includes(labels[opening]), "The control did not follow a programmatic change");
   });
   await test("Station icons preserve their intended responsive footprints", async () => {
     const stations = [
@@ -1559,7 +1587,7 @@
   });
 
   await test("a known BIP39 wallet can be derived through the UI", async () => {
-    document.querySelector('[data-seed-words="12"]').click();
+    chooseSeedWords(12);
     await chooseMode("Number bases");
     document.querySelector('input[name="entropy-format"][value="hex"]').click();
     const hex = await until(() => document.getElementById("hex"), "hex input");

--- a/test/enhanced-inputs.test.mjs
+++ b/test/enhanced-inputs.test.mjs
@@ -95,7 +95,7 @@ class FakeMutationObserver {
   }
 }
 
-function makeHarness() {
+function makeHarness({ optionIcon } = {}) {
   const options = [
     { value: "mainnet", textContent: "Bitcoin mainnet", disabled: false, dataset: {} },
     { value: "testnet", textContent: "Testnet (practice)", disabled: false, dataset: {} },
@@ -117,6 +117,7 @@ function makeHarness() {
   };
   select.ownerDocument = document;
   body.ownerDocument = document;
+  if (optionIcon) select.entropylabOptionIcon = optionIcon;
   new Function("document", "Element", "MutationObserver", "Event", source)(document, FakeElement, FakeMutationObserver, FakeEvent);
   return { select, root: select.afterNode, document, body };
 }
@@ -240,4 +241,38 @@ test("clicking outside an open custom select closes it", () => {
   for (const listener of clicks) listener({ target: body });
   assert.equal(list.hidden, true, "a click outside closes the list");
   assert.equal(button.attributes.get("aria-expanded"), "false");
+});
+
+test("a select can put a mark ahead of every option label", () => {
+  const asked = [];
+  const { root } = makeHarness({
+    optionIcon: (value) => {
+      asked.push(value);
+      const mark = new FakeElement("span");
+      mark.className = `mark-${value}`;
+      return mark;
+    },
+  });
+  const label = root.children[0].children[0];
+  const list = root.children[1];
+  // The button shows the selected method's mark, then its name.
+  assert.equal(label.className, "custom-select-value");
+  assert.equal(label.children.length, 2, "the button label carries a mark and its text");
+  assert.equal(label.children[0].className, "mark-mainnet");
+  assert.equal(label.children[1].textContent, "Bitcoin mainnet");
+  // So does each option in the list.
+  assert.equal(list.children[0].children[0].className, "mark-mainnet");
+  assert.equal(list.children[0].children[1].textContent, "Bitcoin mainnet");
+  assert.equal(list.children[1].children[0].className, "mark-testnet");
+  assert.ok(asked.includes("mainnet") && asked.includes("testnet"), "every option is offered a mark");
+});
+
+test("a select without the hook keeps its plain option text", () => {
+  const { root } = makeHarness();
+  const label = root.children[0].children[0];
+  const list = root.children[1];
+  assert.equal(label.textContent, "Bitcoin mainnet", "the label stays bare text");
+  assert.equal(label.children.length, 0, "no wrapper is introduced without a mark");
+  assert.equal(list.children[0].textContent, "Bitcoin mainnet");
+  assert.equal(list.children[0].children.length, 0);
 });

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -344,6 +344,30 @@ test("Number bases offers exact Base 2, 4, 8, 16, Crockford Base32, and Base64-a
   assert.match(app, /entropyFormat:"bin"/);
   assert.ok(app.includes('function hodlNormalizeEntropyFormat(format){return Object.hasOwn(hodlEntropyFormats,String(format??""))?String(format):"bin"}'));
   assert.match(css, /\.global-sync-status \{[\s\S]*?color: var\(--ok\)/);
+  // The sync control stacks: switch and title on one row, explanation beneath.
+  assert.match(appSource, /<div class="global-sync-head">/);
+  assert.match(appSource, /<span class="label">Sync entropy across methods<\/span><\/label>/);
+  assert.match(appSource, /<p class="seed-autocomplete-note global-sync-note" id="global-sync-note">/);
+  // The explanation describes the switch instead of naming it.
+  assert.match(appSource, /id="global-entropy-sync" aria-describedby="global-sync-note"/);
+  assert.doesNotMatch(appSource, /<strong>Sync entropy across methods<\/strong>/);
+  assert.match(css, /\.global-sync-row \{ display: block; \}/);
+  assert.match(css, /\.global-sync-head \{ display: flex; align-items: center;/);
+  // It gives up the shared toggle's chip chrome, but not its 44px target, and
+  // the chip elsewhere keeps both.
+  // The chip's 44px box left 13px of its own height under the title; the row
+  // hugs its content instead, staying full width and above the 24px floor.
+  assert.match(css, /\.global-sync-toggle \{[^}]*min-height: 32px;[^}]*padding: 0; border: 0; background: none; \}/);
+  assert.match(css, /\.seed-autocomplete-toggle \{[^}]*min-height: 44px;[^}]*border: 1px solid var\(--border\);[^}]*background: var\(--surface-2\);/s);
+  // The title matches the Method label above it.
+  assert.match(css, /\.global-sync-toggle \.label \{ margin: 0; \}/);
+  // The explanation is subordinate to that title and sits directly under it.
+  assert.match(css, /\.global-sync-note \{ display: block; margin: 0; font-size: 13px; line-height: 1\.45; \}/);
+  // Whatever comes off the top is given back below, so the control sits with
+  // the method it qualifies rather than centred in its own gap. Padding, not
+  // margin: a bottom margin would collapse into .seed-length-control's larger
+  // top margin and buy nothing.
+  assert.match(css, /\.global-sync-host \{ margin-top: var\(--space-control\); padding-bottom: var\(--space-control\); \}/);
   assert.match(css, /\.number-base-calculation-list \{/);
   assert.match(app, /fields:\{[\s\S]*?base4:"",base8:"",base32:"",base64:""/);
   assert.match(app, /function hodlBase64KeyboardMarkup\(\)\{return hodlKeyboardMarkup\(!0,"Base64 entropy","base64-keyboard"\)\}/);
@@ -894,28 +918,47 @@ test("Station add controls stay pinned to the right of their tab strips", () => 
   assert.match(css, /\.add-item-control \{ position: relative; display: inline-flex; flex: 0 0 auto; \}/);
 });
 
-test("Key Station methods become one accessible icon row on narrow screens", () => {
+test("the Key Station method picker is one dropdown carrying every method's mark", () => {
   for (const markup of [template, appSource]) {
-    assert.match(markup, /class="row segmented-control key-mode-control" id="modes" role="group" aria-label="Key input mode"/);
+    // #modes hosts the title and the dropdown; the segmented row is gone.
+    assert.match(markup, /<div class="key-mode-select" id="modes"><p class="label" id="key-method-label">Method<\/p><\/div>/);
+    assert.doesNotMatch(markup, /key-mode-control|key-mode-label/);
   }
+  // The title is the control's accessible name, so speech input can say it.
+  assert.match(css, /\.key-mode-select > \.label \{ margin: 0 0 8px; \}/);
   assert.doesNotMatch(template, /Brain wallet — lab/);
   assert.match(appSource, /hodlKeyModeLabels = \{ dice: "Dice rolls", cards: "Cards", hex: "Number bases", seed: "Seed phrase", key: "Private key" \}/);
+  // The marks outlived the buttons: the dropdown shows them instead.
   assert.match(appSource, /function hodlCreateKeyMethodIcon\(mode\) \{/);
   for (const mode of ["dice", "cards", "hex", "seed"]) {
     assert.match(appSource, new RegExp(`mode === "${mode}"`), `${mode} icon branch is missing`);
   }
   assert.match(appSource, /else \{\s*add\("circle", \{ cx: "7\.5"/);
-  assert.match(appSource, /t\.dataset\.keyMode = e;/);
-  assert.match(appSource, /t\.setAttribute\("aria-label", hodlKeyModeLabels\[e\]\);/);
-  assert.match(appSource, /label\.className = "key-mode-label";/);
-  assert.match(appSource, /t\.append\(hodlCreateKeyMethodIcon\(e\), label\);/);
   assert.match(appSource, /fill: "var\(--key-method-card-bg\)", "data-part": "card-front"/);
-  assert.match(css, /\.key-mode-control \{[^}]*flex-wrap: nowrap;[^}]*overflow-x: auto;/s);
-  assert.match(css, /\.key-mode-control > \.tab \{\s*--key-method-card-bg: var\(--bg\);/);
-  assert.match(css, /\.key-mode-control > \.tab:is\(\.active, \[aria-pressed="true"\]\),[\s\S]*?--key-method-card-bg: var\(--selection-accent\);/);
-  assert.match(css, /@media \(max-width: 719px\) \{[\s\S]*?\.key-mode-control > \.tab \{ flex: 1 0 44px; min-width: 44px; min-height: 44px;/);
-  assert.match(css, /@media \(max-width: 719px\) \{[\s\S]*?\.key-mode-control \.key-method-icon \{ display: inline-flex; \}[\s\S]*?\.key-mode-control \.key-mode-label \{ display: none; \}/);
-  assert.match(appSource, /if \(group\.classList\.contains\("key-mode-control"\)\) return;/);
+  // A plain select that enhanced-inputs.js upgrades, so it is the Script type
+  // control's chrome rather than a second dropdown implementation.
+  assert.match(appSource, /hodlKeyModeSelectEl\.id = "key-mode-select";/);
+  assert.match(appSource, /hodlKeyModeSelectEl\.setAttribute\("aria-labelledby", "key-method-label"\);/);
+  assert.match(appSource, /hodlKeyModeSelectEl\.entropylabOptionIcon = \(value\) => hodlCreateKeyMethodIcon\(value\);/);
+  assert.match(appSource, /hodlModesEl\.appendChild\(hodlKeyModeSelectEl\);/);
+  // Every path that changes the method moves the control, and the sync cannot
+  // loop back through onchange.
+  assert.match(appSource, /function hodlSyncKeyModeSelect\(\) \{/);
+  assert.match(appSource, /hodlKeyModeSelectEl\.dispatchEvent\(new Event\("entropylab:sync-select"\)\);/);
+  assert.equal(appSource.match(/hodlSyncKeyModeSelect\(\);/g).length, 3, "every method update must move the dropdown");
+  // No button plumbing is left behind.
+  assert.doesNotMatch(appSource, /hodlModesEl\.children/);
+  assert.doesNotMatch(css, /\.key-mode-control/);
+  // Choosing a method invalidates the live result; opening the list does not.
+  assert.match(appSource, /closest\("#modes \.custom-select-option, #seed-length \.custom-select-option/);
+  // The mark rides ahead of the label in the button and in every option.
+  assert.match(css, /\.key-method-icon \{\s*display: inline-flex; flex: 0 0 18px;/);
+  assert.match(css, /\.key-mode-select \.custom-select-option \{ display: flex; align-items: center; gap: 8px; \}/);
+  assert.match(css, /\.key-mode-select \.custom-select-value \{ display: inline-flex; align-items: center; gap: 8px;/);
+  // The card mark masks against the row it sits on, selected or not.
+  assert.match(css, /\.key-mode-select \.custom-select-button \{ --key-method-card-bg: var\(--bg\); \}/);
+  assert.match(css, /\.key-mode-select \.custom-select-list \{ --key-method-card-bg: var\(--surface-2\); \}/);
+  assert.match(css, /\.key-mode-select \.custom-select-option\[aria-selected="true"\] \{ --key-method-card-bg:/);
 });
 
 test("Station icons keep the original SP mark while normalizing the MS key cluster", () => {
@@ -1400,11 +1443,25 @@ test("PSBT amounts and fees are labeled as unverified claims", () => {
   assert.doesNotMatch(app, /Fee \(from PSBT fields\)/);
 });
 
-test("seed-length selector offers all five BIP39 sizes", () => {
-  for (const words of [12, 15, 18, 21, 24]) {
-    assert.match(template, new RegExp(`data-seed-words="${words}"`), `${words} missing from src/index.html`);
-    assert.match(app, new RegExp(`data-seed-words="${words}"`), `${words} missing from runtime markup in src/js/app.js`);
+test("seed-length selector offers all five BIP39 sizes as a dropdown", () => {
+  for (const markup of [template, appSource]) {
+    // One dropdown in the Method control's clothes, not five buttons.
+    assert.match(markup, /<select id="seed-length-select" aria-labelledby="seed-length-label">/);
+    for (const words of [12, 15, 18, 21, 24]) {
+      assert.match(markup, new RegExp(`<option value="${words}"[^>]*>${words} words</option>`), `${words} is missing`);
+    }
+    assert.match(markup, /<option value="24" selected="selected">24 words<\/option>/);
+    assert.doesNotMatch(markup, /data-seed-words|seed-length-options/);
   }
+  assert.match(css, /\.key-mode-select \.custom-select, \.seed-length-select \.custom-select \{ margin-top: 0; \}/);
+  // Half the card until the header's breakpoint, then the whole of it.
+  assert.match(css, /\.key-mode-select, \.seed-length-select \{ width: calc\(50% - var\(--space-component\) \/ 2\); \}/);
+  assert.match(css, /@media \(max-width: 719px\) \{[\s\S]*?\.key-mode-select, \.seed-length-select \{ width: 100%; \}/);
+  assert.doesNotMatch(css, /\.seed-length-options/);
+  // One choice drives the same state the five buttons did, and the sync back
+  // cannot loop through onchange.
+  assert.match(appSource, /hodlSeedLengthSelectEl\.onchange = \(\) => hodlSetSeedLength\(Number\(hodlSeedLengthSelectEl\.value\)\);/);
+  assert.match(appSource, /hodlSeedLengthSelectEl\.dispatchEvent\(new Event\("entropylab:sync-select"\)\);/);
 });
 
 test("D++ uses the published hexadecimal D16 transcript without a notation toggle", () => {


### PR DESCRIPTION
- Method picker is a dropdown at every width, replacing the button row, with each method's mark ahead of its label and a "Method" title above.
- Seed phrase length becomes a dropdown in the same chrome.
- Both take half the card, going full width at the header's breakpoint.
- enhanced-inputs.js takes an optional per-option icon; selects without one are unchanged.
- Sync entropy control stacks: switch and title, then the description beneath at 13px, and it drops the bordered chip.