### PR TITLE
Complete the landing-page introduction

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -67,7 +67,7 @@
       <div class="tool-intro" id="calc-tool-intro">
         <div class="kicker">Your entropy enters the lab</div>
         <h2>Create. Derive. Verify.</h2>
-        <p class="muted calc-intro">Turn entropy you bring — dice rolls, playing cards, a number in any base, a seed phrase, or a private key — into a BIP-39 seed, then derive its master fingerprint, extended public keys, and receive addresses. The dice methods match COLDCARD, SeedSigner, Keystone, and BitBox, so the same rolls reproduce the same seed on those signers. This does not invent entropy — it is a calculator, and nothing leaves this page.</p>
+        <p class="muted calc-intro">Roll dice, flip coins, or import an existing seed — entirely offline. EntropyLab turns your raw entropy into a BIP39 mnemonic, derives receive addresses and an xpub for watch-only wallets, builds multisig setups, and decodes PSBTs before you sign. Nothing leaves your machine until you choose to export it.</p>
       </div>
       <section class="key-manager no-print" id="key-manager">
       <div class="key-tab-strip"><div class="key-tabs" id="key-tabs" role="tablist" aria-label="Keys"></div><div class="add-item-control"><button class="add-key" id="add-key" type="button" aria-label="Open Key Station to derive another key" aria-describedby="add-key-tooltip">+</button><span class="add-item-tooltip" id="add-key-tooltip" role="tooltip">Open Key Station to derive another key</span></div><div class="add-item-control"><button class="add-key remove-key" id="delete-key" type="button" aria-label="Delete current key" aria-describedby="delete-key-tooltip" disabled>−</button><span class="add-item-tooltip" id="delete-key-tooltip" role="tooltip">Delete this key</span></div></div>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -533,7 +533,7 @@ hodlRootEl.innerHTML = `
       <div class="tool-intro" id="calc-tool-intro">
         <div class="kicker">Your entropy enters the lab</div>
         <h2>Create. Derive. Verify.</h2>
-        <p class="muted calc-intro">Turn entropy you bring \u2014 dice rolls, playing cards, a number in any base, a seed phrase, or a private key \u2014 into a BIP-39 seed, then derive its master fingerprint, extended public keys, and receive addresses. The dice methods match COLDCARD, SeedSigner, Keystone, and BitBox, so the same rolls reproduce the same seed on those signers. This does not invent entropy \u2014 it is a calculator, and nothing leaves this page.</p>
+        <p class="muted calc-intro">Roll dice, flip coins, or import an existing seed \u2014 entirely offline. EntropyLab turns your raw entropy into a BIP39 mnemonic, derives receive addresses and an xpub for watch-only wallets, builds multisig setups, and decodes PSBTs before you sign. Nothing leaves your machine until you choose to export it.</p>
       </div>
       <section class="key-manager no-print" id="key-manager">
       <div class="key-tab-strip"><div class="key-tabs" id="key-tabs" role="tablist" aria-label="Keys"></div><div class="add-item-control"><button class="add-key" id="add-key" type="button" aria-label="Open Key Station to derive another key" aria-describedby="add-key-tooltip">+</button><span class="add-item-tooltip" id="add-key-tooltip" role="tooltip">Open Key Station to derive another key</span></div><div class="add-item-control"><button class="add-key remove-key" id="delete-key" type="button" aria-label="Delete current key" aria-describedby="delete-key-tooltip" disabled>−</button><span class="add-item-tooltip" id="delete-key-tooltip" role="tooltip">Delete this key</span></div></div>

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -1424,8 +1424,10 @@ test("the Keys tool intro tells what the calculator does, like the other tool in
   for (const markup of [template, appSource]) {
     // No placeholder copy rides the page's first tool intro.
     assert.doesNotMatch(markup, /lorem ipsum/i);
-    assert.match(markup, /<p class="muted calc-intro">Turn entropy you bring (?:—|\\u2014) dice rolls, playing cards, a number in any base, a seed phrase, or a private key/);
-    assert.match(markup, /This does not invent entropy (?:—|\\u2014) it is a calculator, and nothing leaves this page\.<\/p>/);
+    assert.match(markup, /<p class="muted calc-intro">Roll dice, flip coins, or import an existing seed (?:—|\\u2014) entirely offline\./);
+    assert.match(markup, /turns your raw entropy into a BIP39 mnemonic, derives receive addresses and an xpub for watch-only wallets/);
+    assert.match(markup, /builds multisig setups, and decodes PSBTs before you sign\./);
+    assert.match(markup, /Nothing leaves your machine until you choose to export it\.<\/p>/);
   }
 });
 


### PR DESCRIPTION
Closes #267

## Summary
- replace the remaining partial Keys introduction with the issue’s proposed landing-page copy
- explain Create, Derive, and Verify through mnemonic, address/xpub, multisig, and PSBT workflows
- strengthen the regression test across both source markups

## Verification
- `node --test test/ui-defaults.test.mjs`
- `npm run build`
- `npm test` (938/939 pass locally; the Firefox subtest cannot launch the host’s Snap package because this sandbox cannot create `/run/user/1000/snap.firefox`)
- Chrome/Chromium browser suite: all 69 checks pass