### PR TITLE
Preserve displayed address ranges in wallet.dat

### DIFF
--- a/src/js/wallet-export.js
+++ b/src/js/wallet-export.js
@@ -25,7 +25,8 @@ var hodlWalletExport = (() => {
 
   const RECORD_VERSION = 280300; // last client version seen by the reference files
   const RECORD_MINVERSION = 169900; // FEATURE_PRE_SPLIT_KEYPOOL; every Core with descriptor support accepts it
-  const RANGE_END = 1000; // importdescriptors default active range
+  const RANGE_END = 1000; // Core's default lookahead, retained beyond the displayed window
+  const MAX_ADDRESS_INDEX = 0x7fffffff;
 
   // Wallet flags (walletutil.h): DESCRIPTORS | BLANK, plus DISABLE_PRIVATE_KEYS for watch-only.
   const FLAG_DISABLE_PRIVATE_KEYS = 1n << 32n;
@@ -146,11 +147,23 @@ var hodlWalletExport = (() => {
       for (const branch of [0, 1]) {
         const descriptor = branch === 0 ? account.receiveDescriptor : account.changeDescriptor;
         const privateDescriptor = branch === 0 ? account.receiveDescriptorPriv : account.changeDescriptorPriv;
+        const branchRows = account.addressBranches?.find((entry) => entry.branch === branch)?.rows;
+        const rows = Array.isArray(branchRows) ? branchRows : branch === 0 ? account.receive : account.change;
+        const indexes = Array.isArray(rows)
+          ? rows.map((row) => row?.index).filter((index) => Number.isSafeInteger(index) && index >= 0 && index <= MAX_ADDRESS_INDEX)
+          : [];
+        const rangeStart = indexes.length ? Math.min(...indexes) : 0;
+        const displayedEnd = indexes.length ? Math.max(...indexes) : 0;
+        const rangeEnd = indexes.length ? Math.min(MAX_ADDRESS_INDEX, displayedEnd + RANGE_END) : RANGE_END;
+        const nextIndex = indexes.length ? Math.min(MAX_ADDRESS_INDEX, displayedEnd + 1) : 0;
         units.push({
           type,
           internal: branch === 1,
           descriptor,
           privateDescriptor: includePrivate ? privateDescriptor : null,
+          nextIndex,
+          rangeStart,
+          rangeEnd,
         });
       }
     }
@@ -193,7 +206,7 @@ var hodlWalletExport = (() => {
 
       push(
         concat(streamString("walletdescriptor"), id),
-        concat(streamString(stored), u64le(creationTime), u32le(0), u32le(0), u32le(RANGE_END)),
+        concat(streamString(stored), u64le(creationTime), u32le(unit.nextIndex), u32le(unit.rangeStart), u32le(unit.rangeEnd)),
       );
 
       const xpub = extractExtendedKey(stored, "watch-only");

--- a/test/wallet-export.test.mjs
+++ b/test/wallet-export.test.mjs
@@ -358,6 +358,42 @@ test("network selects the application id and best-block locator", () => {
   assert.throws(() => buildWalletRecords({ ...WATCH_ONLY_WALLET, network: "signet" }, false, deps, REF_CREATION_TIME), /unknown network/);
 });
 
+test("descriptor ranges cover displayed addresses plus a recovery gap", () => {
+  const { buildWalletRecords, walletDescriptorUnits } = loadModule();
+  const wallet = structuredClone(WATCH_ONLY_WALLET);
+  wallet.accounts[0].addressBranches = [
+    { branch: 0, rows: [{ index: 5000 }, { index: 5001 }, { index: 5002 }] },
+    { branch: 1, rows: [{ index: 7000 }] },
+  ];
+
+  const units = walletDescriptorUnits(wallet, false);
+  assert.deepEqual(
+    units.slice(0, 2).map(({ nextIndex, rangeStart, rangeEnd }) => ({ nextIndex, rangeStart, rangeEnd })),
+    [
+      { nextIndex: 5003, rangeStart: 5000, rangeEnd: 6002 },
+      { nextIndex: 7001, rangeStart: 7000, rangeEnd: 8000 },
+    ],
+  );
+
+  const records = buildWalletRecords(wallet, false, deps, REF_CREATION_TIME);
+  const descriptorValues = records
+    .filter(([key]) => key[0] === 16 && new TextDecoder().decode(key.slice(1, 17)) === "walletdescriptor")
+    .map(([, value]) => Buffer.from(value));
+  const readRange = (value) => {
+    const first = value[0];
+    const lengthBytes = first < 253 ? 1 : first === 253 ? 3 : first === 254 ? 5 : 9;
+    const descriptorLength = first < 253 ? first : first === 253 ? value.readUInt16LE(1) : first === 254 ? value.readUInt32LE(1) : Number(value.readBigUInt64LE(1));
+    const offset = lengthBytes + descriptorLength + 8;
+    return {
+      nextIndex: value.readUInt32LE(offset),
+      rangeStart: value.readUInt32LE(offset + 4),
+      rangeEnd: value.readUInt32LE(offset + 8),
+    };
+  };
+  assert.deepEqual(readRange(descriptorValues[0]), { nextIndex: 5003, rangeStart: 5000, rangeEnd: 6002 });
+  assert.deepEqual(readRange(descriptorValues[1]), { nextIndex: 7001, rangeStart: 7000, rangeEnd: 8000 });
+});
+
 test("button gating: only HD wallets with descriptors", () => {
   const { hasDescriptors } = loadModule();
   assert.equal(hasDescriptors(null), false);


### PR DESCRIPTION
## Summary
- derive each exported descriptor range from the displayed receive/change rows
- advance `next_index` past displayed addresses to avoid reuse
- retain a 1,000-index recovery lookahead after the displayed window
- cap records at the maximum non-hardened BIP32 child index

## Security impact
The UI allows address windows above index 1,000, but wallet.dat previously hard-coded every descriptor to range 0 through 1,000. Bitcoin Core rescans could therefore omit a funded address that EntropyLab had displayed, making the recovery wallet appear empty or incomplete.

The regression checks both computed units and the serialized Bitcoin Core descriptor records for nonzero receive and change windows.

## Tests
- `node --test test/wallet-export.test.mjs`
- `npm run test:ci` (1,094 passed)