### PR TITLE
Fix audit hygiene roundup: brain-wallet note, BIP-85 HMAC wipes, parser strictness

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -455,7 +455,10 @@ function hodlScriptDescriptor(e, t) {
 }
 function hodlIsMiniKey(e) {
   let t = e.trim();
-  return !t.startsWith("S") || t.length !== 22 && t.length !== 30 || !/^[A-Za-z0-9]+$/.test(t) ? false : hodlSha256(new TextEncoder().encode(t + "?"))[0] === 0;
+  // The minikey alphabet is Bitcoin Base58: the decode paths enforce it, so
+  // the auto-detect check must not accept the wider alphanumeric set (0, O,
+  // I, l are not Base58).
+  return !t.startsWith("S") || t.length !== 22 && t.length !== 30 || !/^[1-9A-HJ-NP-Za-km-z]+$/.test(t) ? false : hodlSha256(new TextEncoder().encode(t + "?"))[0] === 0;
 }
 function hodlDecodeMiniKey(e) {
   if (!hodlIsMiniKey(e)) throw hodlError("Not a valid Casascius mini private key.");
@@ -469,11 +472,11 @@ function hodlBrainWalletPassphrase(value, trimBoundaryWhitespace = false) {
 function hodlBrainWalletPrivateKey(value, trimBoundaryWhitespace = false) {
   return hodlSha256(new TextEncoder().encode(hodlBrainWalletPassphrase(value, trimBoundaryWhitespace)));
 }
-function hodlBrainLabEntropy(value) {
+function hodlBrainLabEntropy(value, trimmed = false) {
   let text = String(value ?? ""), notes = [], warnings = [];
   if (!text.length) return { ok: false, error: { key: "Enter the brain-wallet lab text." }, notes, warnings };
   let bytes = hodlSha256(new TextEncoder().encode(text)), hex = hodlHex.encode(bytes);
-  notes.push(hodlNote("SHA-256 of the exact UTF-8 text is 32 bytes of BIP39 entropy (256 bits → 24 words)."));
+  notes.push(hodlNote(trimmed ? "SHA-256 of the UTF-8 text with boundary whitespace trimmed is 32 bytes of BIP39 entropy (256 bits → 24 words)." : "SHA-256 of the exact UTF-8 text is 32 bytes of BIP39 entropy (256 bits → 24 words)."));
   warnings.push(hodlNote("Lab only. Strength is the entropy of this text, not the 24-word count."));
   warnings.push(hodlNote("SHA-256(text) is unsalted and fast. Anyone who can guess the text recovers the wallet."));
   warnings.push(hodlNote("This is not a BIP39 passphrase, and it is not a Bitcoin Core hdseed or address-key backup."));
@@ -2433,17 +2436,20 @@ function hodlAnalyzeDiceInput(value, method = hodlDiceMethod, targetWords = hodl
       index = end;
       continue;
     }
-    let isDie = normalized >= "1" && normalized <= "6", isCoin = normalized === "h" || normalized === "t", valid = false;
+    let isDie = normalized >= "1" && normalized <= "6", valid = false;
     if (method === "coldcard" || method === "coleman") {
       valid = isDie && !coinPositionSet.has(index);
       if (valid) acceptedRolls.push(normalized);
     } else if (words < config.partialWords) {
+      // BitBox: the sixth roll is the coin by die face (1–3 heads, 4–6 tails).
+      // h/t are not accepted — the derivation parser (hodlBitBoxRolls) and the
+      // input sanitizer both keep digits only, so the analyzer must agree.
       if (diceInWord < 5) {
         if (isDie && Number(normalized) <= 4) {
           valid = true;
           diceInWord += 1;
         }
-      } else if (isDie || isCoin) {
+      } else if (isDie) {
         valid = true;
         words += 1;
         diceInWord = 0;
@@ -3886,7 +3892,7 @@ function hodlSyncBrainOutput() {
     hex.className = "muted";
     return;
   }
-  let entropy = hodlBrainLabEntropy(hodlBrainWalletText(input.value));
+  let entropy = hodlBrainLabEntropy(hodlBrainWalletText(input.value), hodlBrainWalletTrimEnabled());
   hex.textContent = entropy.ok ? hodlTText("SHA-256 {hex} · 24 words appear only after {derive}.", { hex: entropy.hex, derive: hodlTText("Derive Key") }) : hodlFormatNote(entropy.error);
   hex.className = "muted" + (entropy.ok ? " ok" : " err");
 }
@@ -6125,7 +6131,7 @@ async function hodlCalculateKey(progress) {
         // The digest becomes BIP39 entropy rather than the private key itself,
         // which is a different wallet from the same text.
         if (passphrase && document.getElementById("passphrase-field")?.hidden) throw hodlError("A passphrase is set but not visible for this output. Show it and confirm it, or clear it, before deriving.");
-        let entropy = hodlBrainLabEntropy(hodlBrainWalletPassphrase(value, hodlBrainWalletTrimEnabled()));
+        let entropy = hodlBrainLabEntropy(hodlBrainWalletPassphrase(value, hodlBrainWalletTrimEnabled()), hodlBrainWalletTrimEnabled());
         hodlThrowIfFailed(entropy);
         hodlWalletResult = await hodlEntropyWalletWithProgress(entropy, passphrase, chain, count, account, addressStart, progress, purpose, coinType, hardening, branchStart, branchRange, derivationPlan);
       } else {

--- a/src/js/bip85.js
+++ b/src/js/bip85.js
@@ -244,31 +244,43 @@ export function derivePwdBase64(root, { length = 21, index = 0 } = {}) {
   let size = Number(length);
   if (!Number.isInteger(size) || size < PWD_BASE64_MIN || size > PWD_BASE64_MAX) throw new Error(`BASE64 passwords are ${PWD_BASE64_MIN} to ${PWD_BASE64_MAX} characters.`);
   let path = bip85Path(BIP85_APPS.PWD_BASE64, size, parseChildIndex(index));
-  let entropy = deriveBip85Entropy(root, path);
-  let encoded = base64Coder.encode(entropy).replace(/\s+/g, "");
-  return result({
-    app: "pwd-base64",
-    path,
-    entropy,
-    secret: encoded.slice(0, size),
-    secretLabel: `Password · Base64 · ${size} characters`,
-    notes: ["RFC 4648 Base64 of all 64 HMAC bytes, then sliced to the requested length. Length ≤ 86 so the password never includes padding."]
-  });
+  let digest = deriveBip85Entropy(root, path);
+  try {
+    // The password encodes all 64 HMAC bytes, so the result keeps its own
+    // copy and the digest is wiped like in the other four apps.
+    let entropy = digest.slice();
+    let encoded = base64Coder.encode(entropy).replace(/\s+/g, "");
+    return result({
+      app: "pwd-base64",
+      path,
+      entropy,
+      secret: encoded.slice(0, size),
+      secretLabel: `Password · Base64 · ${size} characters`,
+      notes: ["RFC 4648 Base64 of all 64 HMAC bytes, then sliced to the requested length. Length ≤ 86 so the password never includes padding."]
+    });
+  } finally {
+    wipeBytes(digest);
+  }
 }
 
 export function derivePwdBase85(root, { length = 12, index = 0 } = {}) {
   let size = Number(length);
   if (!Number.isInteger(size) || size < PWD_BASE85_MIN || size > PWD_BASE85_MAX) throw new Error(`BASE85 passwords are ${PWD_BASE85_MIN} to ${PWD_BASE85_MAX} characters.`);
   let path = bip85Path(BIP85_APPS.PWD_BASE85, size, parseChildIndex(index));
-  let entropy = deriveBip85Entropy(root, path);
-  return result({
-    app: "pwd-base85",
-    path,
-    entropy,
-    secret: encodeRfc1924Base85(entropy).slice(0, size),
-    secretLabel: `Password · RFC1924 Base85 · ${size} characters`,
-    notes: ["RFC 1924 Base85 of all 64 HMAC bytes (4-byte groups), then sliced to the requested length."]
-  });
+  let digest = deriveBip85Entropy(root, path);
+  try {
+    let entropy = digest.slice();
+    return result({
+      app: "pwd-base85",
+      path,
+      entropy,
+      secret: encodeRfc1924Base85(entropy).slice(0, size),
+      secretLabel: `Password · RFC1924 Base85 · ${size} characters`,
+      notes: ["RFC 1924 Base85 of all 64 HMAC bytes (4-byte groups), then sliced to the requested length."]
+    });
+  } finally {
+    wipeBytes(digest);
+  }
 }
 
 export function deriveApplication(root, spec = {}) {

--- a/src/js/hdkey.js
+++ b/src/js/hdkey.js
@@ -223,11 +223,13 @@ export class HDKey {
     }
     let child = this;
     for (const part of parts) {
-      const m = /^(\d+)('?)$/.exec(part);
+      // The hardened marker accepts h, H, or ' — the same grammar the UI
+      // path parsers (app.js) accept before they normalize to '.
+      const m = /^(\d+)([hH']?)$/.exec(part);
       if (!m) throw new Error("invalid child index: " + part);
       let idx = +m[1];
       if (!Number.isSafeInteger(idx) || idx >= HARDENED_OFFSET) throw new Error("Invalid index");
-      if (m[2] === "'") idx += HARDENED_OFFSET;
+      if (m[2]) idx += HARDENED_OFFSET;
       const next = child.deriveChild(idx);
       // Intermediate path nodes are dead once their child exists; wipe the
       // private half instead of leaving the keys for the GC to keep.

--- a/src/js/tx.js
+++ b/src/js/tx.js
@@ -67,6 +67,17 @@ export function scriptPushes(script) {
       i += length;
       continue;
     }
+    if (op === 0x4e) {
+      // PUSHDATA4: without this branch the scanner walks inside the pushed
+      // data and can surface DER-looking bytes as phantom signatures.
+      if (i + 4 > script.length) break;
+      const length = (script[i] | (script[i + 1] << 8) | (script[i + 2] << 16) | (script[i + 3] << 24)) >>> 0;
+      i += 4;
+      if (i + length > script.length) break;
+      pushes.push(script.slice(i, i + length));
+      i += length;
+      continue;
+    }
   }
   return pushes;
 }

--- a/test/bip85.test.mjs
+++ b/test/bip85.test.mjs
@@ -188,3 +188,18 @@ test("wiping a result discards secret bytes", () => {
   assert.notEqual(hexCoder.encode(copy), hexCoder.encode(derived.entropy));
   wipeBytes(copy);
 });
+
+test("password results hold a wipeable copy, not the live HMAC (audit #365)", () => {
+  // The password apps encode all 64 HMAC bytes; the digest is wiped at derive
+  // time like the other four apps, and the result's own copy still wipes.
+  for (const derive of [derivePwdBase64, derivePwdBase85]) {
+    let derived = derive(root, { index: 0 });
+    assert.equal(derived.entropy.length, 64);
+    wipeBip85Result(derived);
+    assert.equal(derived.secret, "");
+    assert.equal(derived.entropyHex, "");
+    assert.ok(derived.entropy.every((b) => b === 0));
+  }
+  // And the digest wipe at derive time must not clobber the result.
+  assert.equal(derivePwdBase64(root, { length: 21, index: 0 }).secret, "dKLoepugzdVJvdL56ogNV");
+});

--- a/test/brain-wallet.test.mjs
+++ b/test/brain-wallet.test.mjs
@@ -91,6 +91,18 @@ test("brain-wallet lab hashes exact UTF-8 text as 256-bit BIP39 entropy", () => 
   assert.match(result.warnings.join(" "), /not mean it is the same wallet/);
 });
 
+test("the lab note says when the hashed text was trimmed (audit #365)", () => {
+  // The HD derive path hashes the passphrase after trimming when the trim
+  // option is on, so the note must not claim the exact text was hashed.
+  const exact = lab.hodlBrainLabEntropy("phrase");
+  assert.match(exact.notes.join(" "), /SHA-256 of the exact UTF-8 text/);
+  const trimmed = lab.hodlBrainLabEntropy("phrase", true);
+  assert.match(trimmed.notes.join(" "), /with boundary whitespace trimmed/);
+  assert.doesNotMatch(trimmed.notes.join(" "), /exact UTF-8 text/);
+  // The HD derive call passes the live trim flag through to the note.
+  assert.match(app, /hodlBrainLabEntropy\(hodlBrainWalletPassphrase\(value, hodlBrainWalletTrimEnabled\(\)\), hodlBrainWalletTrimEnabled\(\)\)/);
+});
+
 test("brain-wallet lab rejects empty text and keeps private-key hashing separate", () => {
   assert.equal(lab.hodlBrainLabEntropy("").ok, false);
   const text = "correct horse battery staple";

--- a/test/dice-input-analysis.test.mjs
+++ b/test/dice-input-analysis.test.mjs
@@ -95,20 +95,30 @@ test("coin-button positions are excluded from the rolls and counted in range onl
   assert.equal(hodlAnalyzeDiceInput("12", "coldcard", 24, [5, 99, -1]).coinDerivedCount, 0);
 });
 
-test("bitbox analysis enforces four low dice then a sixth die-or-coin per word", () => {
+test("bitbox analysis enforces four low dice then a sixth die per word", () => {
   assert.equal(hodlAnalyzeDiceInput("1111", "bitbox", 12, []).diceInWord, 4);
   // Faces 5 and 6 are rerolled away on the first five dice of a word.
   assert.deepEqual(hodlAnalyzeDiceInput("11115", "bitbox", 12, []).invalidRanges, [[4, 5]]);
   assert.deepEqual(hodlAnalyzeDiceInput("11116", "bitbox", 12, []).invalidRanges, [[4, 5]]);
   const five = hodlAnalyzeDiceInput("11114", "bitbox", 12, []);
   assert.equal(five.diceInWord, 5);
-  assert.equal(five.coinTurn, true, "the sixth roll may be a coin flip");
+  assert.equal(five.coinTurn, true, "the sixth roll doubles as the coin flip");
   assert.equal(five.complete, false);
-  for (const sixth of ["1", "6", "h", "t", "H", "T"]) {
+  for (const sixth of ["1", "6"]) {
     const analysis = hodlAnalyzeDiceInput(`11114${sixth}`, "bitbox", 12, []);
     assert.equal(analysis.words, 1, `sixth roll ${sixth}`);
     assert.equal(analysis.diceInWord, 0, sixth);
     assert.equal(analysis.coinTurn, false, sixth);
+  }
+  // Coin letters never complete a word: the derivation parser
+  // (hodlBitBoxRolls) and the input sanitizer both keep digits only, so the
+  // analyzer must not disagree with them on a completed word.
+  for (const coin of ["h", "t", "H", "T"]) {
+    const analysis = hodlAnalyzeDiceInput(`11114${coin}`, "bitbox", 12, []);
+    assert.equal(analysis.words, 0, `coin letter ${coin}`);
+    assert.deepEqual(analysis.invalidRanges, [[5, 6]], coin);
+    assert.equal(analysis.coinTurn, true, `${coin}: still waiting on the sixth die`);
+    assert.equal(analysis.complete, false, coin);
   }
   // Anything else on the sixth roll is invalid.
   assert.deepEqual(hodlAnalyzeDiceInput("11114x", "bitbox", 12, []).invalidRanges, [[5, 6]]);

--- a/test/hdkey-bip39-wasm.test.mjs
+++ b/test/hdkey-bip39-wasm.test.mjs
@@ -59,6 +59,18 @@ test("BIP32 differential: private and public derivation match @scure/bip32", () 
   }
 });
 
+test("BIP32 path grammar accepts h, H, and ' as the hardened marker (audit #365)", () => {
+  // The UI path parsers accept all three notations and normalize to ' before
+  // calling derive; a direct call with h or H must not throw.
+  const root = HDKey.fromMasterSeed(hexToBytes("000102030405060708090a0b0c0d0e0f"));
+  const prime = root.derive("m/84'/0'/0'");
+  for (const path of ["m/84h/0h/0h", "m/84H/0H/0H", "m/84h/0'/0H"]) {
+    const node = root.derive(path);
+    assert.equal(node.privateExtendedKey, prime.privateExtendedKey, path);
+  }
+  assert.throws(() => root.derive("m/84p"), /invalid child index/);
+});
+
 test("BIP32 watch-only: neutered derivation matches scure on normal paths", () => {
   const oursRoot = HDKey.fromMasterSeed(hexToBytes("000102030405060708090a0b0c0d0e0f"));
   const theirsRoot = ScureHDKey.fromMasterSeed(hexToBytes("000102030405060708090a0b0c0d0e0f"));

--- a/test/private-key-inputs.test.mjs
+++ b/test/private-key-inputs.test.mjs
@@ -10,6 +10,7 @@
 // Run with `npm test`.
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -69,7 +70,7 @@ const source = [
     "hodlPrivateKeyCharacterEntries",
     "hodlPrivateKeyInputAnalysis",
   ].map(slice),
-  "export { hodlDetectPrivateKeyKind, hodlNormalizePrivateKeyKind, hodlHexPrivateKeyPrefix, hodlWifPrivateKeyPrefix, hodlMiniPrivateKeyPrefix, hodlDecodeMiniPrivateKey, hodlAssertPrivateKeyKind, hodlPrivateKeyCharacterEntries, hodlPrivateKeyInputAnalysis };",
+  "export { hodlIsMiniKey, hodlDetectPrivateKeyKind, hodlNormalizePrivateKeyKind, hodlHexPrivateKeyPrefix, hodlWifPrivateKeyPrefix, hodlMiniPrivateKeyPrefix, hodlDecodeMiniPrivateKey, hodlAssertPrivateKeyKind, hodlPrivateKeyCharacterEntries, hodlPrivateKeyInputAnalysis };",
 ].join("\n");
 
 const modulePath = join(root, "test", `.private-key-inputs-${process.pid}.mjs`);
@@ -81,6 +82,7 @@ try {
   unlinkSync(modulePath);
 }
 const {
+  hodlIsMiniKey,
   hodlDetectPrivateKeyKind,
   hodlNormalizePrivateKeyKind,
   hodlHexPrivateKeyPrefix,
@@ -109,6 +111,23 @@ const MINIKEY_22_PRIV = "e9873d79c6d87dc0fb6a5778633389f4453213303da61f20bd67fc2
 const MINIKEY_TAMPERED = "S6c56bnXQiBjk9mqSYE7ykVQ7NzrRz";
 
 const hexOf = (bytes) => Buffer.from(bytes).toString("hex");
+
+test("hodlIsMiniKey rejects the non-Base58 alphabet even with a passing checksum (audit #365)", () => {
+  // The auto-detect helper used to accept any alphanumeric string: an
+  // S-prefixed 22/30-char string containing 0, O, I, or l with a lucky
+  // checksum would decode as a minikey even though Base58 cannot represent
+  // it. Find such a string and pin the strict alphabet.
+  let candidate = null;
+  for (let i = 0; i < 100000 && !candidate; i++) {
+    const probe = `S0${i.toString(36).padStart(20, "1")}`;
+    if (createHash("sha256").update(`${probe}?`).digest()[0] === 0) candidate = probe;
+  }
+  assert.ok(candidate, "a checksummed non-Base58 minikey-shaped string exists");
+  assert.equal(candidate.length, 22);
+  assert.equal(hodlIsMiniKey(candidate), false);
+  assert.equal(hodlIsMiniKey(MINIKEY_22), true, "real minikeys still pass");
+  assert.equal(hodlIsMiniKey(MINIKEY_30), true, "real minikeys still pass");
+});
 
 test("kind detection classifies minikey, WIF, and hex by shape only", () => {
   assert.equal(hodlDetectPrivateKeyKind(MINIKEY_22), "minikey");

--- a/test/tx-ownership.test.mjs
+++ b/test/tx-ownership.test.mjs
@@ -168,6 +168,24 @@ test("scriptPushes reads a P2PKH scriptSig", () => {
   assert.equal(pushes[1].length, 33);
 });
 
+test("scriptPushes handles PUSHDATA4 and surfaces no phantom signatures (audit #365)", () => {
+  // An 80-byte PUSHDATA4 payload whose interior opens with a DER-looking
+  // 9-byte sequence: a scanner without PUSHDATA4 support walks inside the
+  // push and reports those interior bytes as a signature push.
+  const derLookalike = Uint8Array.of(0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x01, 0x01);
+  const payload = concat(Uint8Array.of(0x09), derLookalike, new Uint8Array(70).fill(0x42));
+  const script = concat(Uint8Array.of(0x4e), u32(payload.length), payload);
+  const pushes = scriptPushes(script);
+  assert.equal(pushes.length, 1, "the PUSHDATA4 payload is one push");
+  assert.deepEqual([...pushes[0]], [...payload]);
+  // End to end: the interior DER-looking bytes are not a signature.
+  const sigs = extractEcdsaSignatures({ inputs: [{ scriptSig: script, witness: [] }] });
+  assert.equal(sigs.length, 0, "no phantom signature from inside a push");
+  // A truncated PUSHDATA4 length or payload just stops the scan.
+  assert.deepEqual(scriptPushes(Uint8Array.of(0x4e, 0x01, 0x00)), []);
+  assert.deepEqual(scriptPushes(concat(Uint8Array.of(0x4e), u32(500), new Uint8Array(10))), []);
+});
+
 test("app inspects raw transactions and labels outputs", () => {
   assert.match(app, /hodlRenderRawTx/);
   assert.match(app, /hodlSessionOwnership/);

--- a/test/wipe-wasm.test.mjs
+++ b/test/wipe-wasm.test.mjs
@@ -139,7 +139,7 @@ test("the JS facades wipe their secret byte buffers (source guard)", () => {
   assert.equal((bip39.match(/phrase\.fill\(0\)/g) || []).length, 3, "every encoded phrase buffer must be wiped");
   const bip85 = read("src/js/bip85.js");
   assert.match(bip85, /child\.wipePrivateData\(\)/, "deriveBip85Entropy must wipe the derived child node");
-  assert.ok((bip85.match(/wipeBytes\(digest\)/g) || []).length >= 4, "every BIP-85 HMAC digest must be wiped");
+  assert.ok((bip85.match(/wipeBytes\(digest\)/g) || []).length >= 6, "every BIP-85 HMAC digest must be wiped");
   const hdkey = read("src/js/hdkey.js");
   assert.match(hdkey, /if \(child !== this\) child\.wipePrivateData\(\);/, "derive must wipe intermediate path nodes");
   assert.match(hdkey, /input\.fill\(0\)/, "deriveChild must wipe the packed parent node");


### PR DESCRIPTION
Closes #365.

Six minor hygiene items from the security audit, each a one-or-two-line fix with a regression test.

## 1. Brain-wallet HD note text (`src/js/app.js`)
`hodlBrainLabEntropy` always noted "SHA-256 of the exact UTF-8 text", but the HD derive path hashes the *trimmed* passphrase when trim is on (the scalar path's note was already conditional). The note now takes the trim state: "…of the UTF-8 text with boundary whitespace trimmed…" when active. Both live call sites pass `hodlBrainWalletTrimEnabled()`.

## 2. BIP-85 password HMAC wipe (`src/js/bip85.js`)
`derivePwdBase64`/`derivePwdBase85` handed the raw 64-byte HMAC to the result without wiping it, unlike the other four apps' `try { … } finally { wipeBytes(digest) }`. They now copy the entropy for the result and wipe the digest in `finally`. Behavior is unchanged (the password encodes all 64 bytes, and the pinned `entropyHex` vectors still pass); the source guard in `test/wipe-wasm.test.mjs` is bumped from ≥4 to ≥6 `wipeBytes(digest)` sites, and `test/bip85.test.mjs` gains pwd-result wipe coverage.

## 3. `hdkey.js` path grammar (`src/js/hdkey.js`)
`HDKey.derive` accepted only `'` as the hardened marker while the UI path parsers accept `h`/`H`/`'` (internal callers normalize first, so this was latent). The index grammar is now `/^(\d+)([hH']?)$/`; a differential test pins `m/84h/0h/0h` ≡ `m/84H/0H/0H` ≡ `m/84'/0'/0'`.

## 4. `tx.js scriptPushes` PUSHDATA4 (`src/js/tx.js`)
The scanner had no `0x4e` branch, so it walked inside large pushes and could surface DER-looking interior bytes as phantom signatures (noise into `uninspected`, never a silent pass). It now reads the 4-byte length like `app.js`'s `hodlScriptPushes`. The regression builds an 80-byte PUSHDATA4 payload opening with a DER-looking sequence: old code surfaces it as a 9-byte "signature" push, new code returns the payload whole and `extractEcdsaSignatures` reports nothing.

## 5. `hodlIsMiniKey` alphabet (`src/js/app.js`)
The auto-detect helper accepted any alphanumeric string (`/^[A-Za-z0-9]+$/`) while the decode paths enforce Bitcoin Base58. It now uses `/^[1-9A-HJ-NP-Za-km-z]+$/`. The test finds a real 22-char S-prefixed string containing `0`/`l` with a passing SHA-256(`?`) checksum — old code accepted it as a minikey, new code rejects it.

## 6. BitBox analyzer/parser agreement (`src/js/app.js`)
`hodlAnalyzeDiceInput` accepted `h`/`t` coin letters as the sixth character completing a BitBox word, but `hodlBitBoxRolls` (the derivation parser) discards them as leftover and the input sanitizer strips non-digits — unreachable in practice, but the two disagreed on a completed word. The analyzer now takes dice only (the sixth die *is* the coin: 1–3 heads, 4–6 tails, per the UI help). The existing analysis test pinned the old behavior and is updated.

## Verification
- `npm run build` and `npm test`: 1112 pass, 0 fail (Edge skipped — no binary)
- `npm run test:browser`: Firefox and Chrome green
- Each new regression was mutation-checked against the pre-fix behavior (phantom DER push surfaces, checksummed non-Base58 minikey accepted, `t` completes an analyzer word)