### PR TITLE
Match non-witness UTXOs by txid, not wtxid, when the prevtx carries a witness

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -8039,7 +8039,13 @@ function hodlNonWitUtxo(entries, input) {
   let entry = hodlFind(entries, 0).find((item) => item.keydata.length === 0);
   if (!entry) return null;
   let prev = parseRawTx(entry.val);
-  let txid = hodlSha256(hodlSha256(entry.val));
+  // The txid commits to the legacy (witness-stripped) serialization: a
+  // witness-carrying prevtx — legal BIP-174 and common from non-Core wallets —
+  // must be stripped before hashing, otherwise this computes the wtxid and
+  // every such field is a false "does not match" (issue #350). The WASM
+  // inspector's compute_txid() strips unconditionally; stripping only the
+  // segwit case here keeps legacy bytes hashed exactly as before.
+  let txid = hodlSha256(hodlSha256(prev.segwit ? serializeTx(prev) : entry.val));
   if (!hodlEq(txid, input.txid)) throw new Error("A non-witness UTXO's transaction does not match the input's previous output.");
   let output = prev.outputs[input.vout];
   if (!output) throw new Error("A non-witness UTXO's transaction does not contain the spent output.");

--- a/test/psbt-nonwitness-utxo.test.mjs
+++ b/test/psbt-nonwitness-utxo.test.mjs
@@ -10,7 +10,7 @@ import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { parseRawTx } from "../src/js/tx.js";
+import { parseRawTx, serializeTx } from "../src/js/tx.js";
 import { sha256 } from "../src/js/hashes.js";
 
 const root = dirname(fileURLToPath(import.meta.url));
@@ -42,8 +42,9 @@ const hodlNonWitUtxo = new Function(
   "parseRawTx",
   "hodlSha256",
   "hodlEq",
+  "serializeTx",
   `${loadSlice("hodlNonWitUtxo")}; return hodlNonWitUtxo;`,
-)(hodlFind, parseRawTx, sha256, hodlEq);
+)(hodlFind, parseRawTx, sha256, hodlEq, serializeTx);
 
 // A minimal previous transaction paying `sats` to `script` on output `vout`.
 const le32 = (n) => new Uint8Array(new Uint32Array([n >>> 0]).buffer);
@@ -52,6 +53,18 @@ const prevTx = (sats, script = [0x51]) =>
   new Uint8Array([
     ...le32(2), 1, ...new Uint8Array(32), ...le32(0xffffffff), 0, ...le32(0xffffffff),
     1, ...le64(sats), script.length, ...script,
+    ...le32(0),
+  ]);
+// The same transaction witness-serialized (BIP-144 marker/flag plus a
+// one-item stack): legal inside a non-witness UTXO and common from non-Core
+// wallets. Its fields are identical to prevTx's, so prevTx(sats, script) is
+// exactly its witness-stripped form.
+const segwitPrevTx = (sats, script = [0x51]) =>
+  new Uint8Array([
+    ...le32(2), 0, 1,
+    1, ...new Uint8Array(32), ...le32(0xffffffff), 0, ...le32(0xffffffff),
+    1, ...le64(sats), script.length, ...script,
+    1, 1, 0x10,
     ...le32(0),
   ]);
 const txidOf = (bytes) => createHash("sha256").update(createHash("sha256").update(bytes).digest()).digest();
@@ -78,6 +91,23 @@ test("a non-witness UTXO missing the spent output claims nothing", () => {
   const prev = prevTx(42000);
   const input = { txid: new Uint8Array(txidOf(prev)), vout: 3 };
   assert.throws(() => hodlNonWitUtxo([entry(0, prev)], input), /does not contain the spent output/);
+});
+
+test("a witness-serialized non-witness UTXO matches by txid, never by wtxid (issue #350)", () => {
+  const prev = segwitPrevTx(42000);
+  const stripped = prevTx(42000);
+  // The two serializations hash differently: hashing the raw bytes is the wtxid.
+  assert.notDeepEqual(txidOf(prev), txidOf(stripped));
+  assert.deepEqual(parseRawTx(prev).segwit, true);
+  // The outpoint names the txid, so the witness-carrying field verifies…
+  const input = { txid: new Uint8Array(txidOf(stripped)), vout: 0 };
+  const claim = hodlNonWitUtxo([entry(0, prev)], input);
+  assert.equal(claim.amount, 42000n);
+  assert.deepEqual([...claim.script], [0x51]);
+  // …and a field whose bytes only hash to the outpoint with the witness
+  // included is the lie the check exists to catch.
+  const byWtxid = { txid: new Uint8Array(txidOf(prev)), vout: 0 };
+  assert.throws(() => hodlNonWitUtxo([entry(0, prev)], byWtxid), /does not match the input's previous output/);
 });
 
 test("the report resolves claims as a set and flags conflicts (issue #350)", () => {


### PR DESCRIPTION
## Problem

Follow-up to #350. `hodlNonWitUtxo` (src/js/app.js) hashes the raw `PSBT_IN_NON_WITNESS_UTXO` bytes with double-SHA256 and requires the digest to equal the input's previous-output txid. When the embedded previous transaction is witness-serialized (BIP-144 marker/flag + witnesses), that digest is the transaction's **wtxid**, not its txid — so the checkable claim false-mismatches with "A non-witness UTXO's transaction does not match the input's previous output.", the field claims nothing, and without a witness-UTXO claim the fee goes unknown.

Witness-inclusive serialization is legal BIP-174 ("network serialization format") and common from non-Core wallets. The WASM inspector verifies the same field with `compute_txid()` (psbt-wasm/src/lib.rs), which strips the witness — so the two inspectors disagreed on the same file: the WASM side resolved the claim and computed the fee, the JS side reported a problem.

## Change

- src/js/app.js: when the embedded prevtx parses as segwit, hash `serializeTx(prev)` (the witness-stripped legacy serialization the txid actually commits to) instead of the raw field bytes. Legacy-serialized fields keep the exact old path, byte for byte.
- test/psbt-nonwitness-utxo.test.mjs: new regression test — a witness-serialized prevtx verifies against its txid (amount and script resolve), and the same bytes referenced by their wtxid still throw (the lie the check exists to catch). Verified the test fails without the fix. The harness now injects `serializeTx` alongside the other `hodlNonWitUtxo` dependencies.

## Ran

`npm run build`, `npm test` — green (1153 pass, 1 engine-skip; the two Firefox journal subtests flake under full-suite load on this machine and pass in isolation and on repeat full runs, unchanged by this diff).