### PR TITLE
Write the Keys tool intro and fit the language control into the header

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -784,6 +784,11 @@ td { border-top: 1px solid var(--border); padding: 8px; vertical-align: top; fon
   background: var(--bg); color: var(--fg); font-size: 13px; font-weight: 600; letter-spacing: 0.04em;
 }
 .locale-select:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+/* enhanced-inputs.js swaps the select for a custom listbox whose form chrome
+   (44px minimum, control margin, mono face) would bulge out of the 52px bar.
+   In the header the generated control wears the header-button sizing instead. */
+.locale-control .custom-select { flex: 0 0 auto; width: auto; margin-top: 0; font-family: inherit; font-size: 14px; }
+.locale-control .custom-select-button { min-height: 40px; padding: 0 8px; border-radius: 8px; gap: 6px; font-weight: 600; letter-spacing: 0.04em; }
 .theme-toggle svg { display: none; width: 22px; height: 22px; fill: none; stroke: currentColor; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
 .theme-toggle[data-theme-mode="dark"] .theme-icon-dark, .theme-toggle[data-theme-mode="light"] .theme-icon-light { display: block; }
 .btn:is(.download-html, .save-recovery-sheet, .save-wallet-dat) {

--- a/src/index.html
+++ b/src/index.html
@@ -66,7 +66,7 @@
       <div class="tool-intro" id="calc-tool-intro">
         <div class="kicker">Your entropy enters the lab</div>
         <h2>Create. Derive. Verify.</h2>
-        <p class="muted calc-intro">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+        <p class="muted calc-intro">Turn entropy you bring — dice rolls, playing cards, a number in any base, a seed phrase, or a private key — into a BIP-39 seed, then derive its master fingerprint, extended public keys, and receive addresses. The dice methods match COLDCARD, SeedSigner, Keystone, and BitBox, so the same rolls reproduce the same seed on those signers. This does not invent entropy — it is a calculator, and nothing leaves this page.</p>
       </div>
       <section class="key-manager no-print" id="key-manager">
       <div class="key-tab-strip"><div class="key-tabs" id="key-tabs" role="tablist" aria-label="Keys"></div><div class="add-item-control"><button class="add-key" id="add-key" type="button" aria-label="Open Key Station to derive another key" aria-describedby="add-key-tooltip">+</button><span class="add-item-tooltip" id="add-key-tooltip" role="tooltip">Open Key Station to derive another key</span></div><div class="add-item-control"><button class="add-key remove-key" id="delete-key" type="button" aria-label="Delete current key" aria-describedby="delete-key-tooltip" disabled>−</button><span class="add-item-tooltip" id="delete-key-tooltip" role="tooltip">Delete this key</span></div></div>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -502,7 +502,7 @@ hodlRootEl.innerHTML = `
       <div class="tool-intro" id="calc-tool-intro">
         <div class="kicker">Your entropy enters the lab</div>
         <h2>Create. Derive. Verify.</h2>
-        <p class="muted calc-intro">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+        <p class="muted calc-intro">Turn entropy you bring \u2014 dice rolls, playing cards, a number in any base, a seed phrase, or a private key \u2014 into a BIP-39 seed, then derive its master fingerprint, extended public keys, and receive addresses. The dice methods match COLDCARD, SeedSigner, Keystone, and BitBox, so the same rolls reproduce the same seed on those signers. This does not invent entropy \u2014 it is a calculator, and nothing leaves this page.</p>
       </div>
       <section class="key-manager no-print" id="key-manager">
       <div class="key-tab-strip"><div class="key-tabs" id="key-tabs" role="tablist" aria-label="Keys"></div><div class="add-item-control"><button class="add-key" id="add-key" type="button" aria-label="Open Key Station to derive another key" aria-describedby="add-key-tooltip">+</button><span class="add-item-tooltip" id="add-key-tooltip" role="tooltip">Open Key Station to derive another key</span></div><div class="add-item-control"><button class="add-key remove-key" id="delete-key" type="button" aria-label="Delete current key" aria-describedby="delete-key-tooltip" disabled>−</button><span class="add-item-tooltip" id="delete-key-tooltip" role="tooltip">Delete this key</span></div></div>

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -1364,6 +1364,12 @@ test("the site header is fixed, carries the logo, and holds the version, downloa
   // Every header control is one height, and the bar is sized to match it.
   assert.match(css, /\.header-button \{ min-height: 40px; font-size: 14px; \}/);
   assert.match(css, /--site-header-height: 52px;/);
+  // enhanced-inputs.js swaps the language select for a custom listbox; the
+  // generated control keeps the bar's 40px chrome and sans face instead of
+  // the form control's 44px minimum, control margin, and mono face, which
+  // bulged out of the 52px bar.
+  assert.match(css, /\.locale-control \.custom-select \{[^}]*margin-top: 0;[^}]*font-family: inherit;[^}]*font-size: 14px;/s);
+  assert.match(css, /\.locale-control \.custom-select-button \{[^}]*min-height: 40px;[^}]*border-radius: 8px;/s);
 });
 
 test("the header logo is inlined for both themes and never fetched from assets", () => {
@@ -1408,6 +1414,15 @@ test("the marketing card states its pitch as a list rather than a paragraph", ()
   // The list stands in for a paragraph, so it carries the space a paragraph
   // would have above it and leaves the card's padding to close it out.
   assert.match(css, /\.pitch-list \{ display: grid; gap: 7px; margin: var\(--space-component\) 0 0; padding-left: 20px; \}/);
+});
+
+test("the Keys tool intro tells what the calculator does, like the other tool intros", () => {
+  for (const markup of [template, appSource]) {
+    // No placeholder copy rides the page's first tool intro.
+    assert.doesNotMatch(markup, /lorem ipsum/i);
+    assert.match(markup, /<p class="muted calc-intro">Turn entropy you bring (?:—|\\u2014) dice rolls, playing cards, a number in any base, a seed phrase, or a private key/);
+    assert.match(markup, /This does not invent entropy (?:—|\\u2014) it is a calculator, and nothing leaves this page\.<\/p>/);
+  }
 });
 
 test("the favicon ships inside the document instead of the assets directory", () => {


### PR DESCRIPTION
## What

- **Keys tool intro copy** — the `calc-intro` paragraph under "Create. Derive. Verify." carried Lorem ipsum placeholder text (in both `src/index.html` and the rendered markup in `src/js/app.js`). It now says what the calculator does, in the same voice as the BIP-85 / Journal / MultiSig / SP / PSBT intros.
- **Language-control sizing** — `enhanced-inputs.js` swaps `#locale-select` for a custom listbox that inherited the in-page form chrome: 44px minimum height, control top margin, and the mono face. The visible button rendered 51px tall and bulged out of the 52px header bar. New `.locale-control`-scoped rules put the generated control in the 40px header-button sizing with the header's sans face, matching Download and the network picker.

## Tests

- New assertions pin the header sizing of the generated locale control, and a new test pins the intro copy and bars Lorem ipsum from the page.
- `npm run build` + `npm test`: pass (874/879; the 4 failures come from the untracked local WIP file `test/psbt-network.test.mjs`, which is not part of this change and not in `test:ci`).
- Verified the header visually in headless Chrome: all three header controls now measure 40px tall, aligned on the same baseline.

The built `entropylab.html` artifact is intentionally not committed — the artifact job commits the tested build after merge.