### PR TITLE
test: guard numeric BIP39 passphrases against exact-string regressions (#283)

### DIFF
--- a/test/hdkey-bip39-wasm.test.mjs
+++ b/test/hdkey-bip39-wasm.test.mjs
@@ -245,6 +245,38 @@ test("BIP39: no non-canonical separator yields a derivable seed-bearing phrase",
   }
 });
 
+// Regression guard for #283 ("Wrong keys derived when adding numbers as
+// passphrase"): a passphrase of ASCII digits must reach PBKDF2 as the exact
+// string typed — no numeric coercion (leading zeros are significant), no
+// trimming, no length capping. ColdCard and every other BIP39 signer stretch
+// the string as-is, so any transformation here derives a wallet nothing else
+// reproduces. The fingerprints are pinned to values an independent
+// implementation (@scure/bip39 + @scure/bip32) produces, so the guard holds
+// even if the oracle dependency moves.
+test("BIP39 numeric passphrases stretch the exact string (#283)", () => {
+  const phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+  const fingerprintHex = (pass) => (HDKey.fromMasterSeed(mnemonicToSeedSync(phrase, pass)).fingerprint >>> 0).toString(16).padStart(8, "0");
+  const cases = [
+    ["", "73c5da0a"],
+    ["0", "4d9cb38e"],
+    ["007", "9f67e695"],
+    ["123456", "e9646cf9"],
+    ["987654321098765432109876543210", "aa5d8432"],
+    ["abc123", "23a41e58"],
+    ["hello world", "ec372958"],
+  ];
+  for (const [pass, expected] of cases) {
+    assert.equal(bytesToHex(mnemonicToSeedSync(phrase, pass)), bytesToHex(scureBip39.mnemonicToSeedSync(phrase, pass)), `seed for ${JSON.stringify(pass)} disagrees with scure`);
+    assert.equal(fingerprintHex(pass), expected, `master fingerprint for ${JSON.stringify(pass)}`);
+  }
+  // Numeric coercion would collapse these pairs; exact-string semantics keep
+  // every one distinct.
+  const distinct = [["007", "7"], ["123456", "123456 "], ["0", "00"], ["000102", "102"]];
+  for (const [a, b] of distinct) {
+    assert.notEqual(fingerprintHex(a), fingerprintHex(b), `${JSON.stringify(a)} and ${JSON.stringify(b)} must derive different wallets`);
+  }
+});
+
 test("wordlist agreement: JS data file == rust-bip39 English list, word for word", () => {
   assert.equal(bip39English.length, 2048);
   const wasm = wasmExports();


### PR DESCRIPTION
Refs #283.

## Summary

Issue #283 reports that a BIP39 passphrase made of digits produces a different master fingerprint in EntropyLab than on a ColdCard. I investigated exhaustively and **could not reproduce any divergence**: every passphrase-bearing flow in the page stretches the exact string typed and derives keys identical to an independent implementation. This PR adds a regression guard that locks that behavior in, so a future change that coerces, trims, or caps a numeric passphrase fails loudly instead of silently deriving an unrecoverable wallet.

## Verification performed (no divergence found)

All checks compared the real assembled page (headless Chromium, trusted input events) against an independent oracle (`@scure/bip39` + `@scure/bip32`, and `node:crypto` for the BIP85 HMAC). Anchor vectors with mnemonic `abandon … about` (12 words):

| Passphrase | Expected master fingerprint | Observed |
|---|---|---|
| *(empty)* | `73c5da0a` | MATCH |
| `123456` | `e9646cf9` | MATCH |
| `007` | `9f67e695` | MATCH |
| `0` | `4d9cb38e` | MATCH |
| `987654321098765432109876543210` | `aa5d8432` | MATCH |
| `abc123` | `23a41e58` | MATCH |
| `hello world` | `ec372958` | MATCH |

Flows exercised, all byte-exact against the oracle:

- Seed field → typed passphrase (real `Input.insertText` events) → debounced fingerprint preview
- Full *Derive Key* flow — wallet result fingerprint
- On-screen keyboard numeric mode, digit by digit (field char codes verified)
- Key Station tab switch / restore — `#pass` value byte-exact (leading zeros intact)
- Encrypted Key Manager (`.elkeys`) export → in-memory copies removed → re-import → passphrase restored byte-exact, re-derive matches
- BIP85: passphrased parent root xprv byte-identical to oracle; 12-word English child at index 0 identical to an independent BIP85 implementation, for both passphrases
- Multisig cosigner strings (xpub + fingerprint) byte-identical to oracle for a 1-of-2 Native SegWit setup
- Vanity passphrase grind → *Update key* write-back — passphrase string preserved byte-exact, re-derives to the oracle fingerprint

A static audit of every value path (input listener, preview, calculate, global sync, autocomplete, input filters, on-screen keyboard layouts, serialization) found no numeric coercion anywhere.

## What the test locks

New test `BIP39 numeric passphrases stretch the exact string (#283)` in `test/hdkey-bip39-wasm.test.mjs`:

- 7 passphrase cases pinned to hardcoded master fingerprints produced by the independent implementation, so the guard survives oracle dependency changes
- A seed-level differential against `@scure/bip39` for each case
- Distinctness assertions for the pairs a numeric coercion would collapse: `007`/`7`, `0`/`00`, `000102`/`102`, and `123456` vs a trailing-space variant

## Testing

- `npm run build` — clean
- `npm test` — 1118 pass, 0 fail (6 skips: browser engines not installed locally)
- `npm run verify` — site artifact verified

## Note on the issue

Since no divergence reproduces on current `rock`, the remaining possibilities are an older release, a different flow than the ones above, or the entry side on the ColdCard. I have asked the reporter on #283 for their exact reproduction path; happy to follow up there if new details surface.