### PR TITLE
global sync: an over-long hex key goes invalid instead of truncating

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -4598,8 +4598,13 @@ function hodlGlobalSyncCurrentBits(targetWords = hodlTargetWordCount) {
     }
     let kind = hodlNormalizePrivateKeyKind(document.querySelector('input[name="kk"]:checked')?.value || "wif", value);
     if (kind === "hex-key") {
+      // An over-long key is invalid, not truncated: publishing its first 64
+      // characters would mirror a key the source field itself rejects, while
+      // every other source publishes nothing when invalid.
+      let digits = value.replace(/\s/g, "").replace(/^0x/i, "");
+      if (digits.length > 64) return null;
       let bits = "";
-      for (let digit of value.replace(/\s/g, "").replace(/^0x/i, "").slice(0, 64)) {
+      for (let digit of digits) {
         if (!/^[0-9a-fA-F]$/.test(digit)) break;
         bits += Number.parseInt(digit, 16).toString(2).padStart(4, "0");
       }

--- a/test/global-sync.test.mjs
+++ b/test/global-sync.test.mjs
@@ -117,6 +117,15 @@ test("a brain wallet reports unknown strength instead of a green tick", () => {
   assert.match(markup, /entropy unknown/);
 });
 
+test("an over-long hex key goes invalid in sync instead of being truncated", () => {
+  // Publishing the first 64 characters of a 65+-character key would mirror a
+  // key the private-key field itself rejects; every other source publishes
+  // null when its input is invalid.
+  const source = loadSlice("hodlGlobalSyncCurrentBits");
+  assert.match(source, /if \(digits\.length > 64\) return null;/);
+  assert.doesNotMatch(source, /\.slice\(0, 64\)/);
+});
+
 test("a minikey reports its payload keyspace, not its 256-bit digest", () => {
   // A minikey is SHA-256(text) exactly like a brain wallet, format-constrained
   // to S plus 21 or 29 base58 characters, so the accepted 22-character form


### PR DESCRIPTION
## Summary

In the global entropy-sync extractor, the hex private-key source did:

```js
for (let digit of value.replace(/\s/g, "").replace(/^0x/i, "").slice(0, 64)) { … }
```

A 65+-character (invalid) hex key still published its first 64 characters to all mirrored methods, while the key field itself fails derivation (`hodlAssertPrivateKeyKind` requires exactly 64). Every other sync source publishes nothing (`null`) when its input is invalid; the hex source was the only one that truncated instead of going invalid, so the mirrors could show a key the source field rejects.

## Proposed fix

```diff
     if (kind === "hex-key") {
-      let bits = "";
-      for (let digit of value.replace(/\s/g, "").replace(/^0x/i, "").slice(0, 64)) {
+      let digits = value.replace(/\s/g, "").replace(/^0x/i, "");
+      if (digits.length > 64) return null;
+      let bits = "";
+      for (let digit of digits) {
```

## Tests

`test/global-sync.test.mjs` gains a structural assertion (fails on the old `slice(0, 64)` code).

## Caveat (as requested)

Audit-produced; the sync path is structurally asserted but not driven end-to-end through the DOM for this input. Full Docker suite green.

Commands run: `npm ci && npm run build && npm test` (in `docker compose run --rm dev`).
