### PR TITLE
Stop the npm audit endpoint from cancelling CI runs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -62,7 +62,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
       - name: Install locked dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --ignore-scripts --no-audit --no-fund
       - name: Build static site
         run: npm run build
       - name: Generate the SHA-256 checksum manifest
@@ -127,7 +127,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
       - name: Install locked dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --ignore-scripts --no-audit --no-fund
       - name: Rebuild the WASM artifacts from the Rust sources
         run: npm run build:wasm
       - name: Test the freshly built bindings
@@ -176,7 +176,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
       - name: Install locked dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --ignore-scripts --no-audit --no-fund
       # Test the exact object the build job produced — never a rebuild.
       - name: Download the tested candidate
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -205,7 +205,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
       - name: Install locked dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --ignore-scripts --no-audit --no-fund
       - name: Install Firefox (macOS)
         if: inputs.install-firefox && runner.os == 'macOS'
         run: brew install --cask firefox
@@ -267,7 +267,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
       - name: Install locked dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --ignore-scripts --no-audit --no-fund
       # browser-check.test.mjs reads the compiled entropylab.html — test the
       # exact object the build job produced, never a rebuild.
       - name: Download the tested candidate
@@ -290,7 +290,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
       - name: Install locked dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --ignore-scripts --no-audit --no-fund
       - name: Run UI-default tests
         run: npm run test:ui
 
@@ -306,7 +306,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
       - name: Install locked dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --ignore-scripts --no-audit --no-fund
       # validate.test.mjs reads the compiled entropylab.html — test the exact
       # object the build job produced, never a rebuild.
       - name: Download the tested candidate
@@ -341,7 +341,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
       - name: Install locked dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --ignore-scripts --no-audit --no-fund
       - name: Run SeedQR tests
         run: npm run test:seedqr
 
@@ -356,7 +356,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
       - name: Install locked dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --ignore-scripts --no-audit --no-fund
       - name: Run number-base tests
         run: npm run test:number-bases
 
@@ -375,7 +375,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install locked fuzzing dependencies
-        run: npm ci --ignore-scripts --prefix fuzzing
+        run: npm ci --ignore-scripts --no-audit --no-fund --prefix fuzzing
       - name: Run the LifeHash differential fuzzer
         run: npm --prefix fuzzing run fuzz:lifehash
 
@@ -393,7 +393,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install locked fuzzing dependencies
-        run: npm ci --ignore-scripts --prefix fuzzing
+        run: npm ci --ignore-scripts --no-audit --no-fund --prefix fuzzing
       - name: Run the multisig differential fuzzer
         run: npm --prefix fuzzing run fuzz:msig
 
@@ -419,7 +419,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
       - name: Install locked dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --ignore-scripts --no-audit --no-fund
       - name: Rebuild the WASM artifacts from the Rust sources
         run: npm run build:wasm
       - name: Download the tested candidate
@@ -458,7 +458,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
       - name: Install locked dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --ignore-scripts --no-audit --no-fund
       # Verify the exact object the build job produced — never a rebuild.
       - name: Download the tested candidate
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
## Problem

Every CI run since **2026-09-03 ~22:52 UTC** shows as `cancelled` (12 of the last 13 runs). The cause is identical in each: a per-section test job reaches `npm ci --ignore-scripts` and the install **hangs for 5+ minutes** until the job's `timeout-minutes: 5` kills it mid-install (`Terminate orphan process: pid (…) (npm ci)`). One cancelled job marks the entire run cancelled — even though every test that actually ran passed.

Evidence from run [33833210179](https://github.com/w-s-bitcoin/entropylab/actions/runs/33833210179) (`rock` push):
- `npm ci` started 03:26:38 → killed 03:31:43 with zero output in between
- A sibling job that finished logged `added 10 packages in 5m` plus npm's notice: **"This endpoint is being retired. Use the bulk advisory endpoint instead"** — npm's audit endpoint is being decommissioned and npm's implicit audit call hangs on it

## Fix

Pass `--no-audit --no-fund` to all 13 `npm ci` invocations (including the two `--prefix fuzzing` ones). The audit is noise in CI anyway — dependency review belongs in Dependabot, which this repo already runs.

## Verification

- The exact patched command (`npm ci --ignore-scripts --no-audit --no-fund`) completed in **162ms** locally — the same install that hung 5+ minutes in CI
- Workflow YAML re-parsed cleanly, all 18 jobs intact

Once this lands on `rock`, the cancelled PR runs (e.g. #308, whose test failure is already fixed at its head — verified 88/88 `ui-defaults` tests pass locally) can be re-run and should go green.