### PR TITLE
Reject hardened public descriptor paths before WASM

### DIFF
--- a/src/js/addresses.js
+++ b/src/js/addresses.js
@@ -136,8 +136,25 @@ export const addressFromScript = (script, network) => {
 // refused: one call derives one output — pass a single branch. A present
 // #checksum is verified by the crate. Throws on any parse or derivation
 // failure, exactly like the script builders above return null/throw.
+//
+// rust-miniscript 13.x escalates public keys that keep hardened derivation
+// steps (xpub…/0', xpub…/*h, or a bare hex key with a hardened step) to a
+// panic, which with panic=abort is an unrecoverable WASM trap rather than
+// the documented -1. Bitcoin Core rejects the same descriptors (hardened
+// steps need private key material), so refuse them here, where an error can
+// still be thrown. Extended private keys are exempt: the crate derives their
+// hardened steps privately first.
+const DESCRIPTOR_PUBLIC_KEY = /(?:xpub|tpub|ypub|upub|zpub|vpub|Ypub|Zpub|Upub|Vpub)[1-9A-HJ-NP-Za-km-z]{90,}|(?:02|03)[0-9a-fA-F]{64}|04[0-9a-fA-F]{128}|[0-9a-fA-F]{64}(?![0-9a-fA-F])/g;
+const hardenedPublicKeyStep = (text) => {
+  for (const match of text.matchAll(DESCRIPTOR_PUBLIC_KEY)) {
+    const tail = text.slice(match.index + match[0].length).match(/^[0-9/'hH*<>;]*/)[0];
+    if (/['hH]/.test(tail)) return true;
+  }
+  return false;
+};
 export const descriptorDerive = (descriptor, index, network) => {
   if (!Number.isSafeInteger(index) || index < 0 || index > 2147483647) throw new Error("Descriptor derivation index must be 0 to 2,147,483,647.");
+  if (hardenedPublicKeyStep(String(descriptor ?? ""))) throw new Error("Public descriptor keys cannot carry hardened derivation steps.");
   const bytes = textEncoder.encode(String(descriptor ?? ""));
   const net = netOf(network);
   const record = withInput(bytes, (p) =>

--- a/test/addresses-wasm.test.mjs
+++ b/test/addresses-wasm.test.mjs
@@ -178,6 +178,31 @@ test("descriptorDerive verifies a supplied #checksum and refuses multipath", () 
   assert.throws(() => descriptorDerive(body, 0, "regtest"), /Unknown Bitcoin network/);
 });
 
+test("descriptorDerive refuses hardened steps on public keys instead of trapping", async () => {
+  // rust-miniscript escalates public keys with hardened steps to a panic,
+  // which with panic=abort is an unrecoverable WASM trap; the facade rejects
+  // them first, matching Bitcoin Core's acceptance rules.
+  const XPUB = "xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ";
+  for (const descriptor of [
+    `wpkh(${XPUB}/0')`,
+    `wpkh(${XPUB}/0h/*)`,
+    `wpkh(${XPUB}/*h)`,
+    `wpkh(${XPUB}/*')`,
+    `wsh(sortedmulti(2,${XPUB}/0'/*,${XPUB}/*))`,
+    `pk(${bytesToHex(G_COMPRESSED)}/0')`,
+    `tr(${bytesToHex(G_COMPRESSED.slice(1))}/0h)`,
+  ]) assert.throws(() => descriptorDerive(descriptor, 0, "mainnet"), /hardened/, descriptor);
+  // The same xpub without hardened steps derives normally, including one
+  // whose base58 body itself ends in <digit>h before the path separator.
+  const XPUB_TAIL_4H = "xpub6DGDSTSv42ve3BBRALC4UVi3LdaoQjA9R2yV9RSDojTRKQTK5Jk73WKqm6v392eeF3Lxawf8gHiBpD5xBDx7HYvbkLoZ6e1Emu9fvW2M24h";
+  assert.match(descriptorDerive(`wpkh(${XPUB}/0/*)`, 0, "mainnet").address, /^bc1q/);
+  assert.match(descriptorDerive(`wpkh(${XPUB_TAIL_4H}/0/*)`, 0, "mainnet").address, /^bc1q/);
+  // Private keys are exempt: their hardened steps are derived privately.
+  const { HDKey } = await import("../src/js/hdkey.js");
+  const root = HDKey.fromMasterSeed(new Uint8Array(32).fill(7));
+  assert.match(descriptorDerive(`wpkh(${root.privateExtendedKey}/0'/*)`, 0, "mainnet").address, /^bc1q/);
+});
+
 test("base58check and coders match @scure/base", async () => {
   const { createBase58check, hex: scureHex, base64: scureBase64 } = await import("@scure/base");
   const { sha256 } = await import("../src/js/hashes.js");


### PR DESCRIPTION
## Summary
- detect hardened derivation steps following extended, compressed, uncompressed, or x-only public keys
- reject them in the JS facade before calling rust-miniscript WASM
- keep valid unhardened public paths and hardened xprv paths working

## Security impact
`rust-miniscript` 13.x escalates descriptors such as `xpub.../0'` or `xpub.../*h` to a panic in `derived_descriptor`. The release WASM uses panic-abort, so hostile pasted descriptor text can produce an unrecoverable `RuntimeError: unreachable` instead of the documented parse failure.

Bitcoin Core also rejects hardened derivation after public keys because the required private material is unavailable.

The regression includes an xpub whose Base58 body ends in `<digit>h` to ensure key text is not mistaken for a hardened path marker.

## Tests
- `node --test test/addresses-wasm.test.mjs`
- `npm run test:ci` (1,094 passed)