### PR TITLE
Reject future SegWit inputs in BIP352 v0

### DIFF
--- a/src/js/bip352.js
+++ b/src/js/bip352.js
@@ -159,6 +159,7 @@ export const isP2pkh = (spk) => spk.length === 25 && spk[0] === 0x76 && spk[1] =
 export const isP2sh = (spk) => spk.length === 23 && spk[0] === 0xa9 && spk[1] === 0x14 && spk[22] === 0x87;
 export const isP2wpkh = (spk) => spk.length === 22 && spk[0] === 0x00 && spk[1] === 0x14;
 export const isP2tr = (spk) => spk.length === 34 && spk[0] === 0x51 && spk[1] === 0x20;
+const isFutureSegwit = (spk) => spk.length >= 4 && spk.length <= 42 && spk[0] >= 0x52 && spk[0] <= 0x60 && spk[1] === spk.length - 2;
 
 const compressedPointOrNull = (bytes) => {
   if (!(bytes instanceof Uint8Array) || bytes.length !== 33 || (bytes[0] !== 2 && bytes[0] !== 3)) return null;
@@ -380,6 +381,9 @@ export function eligibleInputKeys(vins) {
 }
 
 export function createSilentPaymentOutputs(vins, recipients, { hrp = "sp" } = {}) {
+  if (vins.some((vin) => isFutureSegwit(vinPrevoutScript(vin)))) {
+    throw new Error("BIP-352 v0 cannot send with an input that spends a future SegWit version.");
+  }
   const { pubkeys, privkeys } = eligibleInputKeys(vins);
   if (!pubkeys.length) return { outputs: [], inputPubKeys: [], inputPrivateKeySum: null, sharedSecrets: [] };
   if (privkeys.length !== pubkeys.length) throw new Error("Sending needs a private key for every eligible input.");
@@ -461,6 +465,9 @@ export function createSilentPaymentOutputs(vins, recipients, { hrp = "sp" } = {}
 }
 
 export function scanSilentPaymentOutputs({ scanPriv, spendPub, vins, outputs, labels = [] }) {
+  if (vins.some((vin) => isFutureSegwit(vinPrevoutScript(vin)))) {
+    return { outputs: [], inputPubKeySum: null, tweak: null, sharedSecret: null };
+  }
   const scanScalar = scanPriv instanceof Uint8Array ? scalarFromBytes(scanPriv) : scanPriv;
   const spendPoint = spendPub instanceof Uint8Array ? Point.fromBytes(spendPub) : spendPub;
   const { pubkeys } = eligibleInputKeys(vins);

--- a/test/bip352.test.mjs
+++ b/test/bip352.test.mjs
@@ -190,6 +190,34 @@ test("group sizes beyond K_max fail before any expansion", () => {
   assert.throws(() => createSilentPaymentOutputs(vin, [{ address, count: 0 }], { hrp: "sp" }), /positive integer/);
 });
 
+test("future SegWit inputs fail sending and make v0 receivers skip the transaction", () => {
+  const sending = structuredClone(vectors[0].sending[0].given);
+  const futureWitnessInput = {
+    txid: "22".repeat(32),
+    vout: 1,
+    scriptSig: "",
+    txinwitness: "",
+    prevout: { scriptPubKey: { hex: "5220" + "33".repeat(32) } },
+  };
+  sending.vin.push(futureWitnessInput);
+  assert.throws(
+    () => createSilentPaymentOutputs(sending.vin, sending.recipients, { hrp: "sp" }),
+    /future SegWit version/i,
+  );
+
+  const receiving = vectors[0].receiving[0].given;
+  const scan = hexToBytes(receiving.key_material.scan_priv_key);
+  const spend = hexToBytes(receiving.key_material.spend_priv_key);
+  const result = scanSilentPaymentOutputs({
+    scanPriv: scan,
+    spendPub: secp256k1.getPublicKey(spend, true),
+    vins: [...receiving.vin, futureWitnessInput],
+    outputs: vectors[0].sending[0].expected.outputs[0],
+    labels: receiving.labels || [],
+  });
+  assert.deepEqual(result, { outputs: [], inputPubKeySum: null, tweak: null, sharedSecret: null });
+});
+
 test("generateLabel is deterministic", () => {
   const scan = hexToBytes("0f694e068028a717f8af6b9411f9a133dd3565258714cc226594b34db90c1f2c");
   const a = generateLabel(scan, 0);


### PR DESCRIPTION
## Summary
- detect input prevouts using witness versions 2 through 16
- fail BIP352 v0 sender output derivation when one is present
- make the v0 receiver skip the entire transaction as required by BIP352

## Security impact
BIP352 requires this transaction-wide rule for version upgrade safety. Previously EntropyLab generated and locally detected an output for a transaction that a conforming v0 recipient must skip, so a funded output could remain undiscovered.

The regression appends a version-2 witness program to published vector 0 and checks both sender rejection and receiver skipping.

## Tests
- `node --test test/bip352.test.mjs`
- `npm run test:ci` (1,094 passed)