### PR TITLE
Attribute LifeHash reference sources in lifehash.js

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,11 @@ image, so `npm ci` and `npm run build:wasm` work without further downloads.
   ([SECURITY.md](SECURITY.md)), not as public issues.
 - **License:** public domain ([LICENSE](LICENSE)). By opening a pull request
   you confirm your contribution can be public domain; if not, open an issue
-  instead.
+  instead. Exception: `src/js/lifehash.js` is an adaptation of the LifeHash
+  reference implementations and is *not* public domain — the MIT
+  (AndreasGassmann/lifehash) and BSD-2-Clause-Patent
+  (BlockchainCommons/bc-lifehash) notices in its header must be preserved in
+  copies and derivative works, including the built `entropylab.html`.
 
 ## A final sanity check
 

--- a/src/js/lifehash.js
+++ b/src/js/lifehash.js
@@ -5,10 +5,103 @@
 // gradient and mirrored by a symmetry pattern chosen from hash bits. The
 // result is a deterministic, recognisable icon for a fingerprint.
 //
-// Faithful port of the reference algorithm (Blockchain Commons / the
-// `lifehash` JS package), using WebCrypto SHA-256 so no dependency is added.
-// Rendered via Canvas into a same-origin data URL, so it works fully offline
-// and inside the document's CSP (img-src 'self' data:).
+// Uses WebCrypto SHA-256 (no dependency added) and renders via Canvas into a
+// same-origin data URL, so it works fully offline and inside the document's
+// CSP (img-src 'self' data:).
+//
+// Provenance and licensing
+// ------------------------
+//
+// This file is an adaptation of the LifeHash reference implementations: the
+// version2 algorithm was ported from the "lifehash" JavaScript package
+// (https://github.com/AndreasGassmann/lifehash), itself a port of the
+// Blockchain Commons C++ reference implementation
+// (https://github.com/BlockchainCommons/bc-lifehash). The code was
+// re-expressed for this project (closures instead of classes, flat arrays
+// instead of grid objects, WebCrypto, a hand-rolled PNG encoder), but it
+// follows those sources function-by-function and retains fragments of their
+// expression, so their licenses apply to this file. Correctness is pinned
+// bit-for-bit against the canonical package (test/lifehash.test.mjs,
+// fuzzing/lifehash/fuzz.mjs).
+//
+// Unlike the rest of EntropyLab (public domain, see LICENSE), THIS FILE IS
+// NOT PUBLIC DOMAIN. Copies and derivative works — including the built
+// entropylab.html, which inlines this file verbatim — must retain the
+// following notices:
+//
+// --- MIT License ("lifehash" JS package) ---
+//
+// Copyright (c) 2022 Andreas Gassmann
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// --- BSD-2-Clause Plus Patent License (bc-lifehash C++ reference) ---
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// Copyright (c) 2019 Blockchain Commons, LLC
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// Subject to the terms and conditions of this license, each copyright holder
+// and contributor hereby grants to those receiving rights under this license
+// a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+// (except for failure to satisfy the conditions of this license) patent
+// license to make, have made, use, offer to sell, sell, import, and otherwise
+// transfer this software, where such license applies only to those patent
+// claims, already acquired or hereafter acquired, licensable by such
+// copyright holder or contributor that are necessarily infringed by:
+//
+// (a) their Contribution(s) (the licensed copyrights of copyright holders and
+//     non-copyrightable additions of contributors, in source or binary form)
+//     alone; or
+// (b) combination of their Contribution(s) with the work of authorship to
+//     which such Contribution(s) was added by such copyright holder or
+//     contributor, if, at the time the Contribution is added, such addition
+//     causes such combination to be necessarily infringed. The patent license
+//     shall not apply to any other combinations which include the
+//     Contribution.
+//
+// Except as expressly stated above, no rights or licenses from any copyright
+// holder or contributor is granted under this license, whether expressly, by
+// implication, estoppel or otherwise.
+//
+// DISCLAIMER
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 const hodlLifeHash = (() => {
   const SIZE = 16;


### PR DESCRIPTION
## What

Adds the missing third-party attribution to `src/js/lifehash.js` and documents the exception in `CONTRIBUTING.md`. No behaviour change — comments and documentation only.

## Why

A provenance review of #74 found that `src/js/lifehash.js` was written by closely following the reference sources — primarily the [AndreasGassmann/lifehash](https://github.com/AndreasGassmann/lifehash) TypeScript package (MIT), itself a port of [BlockchainCommons/bc-lifehash](https://github.com/BlockchainCommons/bc-lifehash) (C++, BSD-2-Clause-Patent) — and re-expressing the version2 subset, rather than writing from the prose algorithm description alone. The in-code evidence: verbatim error strings (`"BitEnumerator underflow."`), function names taken from the TS package (`runGameOfLife`, `buildFracGrid` — the C++ inlines that logic), TS-port-specific idioms (`sha256(data).toString()` as the history-set key), and mirrored helper structure.

That makes the file an adaptation, and adapted upstream expression cannot be dedicated to the public domain by a contributor — the project's public-domain terms cover original code only. Both upstream licenses are permissive; the sole obligation is notice retention.

## How

- `src/js/lifehash.js`: the header now states the provenance plainly and carries both notices in full (MIT copyright + permission notice; BSD-2-Clause-Patent copyright, conditions, patent grant, and disclaimer). Because the build inlines this file verbatim behind `@@JS_LIFEHASH@@`, the notices automatically ship inside `entropylab.html` — verified after rebuild.
- `CONTRIBUTING.md`: the License bullet gains the exception — the project stays public domain; `lifehash.js` is not, and its notices must be preserved in copies and derivative works, including the built artifact.

Downstream redistributors of the file or the artifact should carry the same two notices.

## Verified

- `npm run build` — OK; the built `entropylab.html` contains both notices.
- `npm test` — 868 pass, 0 fail, 1 pre-existing skip.
- `npm run verify` — OK.