### PR TITLE
Validate BIP352 input private keys

### DIFF
--- a/src/js/bip352.js
+++ b/src/js/bip352.js
@@ -364,14 +364,20 @@ const normalizeVin = (vin) => ({
 export function eligibleInputKeys(vins) {
   const pubkeys = [];
   const privkeys = [];
-  for (const raw of vins) {
+  for (const [index, raw] of vins.entries()) {
     const vin = normalizeVin(raw);
     const extracted = extractInputPubKey(vin);
     if (!extracted) continue;
     pubkeys.push(extracted);
     if (vin.private_key) {
+      const scalar = scalarFromBytes(typeof vin.private_key === "string" ? hexToBytes(vin.private_key) : vin.private_key);
+      const suppliedPoint = Point.fromBytes(secp256k1.getPublicKey(bigToBytes32(scalar), true));
+      const matches = extracted.isTaproot
+        ? equalBytes(pointToXOnly(suppliedPoint), pointToXOnly(extracted.point))
+        : equalBytes(pointToCompressed(suppliedPoint), pointToCompressed(extracted.point));
+      if (!matches) throw new Error(`Input ${index} private key does not match its eligible input public key.`);
       privkeys.push({
-        scalar: scalarFromBytes(typeof vin.private_key === "string" ? hexToBytes(vin.private_key) : vin.private_key),
+        scalar,
         isTaproot: extracted.isTaproot,
       });
     }

--- a/test/bip352.test.mjs
+++ b/test/bip352.test.mjs
@@ -190,6 +190,15 @@ test("group sizes beyond K_max fail before any expansion", () => {
   assert.throws(() => createSilentPaymentOutputs(vin, [{ address, count: 0 }], { hrp: "sp" }), /positive integer/);
 });
 
+test("sender rejects a private key that does not match its eligible input", () => {
+  const given = structuredClone(vectors[0].sending[0].given);
+  given.vin[0].private_key = "00".repeat(31) + "01";
+  assert.throws(
+    () => createSilentPaymentOutputs(given.vin, given.recipients, { hrp: "sp" }),
+    /input 0 private key does not match/i,
+  );
+});
+
 test("generateLabel is deterministic", () => {
   const scan = hexToBytes("0f694e068028a717f8af6b9411f9a133dd3565258714cc226594b34db90c1f2c");
   const a = generateLabel(scan, 0);


### PR DESCRIPTION
## Summary
- derive a public point from every supplied BIP352 input private key
- require it to match the public key extracted from that input
- compare Taproot inputs by x-only key so parity-equivalent scalars remain valid

## Security impact
Before this change, a valid but unrelated private scalar produced a plausible Silent Payment output. The receiver derives from the transaction input public keys and could not detect that output, creating a funds-loss path if it was funded.

Replacing the first private key in published vector 0 with scalar 1 changed the output from `3e9fce73...` to `41ba134c...`; the recipient found zero matching outputs.

## Tests
- `node --test test/bip352.test.mjs`
- `npm run test:ci` (1,094 passed)