### PR TITLE
brain wallet: trim toggle invalidates the displayed result and re-syncs

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -5735,11 +5735,13 @@ function hodlBindKeyFields() {
     document.getElementById("network")?.addEventListener("change", apply);
     let trim = document.getElementById("brain-wallet-trim");
     if (trim) trim.onchange = () => {
+      // Trimming changes the hashed bytes, so it changes the wallet: retract
+      // the displayed result and re-sync the mirrored representations, like
+      // every other entropy-affecting control.
       if (state) state.brainWalletTrim = trim.checked;
-      hodlSyncBrainOutput();
-      hodlRenderPrivateKeyInputState(key);
-      hodlSyncKeyClearButton();
-      hodlSyncDeriveButton();
+      hodlInvalidateLiveKeyResult();
+      hodlGlobalSyncFromCurrentInput();
+      refreshBrain();
     };
     apply();
   }

--- a/test/brain-wallet.test.mjs
+++ b/test/brain-wallet.test.mjs
@@ -66,6 +66,14 @@ test("exact mode accepts whitespace while trim mode rejects an empty result", ()
   assert.throws(() => helpers.hodlBrainWalletPassphrase(""), /Enter the brain-wallet recovery passphrase/);
 });
 
+test("the trim toggle invalidates the displayed result and re-syncs mirrors", () => {
+  // Trimming changes the hashed bytes — a different wallet — so the handler
+  // must retract the live result and re-run the cross-method sync, like the
+  // sibling brain-wallet controls.
+  const handler = app.match(/getElementById\("brain-wallet-trim"\)[\s\S]{0,600}?hodlInvalidateLiveKeyResult\(\)[\s\S]{0,200}?hodlGlobalSyncFromCurrentInput\(\)/);
+  assert.ok(handler, "trim onchange invalidates and re-syncs");
+});
+
 const lab = new Function(
   "hodlSha256",
   "hodlHex",


### PR DESCRIPTION
## Summary

The **brain-wallet trim toggle** changes the exact bytes that are hashed — i.e. it changes the wallet — but its `onchange` handler only refreshed a few controls. Derive with trim off, toggle trim on: the old wallet stayed displayed and the cross-method mirrors kept mirroring the *untrimmed* hash until the next keystroke. Every sibling entropy-affecting control (output radios, ack checkbox) calls `hodlInvalidateLiveKeyResult()`; the trim toggle did not.

The trim option exists precisely for recovery scenarios, so showing a stale wallet there is a real footgun.

## Proposed fix

Mirror the sibling controls:

```diff
     if (trim) trim.onchange = () => {
       if (state) state.brainWalletTrim = trim.checked;
-      hodlSyncBrainOutput();
-      hodlRenderPrivateKeyInputState(key);
-      hodlSyncKeyClearButton();
-      hodlSyncDeriveButton();
+      hodlInvalidateLiveKeyResult();
+      hodlGlobalSyncFromCurrentInput();
+      refreshBrain();
     };
```

`refreshBrain()` (already used by the sibling handlers) is the superset of the four previous calls.

## Tests

`test/brain-wallet.test.mjs` gains a structural assertion that the handler invalidates and re-syncs (fails on the old handler).

## Caveat (as requested)

Audit-produced; the UI handler is structurally asserted but not driven end-to-end in a browser for this specific toggle. Full Docker suite green.

Commands run: `npm ci && npm run build && npm test` (in `docker compose run --rm dev`).
