### PR TITLE
inscription scan: parse full witness CompactSize, report coverage gaps

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -9343,6 +9343,9 @@ function hodlRenderPsbt(psbt) {
   let inscriptionReport = { inputs: [], envelopes: [] }, inscriptionScanIncomplete = false;
   try {
     inscriptionReport = inspectPsbtInscriptions(psbt);
+    // Malformed witnesses and truncated scripts are coverage gaps: the
+    // summary must not claim a completed inscription scan over them.
+    if (inscriptionReport.incomplete) inscriptionScanIncomplete = true;
   } catch {
     inscriptionReport = { inputs: [], envelopes: [] };
     inscriptionScanIncomplete = true;

--- a/src/js/inscription.js
+++ b/src/js/inscription.js
@@ -220,7 +220,13 @@ export function parseEnvelopes(script) {
   return { envelopes, error: error || null };
 }
 
-export function parseWitness(bytes) {
+// Witness stacks use full Bitcoin CompactSize item lengths: an inscription
+// carrying media puts its tap-leaf script in a single item, so lengths above
+// 64 KiB (0xfe/0xff encodings) are normal, not errors. The strict variant
+// throws on malformed data; the exported parseWitness stays tolerant and
+// returns an empty stack, while callers that report scan coverage use the
+// strict one so a skipped witness can never look like a completed scan.
+function parseWitnessStrict(bytes) {
   if (!(bytes instanceof Uint8Array) || !bytes.length) return [];
   let offset = 0;
   const readVarInt = () => {
@@ -236,18 +242,34 @@ export function parseWitness(bytes) {
       offset += 3;
       return value;
     }
-    throw new Error("witness compact size is too large");
-  };
-  try {
-    const count = readVarInt();
-    const stack = [];
-    for (let i = 0; i < count; i++) {
-      const length = readVarInt();
-      if (offset + length > bytes.length) throw new Error("witness item overruns buffer");
-      stack.push(bytes.slice(offset, offset + length));
-      offset += length;
+    if (first === 0xfe) {
+      if (offset + 5 > bytes.length) throw new Error("witness ended inside compact size");
+      const value = (bytes[offset + 1] | (bytes[offset + 2] << 8) | (bytes[offset + 3] << 16) | (bytes[offset + 4] << 24)) >>> 0;
+      if (value <= 0xffff) throw new Error("non-canonical witness compact size");
+      offset += 5;
+      return value;
     }
-    return stack;
+    if (offset + 9 > bytes.length) throw new Error("witness ended inside compact size");
+    let value = 0n;
+    for (let i = 1; i <= 8; i++) value |= BigInt(bytes[offset + i]) << BigInt(8 * (i - 1));
+    if (value <= 0xffffffffn || value > BigInt(Number.MAX_SAFE_INTEGER)) throw new Error("non-canonical witness compact size");
+    offset += 9;
+    return Number(value);
+  };
+  const count = readVarInt();
+  const stack = [];
+  for (let i = 0; i < count; i++) {
+    const length = readVarInt();
+    if (offset + length > bytes.length) throw new Error("witness item overruns buffer");
+    stack.push(bytes.slice(offset, offset + length));
+    offset += length;
+  }
+  return stack;
+}
+
+export function parseWitness(bytes) {
+  try {
+    return parseWitnessStrict(bytes);
   } catch {
     return [];
   }
@@ -261,14 +283,21 @@ function taprootWitnessScriptCandidates(stack) {
   return items;
 }
 
-export function scriptsFromPsbtInput(entries) {
+export function scriptsFromPsbtInput(entries, errors) {
   const scripts = [];
   if (!Array.isArray(entries)) return scripts;
   for (const entry of entries) {
     if (entry.type === 21 && entry.val && entry.val.length >= 2) {
       scripts.push({ source: "tap-leaf", script: entry.val.slice(0, entry.val.length - 1) });
     } else if (entry.type === 8 && entry.val) {
-      const stack = parseWitness(entry.val);
+      let stack;
+      try {
+        stack = parseWitnessStrict(entry.val);
+      } catch (exception) {
+        // A malformed witness is a coverage gap, not an empty result.
+        errors?.push(exception.message || String(exception));
+        continue;
+      }
       for (const script of taprootWitnessScriptCandidates(stack)) scripts.push({ source: "final-witness", script });
     } else if (entry.type === 5 && entry.val) {
       scripts.push({ source: "witness-script", script: entry.val });
@@ -281,14 +310,18 @@ export function scriptsFromPsbtInput(entries) {
 
 export function inspectPsbtInscriptions(psbt) {
   const inputs = [];
+  const errors = [];
   let envelopeIndex = 0;
   const list = psbt?.inputs || [];
   for (let input = 0; input < list.length; input++) {
     const found = [];
     const seen = new Set();
     try {
-      for (const item of scriptsFromPsbtInput(list[input])) {
-        const { envelopes } = parseEnvelopes(item.script);
+      for (const item of scriptsFromPsbtInput(list[input], errors)) {
+        const { envelopes, error } = parseEnvelopes(item.script);
+        // A tokenizer fault truncates this script's scan; report the
+        // coverage gap instead of claiming a completed scan.
+        if (error) errors.push(error);
         for (const envelope of envelopes) {
           const key = `${envelope.contentType}|${envelope.bodyBytes}|${bytesToHex(envelope.body.slice(0, 32))}`;
           if (seen.has(key)) continue;
@@ -301,14 +334,17 @@ export function inspectPsbtInscriptions(psbt) {
           });
         }
       }
-    } catch {
+    } catch (exception) {
       // A malformed witness must not wipe the rest of the PSBT report.
+      errors.push(exception?.message || String(exception));
     }
     inputs.push({ input, envelopes: found });
   }
   return {
     inputs,
     envelopes: inputs.flatMap((row) => row.envelopes),
+    incomplete: errors.length > 0,
+    errors,
   };
 }
 

--- a/test/inscription.test.mjs
+++ b/test/inscription.test.mjs
@@ -153,6 +153,48 @@ test("final scriptwitness yields the tapscript", () => {
   assert.ok(found.some((row) => parseEnvelopes(row.script).envelopes.length === 1));
 });
 
+test("witness items above 64 KiB use full CompactSize and are still scanned", () => {
+  // A media inscription puts its tap-leaf script in a single witness item,
+  // so >64 KiB items (0xfe/0xff length prefixes) are normal, not errors.
+  const script = envelope({ body: "x".repeat(70000) });
+  assert.ok(script.length > 0xffff);
+  const control = new Uint8Array(33).fill(0xc0);
+  const item32 = (bytes) => concatBytes(
+    Uint8Array.of(0xfe, bytes.length & 0xff, (bytes.length >> 8) & 0xff, (bytes.length >> 16) & 0xff, (bytes.length >> 24) & 0xff),
+    bytes,
+  );
+  const small = (bytes) => concatBytes(Uint8Array.of(bytes.length), bytes);
+  const witness = concatBytes(Uint8Array.of(3), small(new Uint8Array(64)), item32(script), small(control));
+  const stack = parseWitness(witness);
+  assert.equal(stack.length, 3);
+  assert.equal(stack[1].length, script.length);
+  const report = inspectPsbtInscriptions({ inputs: [[{ type: 8, val: witness, keydata: new Uint8Array() }]] });
+  assert.equal(report.envelopes.length, 1);
+  assert.equal(report.envelopes[0].bodyBytes, 70000);
+  assert.equal(report.incomplete, false);
+});
+
+test("a malformed finalized witness flags the scan incomplete instead of claiming coverage", () => {
+  const truncated = Uint8Array.of(0xff); // 0xff length prefix without its 8 bytes
+  assert.deepEqual(parseWitness(truncated), []); // tolerant API unchanged
+  const report = inspectPsbtInscriptions({ inputs: [[{ type: 8, val: truncated, keydata: new Uint8Array() }]] });
+  assert.equal(report.envelopes.length, 0);
+  assert.equal(report.incomplete, true);
+  assert.ok(report.errors.length > 0);
+});
+
+test("a truncated script push flags the scan incomplete", () => {
+  // 0x03 announces a 3-byte push but only one byte follows before the leaf version.
+  const leaf = concatBytes(Uint8Array.of(0x00, 0x63, 0x03, 0x6f), Uint8Array.of(0xc0));
+  const report = inspectPsbtInscriptions({ inputs: [[{ type: 21, val: leaf, keydata: new Uint8Array(33) }]] });
+  assert.equal(report.envelopes.length, 0);
+  assert.equal(report.incomplete, true);
+});
+
+test("the PSBT inspector escalates inscription coverage gaps to the summary", () => {
+  assert.match(app, /inscriptionReport\.incomplete\) inscriptionScanIncomplete = true/);
+});
+
 test("inspectPsbtInscriptions numbers envelopes across inputs and survives junk", () => {
   const script = envelope({ body: "a" });
   const leaf = concatBytes(script, Uint8Array.of(0xc0));


### PR DESCRIPTION
## Summary

The inscription scan could silently miss envelopes while the summary read **"Taproot inscription scan — complete"**:

**1. `parseWitness` rejected 0xfe/0xff CompactSize prefixes ("too large") and swallowed the error into an empty stack.**
BIP144/BIP174 witness item lengths are full CompactSize. A real inscription puts its tap-leaf script — which exceeds 65,535 bytes for image/media bodies — in a **single witness item**, so its length prefix is 0xfe. The entire witness parse then failed, `scriptsFromPsbtInput` yielded nothing, and because no exception escaped, `inscriptionScanIncomplete` stayed false → the summary claimed a completed scan over a witness it never looked at. (Notably, app.js's own `hodlWitnessStackItems` parses 0xfe/0xff fine — the two in-app witness parsers diverged, and the weaker one guarded the security-relevant disclosure scan.)

**2. `tokenizeScript` truncation errors were dropped.**
`parseEnvelopes` returns `{ envelopes, error }`, but `inspectPsbtInscriptions` destructured only `envelopes` — envelopes after a truncated push were missed with no signal.

## Impact

A counterparty hiding a >64 KB envelope in a finalized taproot input defeats the disclosure the tool exists to give. Media inscriptions over 64 KB are routine (the limit is ~400 KB).

## Proposed fix

- Add a strict `parseWitnessStrict` that parses the full CompactSize range (with canonical floors + bounds checks) and throws on malformed data; the exported `parseWitness` keeps its tolerant `[]`-on-error API for existing callers.
- `scriptsFromPsbtInput` takes an optional `errors` sink and records malformed witnesses as coverage gaps.
- `inspectPsbtInscriptions` returns `{ inputs, envelopes, incomplete, errors }` and propagates tokenizer errors into `incomplete`.
- `app.js` escalates `inscriptionReport.incomplete` to the analysis summary.

```diff
+function parseWitnessStrict(bytes) {
+  …
+    if (first === 0xfe) {
+      …const value = (bytes[offset+1] | bytes[offset+2]<<8 | bytes[offset+3]<<16 | bytes[offset+4]<<24) >>> 0;
+      if (value <= 0xffff) throw new Error("non-canonical witness compact size");
+      offset += 5; return value;
+    }
+    // 0xff: 8-byte LE, canonical + safe-integer bounded
   …
+}
+export function parseWitness(bytes) {
+  try { return parseWitnessStrict(bytes); } catch { return []; }
+}
```

```diff
-        const { envelopes } = parseEnvelopes(item.script);
+        const { envelopes, error } = parseEnvelopes(item.script);
+        if (error) errors.push(error);
```

(Full diff on the branch.)

## Tests

`test/inscription.test.mjs` gains 4 tests: a 70,000-byte envelope in a single witness item is found (fails on the old code), a truncated `0xff` witness and a truncated script push both report `incomplete: true`, and a structural assertion that the inspector escalates the flag. All 20 inscription tests pass; full Docker suite green.

## Caveat (as requested)

Audit-produced; unit-tested against synthetic >64 KB witness items, but **not exercised against a real on-chain large inscription transaction**. Recommend validating against a known >64 KB mainnet inscription before merge.

Commands run: `npm ci && npm run build && npm test` (in `docker compose run --rm dev`).
