### PR TITLE
Restore MS Station Key Station import controls

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1022,6 +1022,9 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 #sp-modes + .station-key-source { margin-top: 20px; }
 .station-key-source > .label { margin: 0 0 8px; }
 .station-key-source > .field-note { display: block; margin: 8px 0 0; }
+.msig-key-reuse-toggle { margin-top: 12px; }
+.msig-station-key-source #msig-session-key-status:empty { display: none; }
+.msig-station-key-source + .msig-threshold-labels { margin-top: 0; }
 .session-key-picker { display: flex; flex-wrap: wrap; gap: 8px; }
 .session-key-picker[hidden] { display: none; }
 .session-key-option {

--- a/src/index.html
+++ b/src/index.html
@@ -295,6 +295,16 @@ words, pick one of the checksum words.</span></span>
         <button class="btn secondary" id="msig-edit-inputs" type="button">Edit input</button>
       </div>
       <div class="msig-lab" id="msig-lab">
+      <div class="station-key-source msig-station-key-source">
+        <p class="label">Bring in a key from Key Station</p>
+        <div class="session-key-picker" id="msig-session-keys" role="group" aria-label="Compatible Key Station keys" hidden></div>
+        <p class="field-note">Choose a compatible HD-root key from this session, or paste a co-signer extended public key below.</p>
+        <label class="choice msig-key-reuse-toggle">
+          <input id="msig-reuse-session-keys" type="checkbox">
+          <span><strong>Allow key reuse</strong><span class="desc">Keep selected Key Station keys available for more than one co-signer input. Reused keys need different derivation paths.</span></span>
+        </label>
+        <p class="field-note" id="msig-session-key-status" aria-live="polite"></p>
+      </div>
       <div class="msig-threshold-labels">
         <label for="msig-m-number"><span>Signatures needed to spend (m)</span><input class="msig-threshold-number" id="msig-m-number" type="number" min="1" max="15" step="1" value="2" inputmode="numeric" aria-describedby="msig-threshold-help"></label>
         <label for="msig-n-number"><span>Total signing keys (n)</span><input class="msig-threshold-number" id="msig-n-number" type="number" min="1" max="15" step="1" value="3" inputmode="numeric" aria-describedby="msig-threshold-help"></label>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -650,6 +650,16 @@ hodlRootEl.innerHTML = `
         <button class="btn secondary" id="msig-edit-inputs" type="button">Edit input</button>
       </div>
       <div class="msig-lab" id="msig-lab">
+      <div class="station-key-source msig-station-key-source">
+        <p class="label">Bring in a key from Key Station</p>
+        <div class="session-key-picker" id="msig-session-keys" role="group" aria-label="Compatible Key Station keys" hidden></div>
+        <p class="field-note">Choose a compatible HD-root key from this session, or paste a co-signer extended public key below.</p>
+        <label class="choice msig-key-reuse-toggle">
+          <input id="msig-reuse-session-keys" type="checkbox">
+          <span><strong>Allow key reuse</strong><span class="desc">Keep selected Key Station keys available for more than one co-signer input. Reused keys need different derivation paths.</span></span>
+        </label>
+        <p class="field-note" id="msig-session-key-status" aria-live="polite"></p>
+      </div>
       <div class="msig-threshold-labels">
         <label for="msig-m-number"><span>Signatures needed to spend (m)</span><input class="msig-threshold-number" id="msig-m-number" type="number" min="1" max="15" step="1" value="2" inputmode="numeric" aria-describedby="msig-threshold-help"></label>
         <label for="msig-n-number"><span>Total signing keys (n)</span><input class="msig-threshold-number" id="msig-n-number" type="number" min="1" max="15" step="1" value="3" inputmode="numeric" aria-describedby="msig-threshold-help"></label>
@@ -7175,16 +7185,67 @@ function hodlSyncMsigKeyAvatar(row) {
     if (fingerprint) hodlFillKeyTabLifehash(image, fingerprint);
   }
 }
-function hodlPickMsigSessionKey(state, row) {
-  let ta = row?.querySelector("textarea");
-  if (!ta) return;
+var hodlMsigKeyTarget = null;
+function hodlMsigNextKeyRow() {
+  let rows = [...document.querySelectorAll("#msig-keys .msig-key-row")];
+  if (hodlMsigKeyTarget?.isConnected) {
+    let selected = hodlMsigKeyTarget.closest(".msig-key-row");
+    if (selected && rows.includes(selected)) return selected;
+  }
+  return rows.find((row) => !row.querySelector("textarea")?.value.trim()) || null;
+}
+function hodlMsigSessionKeyOption(state) {
+  try {
+    let value = hodlMatchingMsigExport(state.result), parsed = hodlParseMultisigCosigner(value);
+    return { state, value, baseId: hodlMsigBaseKeyId(parsed) };
+  } catch {
+    return { state, value: "", baseId: "" };
+  }
+}
+function hodlMsigUsedBaseKeyIds(exceptRow = null) {
+  let used = new Set();
+  document.querySelectorAll("#msig-keys .msig-key-row").forEach((row) => {
+    if (row === exceptRow) return;
+    let parsed = hodlParseMsigRowKey(row);
+    if (parsed) used.add(hodlMsigBaseKeyId(parsed));
+  });
+  return used;
+}
+function hodlCreateMsigSessionKeyButton(option, className, active, onSelect, ariaLabel) {
+  let { state } = option, fingerprint = state.result?.masterFingerprint || state.name, button = document.createElement("button"), image = document.createElement("img"), label = document.createElement("span");
+  button.type = "button";
+  button.className = className + (active ? " active" : "");
+  button.dataset.keyId = String(state.id);
+  button.dataset.fingerprint = fingerprint;
+  button.setAttribute("aria-pressed", String(active));
+  button.setAttribute("aria-label", ariaLabel(fingerprint));
+  image.className = "key-tab-lifehash";
+  image.width = 22;
+  image.height = 22;
+  image.alt = "";
+  image.hidden = true;
+  if (fingerprint) hodlFillKeyTabLifehash(image, fingerprint);
+  label.textContent = fingerprint;
+  button.append(image, label);
+  button.onclick = onSelect;
+  return button;
+}
+function hodlPickMsigSessionKey(state, row = hodlMsigNextKeyRow()) {
+  let ta = row?.querySelector("textarea"), status = document.getElementById("msig-session-key-status");
+  if (!ta) {
+    if (status) status.textContent = "All co-signer inputs are filled. Focus or clear an input before choosing another key.";
+    return;
+  }
   let value = hodlMatchingMsigExport(state.result);
   if (!value) {
     hodlHint(ta, false, "That Key Station key has no compatible multisig export for the selected script type.");
     return;
   }
+  hodlMsigKeyTarget = ta;
   ta.value = value;
   ta.dispatchEvent(new Event("input"));
+  let position = [...document.querySelectorAll("#msig-keys .msig-key-row")].indexOf(row) + 1;
+  if (status) status.textContent = `Added ${state.result?.masterFingerprint || state.name} to co-signer ${position}.`;
 }
 function hodlStripMsigKeyPath(value) {
   return String(value ?? "").trim().replace(/\/(?:<\d+(?:;\d+)*>|\d+)\/\*$/, "").replace(/(\/\d+[hH']?)+$/, "");
@@ -7243,30 +7304,25 @@ function hodlSyncMsigKeyReuse(row) {
   if (clear) clear.hidden = !current;
 }
 function hodlRefreshMsigSessionPickers() {
-  let keys = hodlSessionMsigKeys();
+  let options = hodlSessionMsigKeys().map(hodlMsigSessionKeyOption), reuse = Boolean(document.getElementById("msig-reuse-session-keys")?.checked), used = hodlMsigUsedBaseKeyIds(), globalBox = document.getElementById("msig-session-keys"), status = document.getElementById("msig-session-key-status");
+  if (globalBox) {
+    let available = reuse ? options : options.filter((option) => !option.baseId || !used.has(option.baseId));
+    globalBox.replaceChildren();
+    globalBox.hidden = !available.length;
+    available.forEach((option) => {
+      globalBox.appendChild(hodlCreateMsigSessionKeyButton(option, "session-key-option", Boolean(option.baseId) && used.has(option.baseId), () => hodlPickMsigSessionKey(option.state), (fingerprint) => `Add Key Station key ${fingerprint} to the next co-signer input`));
+    });
+    if (status && !status.textContent && options.length && !available.length) status.textContent = "All compatible Key Station keys are assigned. Enable key reuse to keep them available.";
+    if (status && (!options.length || available.length) && status.textContent.startsWith("All compatible")) status.textContent = "";
+  }
   document.querySelectorAll("#msig-keys .msig-key-row").forEach((row) => {
-    let box = row.querySelector(".msig-session-keys"), ta = row.querySelector("textarea");
+    let box = row.querySelector(".msig-session-keys"), parsed = hodlParseMsigRowKey(row), currentBaseId = parsed ? hodlMsigBaseKeyId(parsed) : "", usedElsewhere = hodlMsigUsedBaseKeyIds(row);
     if (!box) return;
+    let available = reuse ? options : options.filter((option) => option.baseId === currentBaseId || !option.baseId || !usedElsewhere.has(option.baseId));
     box.replaceChildren();
-    box.hidden = !keys.length;
-    keys.forEach((state) => {
-      let fingerprint = state.result?.masterFingerprint || state.name, button = document.createElement("button"), image = document.createElement("img"), label = document.createElement("span");
-      button.type = "button";
-      button.className = "msig-session-key";
-      button.dataset.keyId = String(state.id);
-      button.dataset.fingerprint = fingerprint;
-      button.setAttribute("aria-pressed", "false");
-      button.setAttribute("aria-label", `Use Key Station key ${fingerprint} for this co-signer`);
-      image.className = "key-tab-lifehash";
-      image.width = 22;
-      image.height = 22;
-      image.alt = "";
-      image.hidden = true;
-      if (fingerprint) hodlFillKeyTabLifehash(image, fingerprint);
-      label.textContent = fingerprint;
-      button.append(image, label);
-      button.onclick = () => hodlPickMsigSessionKey(state, row);
-      box.appendChild(button);
+    box.hidden = !available.length;
+    available.forEach((option) => {
+      box.appendChild(hodlCreateMsigSessionKeyButton(option, "msig-session-key", Boolean(option.baseId) && option.baseId === currentBaseId, () => hodlPickMsigSessionKey(option.state, row), (fingerprint) => `Use Key Station key ${fingerprint} for this co-signer`));
     });
     hodlSyncMsigKeyAvatar(row);
     hodlSyncMsigKeyReuse(row);
@@ -7389,7 +7445,12 @@ function hodlFillKeys(values) {
       hodlInvalidateMsig();
       hodlSyncMsigKeyAvatar(row);
       hodlRefreshMsigSessionPickers();
-    }
+    };
+    ta.addEventListener("focus", () => {
+      hodlMsigKeyTarget = ta;
+      let status = document.getElementById("msig-session-key-status");
+      if (status) status.textContent = `The next selected Key Station key will fill co-signer ${i + 1}.`;
+    });
   }
   hodlBindMsigKeyReorder(box);
   hodlSyncMsigKeyMoveButtons();
@@ -7490,6 +7551,10 @@ function hodlResetMsigForm() {
   hodlSetMsigPurpose(48);
   let legacy = document.getElementById("msig-legacy-bip87");
   if (legacy) legacy.checked = false;
+  let reuseSessionKeys = document.getElementById("msig-reuse-session-keys"), sessionStatus = document.getElementById("msig-session-key-status");
+  if (reuseSessionKeys) reuseSessionKeys.checked = false;
+  if (sessionStatus) sessionStatus.textContent = "";
+  hodlMsigKeyTarget = null;
   hodlUpdateMsigLegacyControls();
   hodlSyncSelect(document.getElementById("msig-key-order"), "sorted");
   let advanced = document.getElementById("msig-advanced");
@@ -7523,7 +7588,14 @@ function hodlInitMsig() {
     branchStartInput = document.getElementById("msig-branch-start"),
     addressStartInput = document.getElementById("msig-address-start"),
     legacy = document.getElementById("msig-legacy-bip87"),
+    reuseSessionKeys = document.getElementById("msig-reuse-session-keys"),
     keyOrder = document.getElementById("msig-key-order");
+  reuseSessionKeys?.addEventListener("change", () => {
+    let status = document.getElementById("msig-session-key-status");
+    if (status) status.textContent = reuseSessionKeys.checked ? "Selected Key Station keys remain available for every co-signer input." : "Each selected Key Station key is removed from the other co-signer choices.";
+    hodlRefreshMsigSessionPickers();
+    hodlSyncMsigClearButton(true);
+  });
   script.addEventListener("change", () => {
     if (script.value !== "mixed") script.dataset.lastConcrete = script.value;
     hodlSetMsigPurpose(hodlStandardMsigPurpose(script.value));
@@ -10229,6 +10301,7 @@ function hodlNewMsigState(name, msigId, msigNumber) {
       purposeHarden: true,
       legacyBip87: !1,
       keyOrder: "sorted",
+      reuseSessionKeys: false,
       xpubs: ["", "", ""],
       coinType: String(hodlDefaultCoinType()),
       coinTypeHarden: true,
@@ -10374,7 +10447,7 @@ function hodlMsigStateNeedsClear(state) {
   let fields = state.fields || {},
     xpubs = Array.isArray(fields.xpubs) ? fields.xpubs : [];
   return Boolean(state.result) || String(state.error ?? "").length > 0 || xpubs.some(value => String(value ?? "").length > 0) ||
-    String(fields.m ?? "2") !== "2" || String(fields.n ?? "3") !== "3" || String(fields.script ?? "p2wsh") !== "p2wsh" || String(fields.purpose ?? "48") !== "48" || fields.purposeHarden === false || Boolean(fields.legacyBip87) || String(fields.keyOrder ?? "sorted") !== "sorted" || String(fields.coinType ?? (fields.network === "testnet" ? "1" : "0")) !== "0" || fields.coinTypeHarden === false || fields.accountHarden === false || String(fields.branchStart ?? "0") !== "0" || Boolean(fields.branchHarden) || String(fields.branchRange ?? "2") !== "2" || String(fields.addressStart ?? "0") !== "0" || Boolean(fields.addressHarden) || String(fields.addressRange ?? fields.count ?? "5") !== "5"
+    String(fields.m ?? "2") !== "2" || String(fields.n ?? "3") !== "3" || String(fields.script ?? "p2wsh") !== "p2wsh" || String(fields.purpose ?? "48") !== "48" || fields.purposeHarden === false || Boolean(fields.legacyBip87) || String(fields.keyOrder ?? "sorted") !== "sorted" || Boolean(fields.reuseSessionKeys) || String(fields.coinType ?? (fields.network === "testnet" ? "1" : "0")) !== "0" || fields.coinTypeHarden === false || fields.accountHarden === false || String(fields.branchStart ?? "0") !== "0" || Boolean(fields.branchHarden) || String(fields.branchRange ?? "2") !== "2" || String(fields.addressStart ?? "0") !== "0" || Boolean(fields.addressHarden) || String(fields.addressRange ?? fields.count ?? "5") !== "5"
 }
 
 function hodlSyncMsigClearButton(capture = !1) {
@@ -10393,6 +10466,7 @@ function hodlCaptureMsig() {
   state.fields.purpose = document.getElementById("msig-purpose")?.value || "48";
   state.fields.legacyBip87 = hodlSelectedLegacyMultisigStandard() === "bip87";
   state.fields.keyOrder = hodlMsigKeysSorted() ? "sorted" : "listed";
+  state.fields.reuseSessionKeys = Boolean(document.getElementById("msig-reuse-session-keys")?.checked);
   hodlMergeMsigXpubs(state);
   state.fields.coinType = document.getElementById("msig-network")?.value || "0";
   let hardening = hodlReadHardening("msig-");
@@ -10432,6 +10506,10 @@ function hodlRestoreMsig() {
   hodlUpdateMsigLegacyControls();
   state.fields.keyOrder = state.fields.keyOrder === "listed" ? "listed" : "sorted";
   hodlSyncSelect(document.getElementById("msig-key-order"), state.fields.keyOrder);
+  let reuseSessionKeys = document.getElementById("msig-reuse-session-keys"), sessionStatus = document.getElementById("msig-session-key-status");
+  if (reuseSessionKeys) reuseSessionKeys.checked = Boolean(state.fields.reuseSessionKeys);
+  if (sessionStatus) sessionStatus.textContent = "";
+  hodlMsigKeyTarget = null;
   let advanced = document.getElementById("msig-advanced");
   if (advanced) advanced.open = state.fields.keyOrder === "listed";
   state.fields.coinType = String(state.fields.coinType ?? (state.fields.network === "testnet" ? 1 : 0));

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -1740,26 +1740,42 @@
     await until(() => !document.getElementById("key-manager").hidden, "key workspace after SP Station test");
   });
 
-  await test("MS Station offers every Key Station key on each co-signer and a derivation path for reuse", async () => {
+  await test("MS Station restores its Key Station import section and safely controls key reuse", async () => {
     document.querySelector('#workspace [data-workspace="msig"]').click();
     await until(() => !document.getElementById("msig-manager").hidden, "MS Station");
-    assert(!document.getElementById("msig-session-keys"), "MS Station kept the global key picker above the co-signers");
-    const rows = [...document.querySelectorAll("#msig-keys .msig-key-row")];
+    const globalPicker = document.getElementById("msig-session-keys");
+    const reuseToggle = document.getElementById("msig-reuse-session-keys");
+    assert(globalPicker, "MS Station is missing the global Key Station picker");
+    assert(reuseToggle && !reuseToggle.checked, "MS Station key reuse was not opt-in");
+    assert(document.querySelector(".msig-station-key-source .label")?.textContent.includes("Bring in a key from Key Station"), "MS Station is missing the restored key import heading");
+    let rows = [...document.querySelectorAll("#msig-keys .msig-key-row")];
     assert(rows.length >= 2, "MS Station did not start with at least two co-signer rows");
     const rowOption = (row) => row.querySelector(".msig-session-keys .msig-session-key");
+    rows.forEach((row) => input(row.querySelector("textarea"), ""));
+    rows = [...document.querySelectorAll("#msig-keys .msig-key-row")];
     assert(rows.every((row) => rowOption(row)), "A co-signer row did not offer the compatible Key Station key");
 
+    const globalOption = globalPicker.querySelector(".session-key-option");
+    assert(globalOption, "MS Station did not offer the compatible key in its global picker");
+    globalOption.click();
+    rows = [...document.querySelectorAll("#msig-keys .msig-key-row")];
     const first = document.getElementById("msig-x-0");
-    rowOption(rows[0]).click();
-    assert(first.value.trim(), "The first co-signer row did not populate from its own picker");
-    assert(!rows[0].querySelector(".msig-key-ident").hidden, "The selected key identity was not shown above its co-signer input");
+    assert(first.value.trim(), "The global Key Station picker did not populate the first co-signer row");
+    const identity = document.querySelector("#msig-keys .msig-key-row .msig-key-ident");
+    assert(identity && !identity.hidden, "The selected key identity was not shown above its co-signer input");
+    rows = [...document.querySelectorAll("#msig-keys .msig-key-row")];
     assert(rowOption(rows[0]).classList.contains("active"), "The picked key was not marked active on the first row");
+    assert(!rowOption(rows[1]), "An assigned key remained available on another row while reuse was off");
+    assert(globalPicker.hidden, "An assigned key remained in the global picker while reuse was off");
 
-    // Every key stays selectable on every other row; picking the same key
+    // Opting into reuse keeps the key selectable on every row. Picking it
     // again offers a derivation path so its descriptor public keys differ.
+    reuseToggle.click();
+    rows = [...document.querySelectorAll("#msig-keys .msig-key-row")];
+    assert(!globalPicker.hidden && globalPicker.querySelector(".session-key-option"), "Enabling reuse did not restore the global key choice");
     const second = document.getElementById("msig-x-1");
     const secondOption = rowOption(rows[1]);
-    assert(secondOption, "An assigned key disappeared from the second row's picker");
+    assert(secondOption, "Enabling reuse did not restore the assigned key on another co-signer row");
     const secondFingerprint = secondOption.dataset.fingerprint;
     secondOption.click();
     assert(second.value.trim(), "The second co-signer row did not populate the reused key");
@@ -1777,8 +1793,9 @@
     reusePanel.querySelector(".msig-key-reuse-clear").click();
     assert(!/\/1$/.test(second.value), "Remove path did not strip the appended derivation path");
 
-    input(first, "");
-    input(second, "");
+    input(document.getElementById("msig-x-0"), "");
+    input(document.getElementById("msig-x-1"), "");
+    if (reuseToggle.checked) reuseToggle.click();
     document.querySelector('#workspace [data-workspace="calc"]').click();
     await until(() => !document.getElementById("key-manager").hidden, "key workspace after MS Station picker test");
   });

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -1698,18 +1698,16 @@ test("derived key results put private recovery before script type and addresses"
 
 test("every MS Station co-signer row can pick any session key, and key reuse offers a derivation path", () => {
   for (const markup of [template, appSource]) {
-    assert.doesNotMatch(markup, /msig-station-key-source/);
-    assert.doesNotMatch(markup, /id="msig-session-keys"/);
-    assert.doesNotMatch(markup, /id="msig-reuse-session-keys"/);
-    assert.doesNotMatch(markup, /id="msig-session-key-status"/);
+    assert.match(markup, /class="station-key-source msig-station-key-source"[\s\S]*id="msig-session-keys"[\s\S]*id="msig-reuse-session-keys"[\s\S]*id="msig-session-key-status"/);
+    assert.match(markup, /Bring in a key from Key Station/);
   }
   assert.match(appSource, /function hodlSessionMsigKeys\(\) \{/);
   assert.match(appSource, /function hodlMatchingMsigExport\(result\) \{/);
   assert.match(appSource, /function hodlSyncMsigKeyAvatar\(row\) \{/);
   assert.match(appSource, /chips\.className = "msig-session-keys"/);
-  assert.match(appSource, /button\.className = "msig-session-key"/);
-  assert.match(appSource, /function hodlPickMsigSessionKey\(state, row\) \{/);
-  assert.match(appSource, /button\.onclick = \(\) => hodlPickMsigSessionKey\(state, row\)/);
+  assert.match(appSource, /hodlCreateMsigSessionKeyButton\(option, "msig-session-key"/);
+  assert.match(appSource, /function hodlPickMsigSessionKey\(state, row = hodlMsigNextKeyRow\(\)\) \{/);
+  assert.match(appSource, /\(\) => hodlPickMsigSessionKey\(option\.state, row\)/);
   assert.match(appSource, /hodlFillKeyTabLifehash\(image, fingerprint\)/);
   assert.match(appSource, /hodlRefreshMsigSessionPickers\(\)/);
   // Reusing a key for another co-signer must come with a derivation path so
@@ -1725,7 +1723,10 @@ test("every MS Station co-signer row can pick any session key, and key reuse off
   assert.match(appSource, /function hodlMsigDerivedNode\(parsed\) \{/);
   assert.match(appSource, /let node = hodlMsigDerivedNode\(parsed\);\s*return hodlHex\.encode\(node\.publicKey\)/);
   assert.match(appSource, /\]\$\{canonical\}\$\{parsed\.derivationPath \? "\/" \+ parsed\.derivationPath : ""\}/);
-  assert.doesNotMatch(appSource, /hodlMsigKeyTarget|reuseSessionKeys/);
+  assert.match(appSource, /var hodlMsigKeyTarget = null/);
+  assert.match(appSource, /function hodlMsigNextKeyRow\(\) \{/);
+  assert.match(appSource, /reuseSessionKeys\?\.addEventListener\("change"/);
+  assert.match(appSource, /Reused keys need different derivation paths\./);
   assert.match(css, /\.msig-session-keys \{/);
   assert.match(css, /\.msig-session-key \{/);
   assert.match(css, /\.msig-session-key\.active/);


### PR DESCRIPTION
## What changed\n- restore the top-level **Bring in a key from Key Station** section in MS Station\n- restore opt-in **Allow key reuse** behavior while keeping the newer per-co-signer pickers\n- remove assigned keys from other co-signer choices by default\n- preserve derivation-path safeguards when a key is intentionally reused\n- persist the reuse preference per MS Station workspace\n\n## Audit\nThe section was removed by commit `0927740`, before PR #244 merged. A source/UI scan found no other station UX removed: Key Station, BIP-85 Station, SP Station, responsive method icons, station icons, and cross-station key selection remain intact.\n\n## Verification\n- `npm test`: 848 passed, 0 failed, 2 browser engines skipped because unavailable\n- Chrome hosted/offline integration: all 64 checks passed\n- focused multisig identity/path/static UI tests passed