### PR TITLE
Clarify what the reproducible site build covers

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,14 @@ gh attestation verify entropylab.html -R OogaBoogaX/entropylab
 The attestation is keyless (Sigstore) and bound to this repository's release
 workflow, so it authenticates the artifact independently of the hosting
 account. The checksum manifest alone only detects accidental corruption —
-always pair it with the attestation or with your own rebuild from source,
-which is byte-for-byte reproducible.
+always pair it with the attestation or reproduce the build from reviewed
+source. For a given Git revision, `npm run build` deterministically assembles
+`entropylab.html` from committed inputs, including the committed WASM modules;
+the revision to check out is stamped in the generated file. Rebuilding those
+modules from their Rust/C sources (`npm run build:wasm`) is separate, and its
+output is not currently asserted to be byte-identical across machines. CI
+still rebuilds the modules from source and runs the WASM binding tests against
+the fresh build (see [Building from source](#building-from-source)).
 
 An online version is available at [entropylab.online](https://entropylab.online)
 for convenient access. Do not enter seed phrases, private keys, or other secret


### PR DESCRIPTION
"Verifying the download" tells readers to pair the checksum manifest with the
attestation "or with your own rebuild from source, which is byte-for-byte
reproducible". Two details that live elsewhere in the README make that
sentence easy to misread:

1. `npm run build` stamps the current Git revision into `entropylab.html`
   (footer commit and LifeHash, plus the derived service-worker cache-buster).
   The artifact committed at `677a212` was built at `5d4dec9` and carries
   `5d4dec9`, so rebuilding at a later artifact-only commit intentionally
   produces different bytes. Reproducing published bytes means checking out
   the revision stamped in the generated file.
2. "Building from source" already records that byte identity of the WASM
   across machines is not asserted, since the C side compiles with the
   builder's clang. That caveat sits about a hundred lines below the
   reproducibility claim.

This states the existing guarantee more precisely:

- for a given Git revision, `npm run build` deterministically assembles
  `entropylab.html` from committed inputs, including the committed WASM
  modules;
- the generated file identifies the revision to check out;
- `npm run build:wasm` is a separate Rust/C rebuild whose cross-machine byte
  identity is not currently asserted;
- CI still rebuilds the modules from source and runs the WASM binding tests
  against the fresh build.

No guarantee changes and no behaviour changes. README.md only — no workflows,
Dockerfiles, source, dependencies, or generated artifacts.

### Commands run

- `npm ci --ignore-scripts` — 10 packages added, 0 vulnerabilities (exit 0)
- `git diff --check` — clean (exit 0)
- `npm run build` — entropylab.html (2774284 bytes), service-worker.js
  (1401 bytes) (exit 0)
- `npm test` — 877 tests, 870 pass, 0 fail, 7 skipped, 46.9 s (exit 0)

The 7 skips are the pre-existing optional SQLite `wallet.dat` checks, which
need Python. The build restamps the tracked `entropylab.html` with the current
revision; that expected build output was restored so the commit carries
README.md alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
