### PR TITLE
Fix wallet.dat hardened branch caching and signing

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1441,6 +1441,9 @@ function hodlWalletDatDeps() {
       body.set(node.publicKey, 41);
       return body;
     },
+    // Hardened-branch private key records are derived from the account xprv.
+    deriveExtendedPrivateChild: (extendedKeyText, index) =>
+      hodlHDKey.fromExtendedKey(hodlReversionExtendedKey(extendedKeyText, hodlExtendedKeyVersions.mainnet.x.prv)).deriveChild(index).privateExtendedKey,
     publicKeyForPrivate: (secret) => hodlSecp256k1.getPublicKey(secret, true)
   };
 }

--- a/src/js/wallet-export.js
+++ b/src/js/wallet-export.js
@@ -14,7 +14,11 @@
 //   version / minversion / flags / bestblock / bestblock_nomerkle
 //   walletdescriptor      <id>  -> public descriptor string, creation time,
 //                                  next_index, range_start, range_end
-//   walletdescriptorcache <id> <pos 0> -> branch xpub (74 bytes, no version)
+//   walletdescriptorcache <id> <pos 0> -> parent xpub of the wildcard
+//                                  (74 bytes, no version): the branch child
+//                                  of the account key, or the descriptor
+//                                  root key itself for hardened-branch
+//                                  descriptors
 //   walletdescriptorkey   <id> <pubkey> -> DER private key + key hash (private only)
 //   activeexternalspk / activeinternalspk <type> -> descriptor id
 //
