### PR TITLE
Fix mobile wallet result overflow

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -614,10 +614,10 @@ details.lab-entropy .wallet-result-messages { margin-top: var(--space-control); 
 .table-private-field-value { display: inline-grid; white-space: nowrap; }
 .private-field-value:not(.secret-placeholder),
 .table-private-field-value:not(.secret-placeholder) { color: var(--blue); }
-.secret-placeholder { display: grid; color: var(--muted); }
+.secret-placeholder { display: grid; min-width: 0; max-width: 100%; color: var(--muted); }
 .secret-placeholder > .secret-placeholder-mask,
 .secret-placeholder > .secret-placeholder-message { grid-area: 1 / 1; }
-.secret-placeholder-mask { visibility: hidden; user-select: none; }
+.secret-placeholder-mask { min-width: 0; max-width: 100%; visibility: hidden; overflow-wrap: anywhere; word-break: break-all; user-select: none; }
 .secret-placeholder-message { color: var(--muted); }
 .secret-placeholder-label {
   position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
@@ -629,12 +629,12 @@ details.lab-entropy .wallet-result-messages { margin-top: var(--space-control); 
 table { width: 100%; border-collapse: collapse; font-size: 12px; }
 th { text-align: left; color: var(--muted); font-weight: 600; padding: 8px; }
 td { border-top: 1px solid var(--border); padding: 8px; vertical-align: top; font-family: var(--mono); }
-.qr { background: var(--paper); padding: 8px; border: 1px solid var(--border); border-radius: 8px; display: inline-block; }
-.qr svg { display: block; width: 140px; height: 140px; }
+.qr { max-width: 100%; background: var(--paper); padding: 8px; border: 1px solid var(--border); border-radius: 8px; display: inline-block; }
+.qr svg { display: block; max-width: 100%; width: 140px; height: auto; aspect-ratio: 1; }
 .qr-descriptor { padding: 12px; }
-.qr-descriptor svg { width: 280px; height: 280px; }
+.qr-descriptor svg { width: 280px; height: auto; }
 .qr-seed { padding: 12px; }
-.qr-seed svg { width: 200px; height: 200px; }
+.qr-seed svg { width: 200px; height: auto; }
 .watch-only-qr { margin: 12px 0 16px; }
 .seed-qr-pair { display: grid; gap: 16px; }
 .seed-qr-pair .watch-only-qr { margin: 0; }
@@ -1042,9 +1042,9 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .key-tab.is-lab { font-weight: 700; }
 .key-tab-lab-icon { width: 16px; height: 16px; padding: 0; color: var(--muted); }
 .key-tab-lab-icon svg { display: block; width: 100%; height: 100%; }
-.key-result { margin-top: 16px; }
+.key-result { min-width: 0; max-width: 100%; margin-top: 16px; }
 .key-result-scripts-label { margin: 0 0 8px; color: var(--muted); font-size: 12px; font-weight: 700; }
-.key-result-main { margin-top: 8px; padding: 16px 16px 20px; border: 1px solid var(--border); border-radius: 20px; background: var(--surface); }
+.key-result-main { min-width: 0; max-width: 100%; margin-top: 8px; padding: 16px 16px 20px; border: 1px solid var(--border); border-radius: 20px; background: var(--surface); }
 .key-result .wallet-result-messages { margin: 0 0 16px; }
 .account-receive-section { margin-top: 0; }
 .station-key-source { margin: 0 0 20px; }
@@ -1780,7 +1780,7 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .account-address-lead { display: grid; gap: 10px; justify-items: start; margin-bottom: 22px; }
 .account-address-lead p { margin: 0; }
 .wallet-table {
-  width: 100%; max-height: 252px; overflow: auto; border: 1px solid var(--border); border-radius: 9px;
+  width: 100%; max-width: 100%; max-height: 252px; overflow: auto; border: 1px solid var(--border); border-radius: 9px;
   overflow-anchor: none; overscroll-behavior: contain;
   scrollbar-width: thin; scrollbar-color: var(--scrollbar-thumb) var(--surface);
 }

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -1782,6 +1782,13 @@
     derive.click();
     await until(() => document.getElementById("save") || document.getElementById("error").textContent, "wallet result");
     assert(!document.getElementById("error").textContent, "Wallet derivation failed");
+    const mobileResult = document.querySelector(".key-result");
+    mobileResult.style.width = "220px";
+    assert(
+      mobileResult.scrollWidth <= mobileResult.clientWidth,
+      `Derived wallet widened a mobile layout to ${mobileResult.scrollWidth}px from ${mobileResult.clientWidth}px`,
+    );
+    mobileResult.style.width = "";
     const derivationProgress = await until(() => document.getElementById("derive-progress").classList.contains("is-complete") && document.getElementById("derive-progress"), "completed derivation progress");
     assert(!derivationProgress.hidden, "Completed derivation progress did not remain visible");
     equal(derivationProgress.getAttribute("aria-valuenow"), "100", "Derivation progress did not reach 100%");

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -1859,6 +1859,18 @@ test("derived key results put private recovery before script type and addresses"
   assert.match(appSource, /hodlBindWalletResultActions\(\);/);
 });
 
+test("derived wallet results stay within the mobile layout (#238)", () => {
+  assert.match(css, /\.key-result \{ min-width: 0; max-width: 100%;/);
+  assert.match(css, /\.key-result-main \{ min-width: 0; max-width: 100%;/);
+  assert.match(css, /\.secret-placeholder \{ display: grid; min-width: 0; max-width: 100%;/);
+  assert.match(css, /\.secret-placeholder-mask \{[^}]*max-width: 100%;[^}]*overflow-wrap: anywhere;[^}]*word-break: break-all;/);
+  assert.match(css, /\.qr \{ max-width: 100%;/);
+  assert.match(css, /\.qr svg \{[^}]*max-width: 100%;[^}]*height: auto;[^}]*aspect-ratio: 1;/);
+  assert.match(css, /\.qr-descriptor svg \{ width: 280px; height: auto; \}/);
+  assert.match(css, /\.qr-seed svg \{ width: 200px; height: auto; \}/);
+  assert.match(css, /\.wallet-table \{[^}]*width: 100%; max-width: 100%;[^}]*overflow: auto;/);
+});
+
 test("every MS Station co-signer row can pick any session key, and key reuse offers a derivation path", () => {
   for (const markup of [template, appSource]) {
     assert.match(markup, /class="station-key-source msig-station-key-source"[\s\S]*id="msig-session-keys"[\s\S]*id="msig-reuse-session-keys"[\s\S]*id="msig-session-key-status"/);


### PR DESCRIPTION
Fixes #238.

Constrain derived-wallet result content to the available inline size so long hidden recovery placeholders, wide address tables, and QR exports cannot enlarge the mobile page during the result transition. QR codes now scale down while preserving their square aspect ratio.

Adds a browser regression that renders a completed wallet inside a 220px-wide result area and asserts it creates no horizontal overflow, plus source-level responsive-style guards.

Tests:
- `npm run build`
- `node --test test/ui-defaults.test.mjs`
- Chrome browser suite: all 66 integration checks passed

The local Firefox Snap could not launch because its runtime directory under `/run/user/1000` is read-only; CI should exercise Firefox normally.