### PR TITLE
PSBT: an impossible (negative) claimed fee escalates the summary

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -9339,7 +9339,8 @@ function hodlRenderPsbt(psbt) {
     uninspected = 0,
     policyProblems = 0,
     policyIncomplete = 0,
-    unsupportedNonceChecks = 0;
+    unsupportedNonceChecks = 0,
+    feeInconsistent = 0;
   let inscriptionReport = { inputs: [], envelopes: [] }, inscriptionScanIncomplete = false;
   try {
     inscriptionReport = inspectPsbtInscriptions(psbt);
@@ -9492,7 +9493,10 @@ function hodlRenderPsbt(psbt) {
   if (knownInputs === tx.inputs.length) {
     let outputSum = tx.outputs.reduce((sum, output) => sum + output.amount, 0n), fee = inputSum - outputSum;
     if (fee >= 0n) html.push("<p class='psbt-kv'><strong>Unverified fee (PSBT witness UTXO claims)</strong> \xB7 " + hodlSats(fee) + " BTC</p>");
-    else html.push("<p class='psbt-bad'><strong>Inconsistent claimed amounts:</strong> outputs exceed claimed inputs by " + hodlSats(-fee) + " BTC.</p>");
+    else {
+      feeInconsistent = 1;
+      html.push("<p class='psbt-bad'><strong>Inconsistent claimed amounts:</strong> outputs exceed claimed inputs by " + hodlSats(-fee) + " BTC.</p>");
+    }
   } else html.push("<p class='muted'>Fee unknown — some inputs do not include a claimed witness UTXO amount.</p>");
   html.push("<p class='muted'>Input amounts and any fee are unverified PSBT claims. This tool does not check them against previous transactions or the blockchain.</p>");
   if (inscriptionReport.envelopes.length) {
@@ -9518,10 +9522,12 @@ function hodlRenderPsbt(psbt) {
   let checks = [
     {
       label: "Previous outputs and fee",
-      state: "incomplete",
-      detail: knownInputs === tx.inputs.length
-        ? "Amounts and fee were calculated from PSBT-provided witness UTXO claims, but those claims were not checked against previous transactions or the blockchain."
-        : "One or more inputs have no witness UTXO amount, and available PSBT claims were not checked against previous transactions or the blockchain.",
+      state: feeInconsistent ? "problem" : "incomplete",
+      detail: feeInconsistent
+        ? "The claimed output amounts exceed the claimed input amounts, so the PSBT's own claims are inconsistent; claims were not checked against previous transactions or the blockchain."
+        : knownInputs === tx.inputs.length
+          ? "Amounts and fee were calculated from PSBT-provided witness UTXO claims, but those claims were not checked against previous transactions or the blockchain."
+          : "One or more inputs have no witness UTXO amount, and available PSBT claims were not checked against previous transactions or the blockchain.",
     },
     {
       label: "SIGHASH policy",

--- a/test/psbt-analysis-status.test.mjs
+++ b/test/psbt-analysis-status.test.mjs
@@ -55,6 +55,14 @@ test("a problem outranks incomplete coverage without hiding either state", () =>
   assert.doesNotMatch(html, /<p class='psbt-warn'><strong>|LISTED CHECKS COMPLETE/);
 });
 
+test("an impossible (negative) claimed fee escalates the fee check to a problem", () => {
+  // Outputs exceeding claimed inputs is an inconsistency in the PSBT's own
+  // data, not missing coverage: the banner must turn red, not stay yellow.
+  const render = loadSlice("hodlRenderPsbt");
+  assert.match(render, /feeInconsistent = 1/);
+  assert.match(render, /state: feeInconsistent \? "problem" : "incomplete"/);
+});
+
 test("the report maps each implemented incomplete-analysis condition", () => {
   const render = loadSlice("hodlRenderPsbt") + loadSlice("hodlPsbtNonceCheck");
   for (const limitation of [


### PR DESCRIPTION
## Summary

When a PSBT's claimed output amounts exceed its claimed input amounts (a negative "fee" — an inconsistency in the PSBT's *own* data), the inspector showed a red inline paragraph (`Inconsistent claimed amounts: outputs exceed claimed inputs by …`), but the **analysis summary** kept the "Previous outputs and fee" check hardcoded at `state: "incomplete"`, so the banner stayed yellow ("ANALYSIS INCOMPLETE") instead of red ("ISSUES FOUND").

An impossible fee is a *found problem*, not missing coverage — the banner should reflect that.

## Proposed fix

```diff
     if (fee >= 0n) html.push("…Unverified fee…");
-    else html.push("<p class='psbt-bad'>…outputs exceed claimed inputs…");
+    else {
+      feeInconsistent = 1;
+      html.push("<p class='psbt-bad'>…outputs exceed claimed inputs…");
+    }
```

```diff
     {
       label: "Previous outputs and fee",
-      state: "incomplete",
+      state: feeInconsistent ? "problem" : "incomplete",
       detail: feeInconsistent
         ? "The claimed output amounts exceed the claimed input amounts, so the PSBT's own claims are inconsistent; …"
         : …
     },
```

## Tests

`test/psbt-analysis-status.test.mjs` gains a structural assertion that the render path tracks `feeInconsistent` and escalates the check to `"problem"`.

## Caveat (as requested)

Audit-produced; the escalation is structurally asserted but not driven end-to-end against a crafted negative-fee PSBT fixture. Full Docker suite green.

Commands run: `npm ci && npm run build && npm test` (in `docker compose run --rm dev`).