@@ -134,6 +138,20 @@ var hodlWalletExport = (() => {
     return match[1];
   };
 
+  // Path between a descriptor's extended key and its closing parens, reduced
+  // to the step above the wildcard: { branch, hardened } for "…/0/*" style
+  // tails, { branch: null } when the key is already at the branch level
+  // ("…/*", the hardened-branch watch-only layout, where the branch xpub is
+  // the descriptor root key).
+  const descriptorKeyTail = (descriptor, extendedKey) => {
+    const body = stripChecksum(descriptor);
+    const tail = body.slice(body.indexOf(extendedKey) + extendedKey.length).replace(/\)+$/, "");
+    if (tail === "/*") return { branch: null, hardened: false };
+    const branch = tail.match(/^\/(\d+)(['hH]?)\/\*$/);
+    if (!branch || Number(branch[1]) >= 0x80000000) throw new Error("wallet.dat export: unsupported descriptor path shape");
+    return { branch: Number(branch[1]), hardened: Boolean(branch[2]) };
+  };
+
   // One descriptor export unit per account branch: the watch-only descriptor
   // plus, when requested and available, its private key record material.
   const walletDescriptorUnits = (wallet, includePrivate) => {
@@ -170,6 +188,14 @@ var hodlWalletExport = (() => {
     const records = [];
     const push = (key, value) => records.push([key, value]);
 
+    // The 74-byte serialized node (no version bytes), as Core's descriptor
+    // cache stores it.
+    const extendedKeyBody = (extendedKey) => {
+      const raw = deps.base58Decode(extendedKey);
+      if (raw.length !== 78) throw new Error("wallet.dat export: unexpected extended key payload");
+      return raw.slice(4);
+    };
+
     push(streamString("version"), u32le(RECORD_VERSION));
     push(streamString("minversion"), u32le(RECORD_MINVERSION));
     // The wallet is only signing-capable if at least one descriptor got a
@@ -197,7 +223,15 @@ var hodlWalletExport = (() => {
       );
 
       const xpub = extractExtendedKey(stored, "watch-only");
-      const branchBody = deps.deriveBranchBody(xpub, unit.internal ? 1 : 0);
+      const tail = descriptorKeyTail(stored, xpub);
+      if (tail.hardened) throw new Error("wallet.dat export: hardened step after a public key");
+      // Core caches the parent key of the wildcard: the branch child for
+      // account-level descriptors ("…xpub/0/*"), or the descriptor root key
+      // itself when a hardened branch already moved the key to branch level
+      // ("…xpubBranch/*") — BIP32PubkeyProvider with an empty path caches
+      // its root key. Caching the wrong parent makes Core watch a different
+      // subtree than the descriptor's.
+      const branchBody = tail.branch === null ? extendedKeyBody(xpub) : deps.deriveBranchBody(xpub, tail.branch);
       if (branchBody.length !== 74) throw new Error("wallet.dat export: branch xpub body must be 74 bytes");
       push(
         concat(streamString("walletdescriptorcache"), id, u32le(0)),
@@ -205,7 +239,13 @@ var hodlWalletExport = (() => {
       );
 
       if (unit.privateDescriptor) {
-        const xprv = extractExtendedKey(unit.privateDescriptor, "spending");
+        let xprv = extractExtendedKey(unit.privateDescriptor, "spending");
+        // The key record must map the stored descriptor's root pubkey, or
+        // Core's GetExtKey finds no key for it and the wallet cannot sign.
+        // A hardened branch step means the stored root is the branch key, so
+        // derive the branch xprv; otherwise the account key signs as itself.
+        const privateTail = descriptorKeyTail(unit.privateDescriptor, xprv);
+        if (privateTail.hardened) xprv = deps.deriveExtendedPrivateChild(xprv, 0x80000000 + privateTail.branch);
         const raw = deps.base58Decode(xprv);
         if (raw.length !== 78 || raw[45] !== 0) throw new Error("wallet.dat export: unexpected extended private key payload");
         const secret = raw.slice(46, 78);

--- a/test/wallet-export.test.mjs
+++ b/test/wallet-export.test.mjs
@@ -180,7 +180,33 @@ const deriveBranchBody = (xpubText, branch) => {
 };
 const publicKeyForPrivate = (secret) => serPub(pointMul(BigInt("0x" + bytesToHex(secret))));
 
-const deps = { sha256, checksum: descriptorChecksum, base58Decode: b58checkDecode, deriveBranchBody, publicKeyForPrivate };
+// Reference private derivation (test-local), for hardened-branch fixtures.
+const hmac512 = (key, data) => new Uint8Array(createHmac("sha512", key).update(data).digest());
+const masterFromSeed = (seed) => {
+  const I = hmac512(new TextEncoder().encode("Bitcoin seed"), seed);
+  return { secret: new Uint8Array(I.subarray(0, 32)), chain: new Uint8Array(I.subarray(32)), depth: 0, fp: new Uint8Array(4), child: 0 };
+};
+const pubkeyOf = (node) => serPub(pointMul(BigInt("0x" + bytesToHex(node.secret))));
+const ckdPriv = (node, index) => {
+  const indexBytes = bigintBytes(BigInt(index >>> 0), 4);
+  const data = index >= 0x80000000
+    ? Uint8Array.from([0, ...node.secret, ...indexBytes])
+    : Uint8Array.from([...pubkeyOf(node), ...indexBytes]);
+  const I = hmac512(node.chain, data);
+  const secret = bigintBytes((BigInt("0x" + bytesToHex(node.secret)) + BigInt("0x" + bytesToHex(I.subarray(0, 32)))) % ORDER_N, 32);
+  return { secret, chain: new Uint8Array(I.subarray(32)), depth: node.depth + 1, fp: ripemd160(sha256(pubkeyOf(node))).subarray(0, 4), child: index >>> 0 };
+};
+const serializeNode = (node, version, isPrivate) => b58checkEncode(Uint8Array.from([
+  ...bigintBytes(BigInt(version), 4), node.depth, ...node.fp, ...bigintBytes(BigInt(node.child), 4), ...node.chain,
+  ...(isPrivate ? [0, ...node.secret] : pubkeyOf(node)),
+]));
+const deriveExtendedPrivateChild = (xprvText, index) => {
+  const raw = b58checkDecode(xprvText);
+  const child = ckdPriv({ secret: raw.slice(46, 78), chain: raw.slice(13, 45), depth: raw[4], fp: raw.slice(5, 9), child: 0 }, index);
+  return serializeNode(child, Buffer.from(raw.slice(0, 4)).readUInt32BE(0), true);
+};
+
+const deps = { sha256, checksum: descriptorChecksum, base58Decode: b58checkDecode, deriveBranchBody, deriveExtendedPrivateChild, publicKeyForPrivate };
 
 // --- reference wallets ------------------------------------------------------
 
@@ -324,6 +350,66 @@ test("accounts without private material stay watch-only in a private export", ()
   const fallback = moduleRecords(WATCH_ONLY_WALLET, true);
   assert.deepEqual([...fallback.keys()].sort(), [...watchOnly.keys()].sort());
   for (const key of watchOnly.keys()) assert.equal(fallback.get(key), watchOnly.get(key));
+});
+
+// Regression for the Harden branch option: the watch-only descriptor is
+// "wpkh([fp/84h/0h/0h/0h]xpubBranch/*)" — the branch xpub IS the descriptor
+// root key. Core caches the root key itself when the path after it is empty
+// (BIP32PubkeyProvider) and looks the root pubkey up in walletdescriptorkey.
+// Deriving branch 0/1 of that key for the cache made Core watch a different
+// subtree, and recording the account key left the spending variant unable to
+// sign (root pubkey lookup misses in m_map_keys).
+test("hardened-branch descriptors cache and sign with the descriptor root key", () => {
+  const seed = new Uint8Array(32);
+  seed[31] = 1;
+  const master = masterFromSeed(seed);
+  const fp = bytesToHex(ripemd160(sha256(pubkeyOf(master))).subarray(0, 4));
+  let account = master;
+  for (const step of [84, 0, 0]) account = ckdPriv(account, (step | 0x80000000) >>> 0);
+  const accountXprv = serializeNode(account, 0x0488ade4, true);
+  const branch = (b) => ckdPriv(account, (b | 0x80000000) >>> 0);
+  const branchXpub = (b) => serializeNode(branch(b), 0x0488b21e, false);
+  const descriptorFor = (b) => {
+    const body = `wpkh([${fp}/84h/0h/0h/${b}h]${branchXpub(b)}/*)`;
+    return `${body}#${descriptorChecksum(body)}`;
+  };
+  const privateDescriptorFor = (b) => {
+    const body = `wpkh([${fp}/84h/0h/0h]${accountXprv}/${b}'/*)`;
+    return `${body}#${descriptorChecksum(body)}`;
+  };
+  const wallet = {
+    kind: "hd",
+    network: "mainnet",
+    accounts: [{
+      def: { id: "bip84" },
+      receiveDescriptor: descriptorFor(0),
+      changeDescriptor: descriptorFor(1),
+      receiveDescriptorPriv: privateDescriptorFor(0),
+      changeDescriptorPriv: privateDescriptorFor(1),
+    }],
+  };
+
+  // Watch-only: the cache parent is the branch xpub itself (raw 74-byte body).
+  const watch = moduleRecords(wallet, false);
+  const cachePrefix = "15" + "77616c6c657464657363726970746f726361636865"; // \x15walletdescriptorcache
+  const caches = [...watch.entries()].filter(([key]) => key.startsWith(cachePrefix)).map(([, value]) => value);
+  assert.equal(caches.length, 2);
+  for (const b of [0, 1]) {
+    const expected = "4a" + bytesToHex(b58checkDecode(branchXpub(b)).slice(4));
+    assert.ok(caches.includes(expected), `cache parent for branch ${b} is the descriptor root key itself`);
+  }
+
+  // Spending: each key record maps the branch pubkey to the branch secret.
+  const spending = moduleRecords(wallet, true);
+  const keyRecords = [...spending.entries()].filter(([key]) => key.includes("77616c6c657464657363726970746f726b6579"));
+  assert.equal(keyRecords.length, 2);
+  for (const b of [0, 1]) {
+    const pubkey = bytesToHex(pubkeyOf(branch(b)));
+    const record = keyRecords.find(([key]) => key.endsWith("21" + pubkey));
+    assert.ok(record, `key record for branch ${b} names the branch pubkey`);
+    const secret = bytesToHex(branch(b).secret);
+    assert.ok(record[1].startsWith("d6") && record[1].includes(secret), `key record for branch ${b} carries the branch secret`);
+  }
 });
 
 test("generated watch-only wallet.dat verifies with real SQLite", { skip: !PYTHON_SQLITE }, () => {


### PR DESCRIPTION
## Summary
- parse the path between each descriptor extended key and wildcard
- cache the descriptor root key itself when a hardened branch already moved the xpub to branch level
- derive and store the matching branch xprv for private wallet exports
- add independent hardened BIP32 reference tests for watch-only and signing records

## Security and recovery impact
With the Harden branch option, the watch-only descriptor root is already the branch xpub. The exporter instead cached child 0 or 1 beneath that key, so Bitcoin Core watched `xpubBranch/0/i` instead of `xpubBranch/i`, disagreeing with EntropyLab addresses and potentially missing funds.

Private exports recorded the account key while Core looked up the branch root pubkey, so the generated wallet could not sign.

## Tests
- `node --test test/wallet-export.test.mjs`
- `npm run test:ci` (1,094 passed)