### PR TITLE
Keep the browser-suite test bridge out of the release build

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -8,15 +8,28 @@
 // serve the same application. The output is byte-for-byte reproducible from
 // the sources, the version declared in package.json, and the commit the
 // build is cut from (stamped into the footer).
+//
+// The browser test harness builds a staging variant with
+// `--test-hooks --out <dir>`: it compiles in the suite's test bridge (see
+// src/js/app.js) and writes the files outside the repository root. The
+// release build leaves the flag off, so no test code reaches entropylab.html.
 import { execFileSync } from "node:child_process";
-import { readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildSync } from "esbuild";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const SRC = join(root, "src");
+
+const testHooks = process.argv.includes("--test-hooks");
+const outFlag = process.argv.indexOf("--out");
+if (outFlag !== -1 && !process.argv[outFlag + 1]) throw new Error("--out requires a directory");
+const outDir = outFlag === -1 ? root : resolve(root, process.argv[outFlag + 1]);
+if (testHooks && outDir === root) {
+  throw new Error("--test-hooks requires --out outside the repository root: the release artifact ships no test code");
+}
 
 const read = (path) => readFileSync(join(SRC, path), "utf8");
 const version = JSON.parse(readFileSync(join(root, "package.json"), "utf8")).version;
@@ -79,6 +92,7 @@ const jsMain = buildSync({
   target: "es2022",
   legalComments: "none",
   charset: "utf8",
+  define: { __ENTROPYLAB_TEST_HOOKS__: testHooks ? "true" : "false" },
 }).outputFiles[0].text.split(siteLogoSpan).join(siteLogo);
 const jsSqliteWriter = read("js/sqlite-writer.js");
 const jsWalletExport = read("js/wallet-export.js");
@@ -125,12 +139,16 @@ for (const leftover of `${html}\n${worker}`.match(/\/\*@@|{{(?:VERSION|PWA_VERSI
   throw new Error(`Unreplaced build token in output: ${leftover}`);
 }
 
-// Remove stale generated files (e.g. versioned copies from older releases)
-for (const name of generated()) rmSync(join(root, name), { force: true });
+if (outDir === root) {
+  // Remove stale generated files (e.g. versioned copies from older releases)
+  for (const name of generated()) rmSync(join(root, name), { force: true });
+} else {
+  mkdirSync(outDir, { recursive: true });
+}
 
-writeFileSync(join(root, appFile), html);
-writeFileSync(join(root, workerFile), worker);
+writeFileSync(join(outDir, appFile), html);
+writeFileSync(join(outDir, workerFile), worker);
 
-console.log(`Built EntropyLab v${version}`);
+console.log(`Built EntropyLab v${version}${testHooks ? " (test hooks enabled; not for release)" : ""}`);
 console.log(`  ${appFile} (${Buffer.byteLength(html, "utf8")} bytes)`);
 console.log(`  ${workerFile} (${Buffer.byteLength(worker, "utf8")} bytes)`);

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -480,7 +480,12 @@ function hodlSingleKeyWallet(e, t, r, trimBrainWallet = false) {
 function hodlQrSvg(e, t = "#111111", r = "#ffffff") {
   return hodlUqrRenderSvg(e, { ecc: "M", border: 2, pixelSize: 4, blackColor: t, whiteColor: r });
 }
-if (globalThis.__entropyLabTest) globalThis.__entropyLabCrypto = { entropyToMnemonic: (hex) => hodlEntropyToMnemonic(hodlHex.decode(hex), hodlBip39Wordlist), mnemonicToEntropy: (mnemonic) => hodlHex.encode(hodlMnemonicToEntropy(mnemonic, hodlBip39Wordlist)), mnemonicToSeed: (mnemonic, passphrase) => hodlHex.encode(hodlMnemonicToSeed(mnemonic, passphrase)), validateMnemonic: (mnemonic) => hodlValidateMnemonic(mnemonic).ok, masterXprv: (mnemonic, passphrase) => hodlHDKey.fromMasterSeed(hodlMnemonicToSeed(mnemonic, passphrase)).privateExtendedKey, privateKeyInputIsValid: () => hodlPrivateKeyInputIsValid(), computeTargetLastWords: (words, targetWords) => hodlComputeTargetLastWords(words, targetWords), clearLastWordCache: () => hodlLastWordCache.clear(), validateTargetMnemonic: (value, targetWords) => hodlValidateTargetMnemonic(value, targetWords), bruteTargetLastWords: (value) => hodlLastWordCandidates(value) };
+// Test-only bridge for the browser suite (test/browser-suite.html), armed
+// solely when the injected instrumentation is present. The release build
+// defines __ENTROPYLAB_TEST_HOOKS__ as false (scripts/build.mjs), so the
+// minifier drops this statement and no test code ships in entropylab.html;
+// the browser harness stages a --test-hooks variant instead.
+if (__ENTROPYLAB_TEST_HOOKS__ && globalThis.__entropyLabTest) globalThis.__entropyLabCrypto = { entropyToMnemonic: (hex) => hodlEntropyToMnemonic(hodlHex.decode(hex), hodlBip39Wordlist), mnemonicToEntropy: (mnemonic) => hodlHex.encode(hodlMnemonicToEntropy(mnemonic, hodlBip39Wordlist)), mnemonicToSeed: (mnemonic, passphrase) => hodlHex.encode(hodlMnemonicToSeed(mnemonic, passphrase)), validateMnemonic: (mnemonic) => hodlValidateMnemonic(mnemonic).ok, masterXprv: (mnemonic, passphrase) => hodlHDKey.fromMasterSeed(hodlMnemonicToSeed(mnemonic, passphrase)).privateExtendedKey, privateKeyInputIsValid: () => hodlPrivateKeyInputIsValid(), computeTargetLastWords: (words, targetWords) => hodlComputeTargetLastWords(words, targetWords), clearLastWordCache: () => hodlLastWordCache.clear(), validateTargetMnemonic: (value, targetWords) => hodlValidateTargetMnemonic(value, targetWords), bruteTargetLastWords: (value) => hodlLastWordCandidates(value) };
 var hodlRootEl = document.getElementById("btc-calc");
 if (!hodlRootEl) throw new Error("#app missing");
 hodlRootEl.innerHTML = `

--- a/test/browser.test.mjs
+++ b/test/browser.test.mjs
@@ -10,7 +10,7 @@
 // Run with `npm run test:browser` or `npm test`.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { spawn, spawnSync } from "node:child_process";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { createServer } from "node:http";
 import {
   closeSync,
@@ -188,10 +188,17 @@ const stageWorkDir = () => {
   const workDir = mkdtempSync(join(stagingBase(), "entropylab-browser-"));
   const siteDir = join(workDir, "site");
   mkdirSync(join(siteDir, "assets"), { recursive: true });
+  // The served download target stays the exact release artifact, so the
+  // export check below keeps proving the download link serves the release.
   cpSync(appSource, join(siteDir, appFile));
   cpSync(join(root, "assets"), join(siteDir, "assets"), { recursive: true });
 
-  const appHtml = read(appFile);
+  // The suite drives app internals through __entropyLabCrypto, a test-only
+  // bridge the release build strips (scripts/build.mjs). Assemble the test
+  // document from a hooks-enabled variant built into the work dir; the build
+  // is identical to the release except for that one compiled-in statement.
+  execFileSync(process.execPath, [join(root, "scripts/build.mjs"), "--test-hooks", "--out", workDir], { stdio: "inherit" });
+  const appHtml = readFileSync(join(workDir, appFile), "utf8");
   const instrumentation = read("test/browser-instrumentation.html");
   const suite = read("test/browser-suite.html");
 

--- a/test/validate.test.mjs
+++ b/test/validate.test.mjs
@@ -338,6 +338,12 @@ for (const file of htmlFiles) {
       `${file} favicon does not match assets/favicon.png`,
     );
   });
+  test(`${file} ships none of the test-only browser-suite bridge`, () => {
+    // The __entropyLabCrypto hook lets the browser suite reach app internals;
+    // it is compiled in only for the harness's --test-hooks staging variant.
+    const html = read(file);
+    assert.doesNotMatch(html, /__ENTROPYLAB_TEST_HOOKS__|__entropyLabTest|__entropyLabCrypto/);
+  });
   test(`${file} never fetches the header logo or favicon from assets`, () => {
     // The downloaded file has no assets/ beside it, so both have to travel
     // inside the document or the fixed header renders empty when air-gapped.
@@ -363,6 +369,17 @@ test("the build inlines the header logo and SVG favicon from src/assets", () => 
   assert.match(build, /\.split\(siteLogoSpan\)\.join\(siteLogo\)/);
   assert.match(template, /<span class="site-logo" aria-hidden="true"><\/span>/);
   assert.match(template, /<link rel="icon" type="image\/svg\+xml" href="data:image\/svg\+xml,\/\*@@FAVICON_SVG@@\*\/">/);
+});
+
+test("the browser-suite crypto bridge is gated out of the release build", () => {
+  // The artifact check above is the invariant; this pins the mechanism so the
+  // gate cannot be dropped without a red test: the hook in app.js must sit
+  // behind the build-time flag, and the build must default that flag off and
+  // refuse to write a hooks build over the release artifact.
+  assert.match(read("src/js/app.js"), /if \(__ENTROPYLAB_TEST_HOOKS__ && globalThis\.__entropyLabTest\) globalThis\.__entropyLabCrypto = /);
+  const build = read("scripts/build.mjs");
+  assert.match(build, /define: \{ __ENTROPYLAB_TEST_HOOKS__: testHooks \? "true" : "false" \}/);
+  assert.match(build, /--test-hooks requires --out outside the repository root/);
 });
 
 test("the document head declares its link-preview card", () => {


### PR DESCRIPTION
## What

`src/js/app.js` ships a test-only bridge — `if (globalThis.__entropyLabTest) globalThis.__entropyLabCrypto = {…}` — that lets `test/browser-suite.html` reach app internals. It is dormant in production, but it is still **test code compiled into the release `entropylab.html`**. This PR isolates it from the main build.

## How

- **`src/js/app.js`** — the bridge is now gated behind a build-time constant: `if (__ENTROPYLAB_TEST_HOOKS__ && globalThis.__entropyLabTest) …`.
- **`scripts/build.mjs`** — esbuild `define` sets `__ENTROPYLAB_TEST_HOOKS__` to `false` for release builds, so the minifier drops the block from `entropylab.html` entirely. New `--test-hooks --out <dir>` flags build the harness staging variant; the build **refuses `--test-hooks` at the repository root**, so a hooks build can never overwrite the release artifact.
- **`test/browser.test.mjs`** — the staged test document is assembled from a `--test-hooks` variant built into the temp work dir; the served `entropylab.html` download target stays the byte-exact release artifact, so the export check keeps proving the download link serves the release.
- **`test/validate.test.mjs`** — two new invariants: the built artifact must contain no `__ENTROPYLAB_TEST_HOOKS__` / `__entropyLabTest` / `__entropyLabCrypto` strings, and the source gate + build flag are pinned so the isolation cannot be dropped silently.

No generated files committed; CI rebuilds and commits `entropylab.html` after merge as usual.

## Verified

- `npm run build` — release artifact contains zero test-bridge bytes; `--test-hooks --out …` variant retains the bridge; bare `--test-hooks` throws.
- `npm test` — 1019 pass, 0 fail, 1 skip (Microsoft Edge binary absent); Firefox and Chrome/Chromium each ran all 72 browser-integration checks against the hooks variant.
- `npm run verify` — passes.