### PR TITLE
SP send: validate BIP-352 input keys and spend taproot inputs with the output key

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -20,6 +20,7 @@ import {
   p2trAddressFromXonly,
   scanSilentPaymentOutputs,
   spendPrivForOutput,
+  taprootOutputPrivateKey,
   vinPrevoutScript,
   bytesToHex as hodlSpBytesToHex,
 } from "./bip352.js";
@@ -9188,7 +9189,11 @@ function hodlSpDeriveVinKeys(vins) {
         throw new Error(`Input ${i}: the key derived at ${path} does not produce the prevout's scriptPubKey.`);
       }
       if (expected === null) throw new Error(`Input ${i}: unrecognized prevout script type.`);
-      return { ...vin, private_key: hodlSpBytesToHex(node.privateKey) };
+      // BIP-352 spends a taproot input with the key of its output key, so the
+      // P2TR case injects the BIP-341-tweaked scalar; anything less would
+      // produce outputs the recipient can never detect.
+      const privateKey = isP2tr(scriptBytes) ? taprootOutputPrivateKey(node.privateKey) : node.privateKey;
+      return { ...vin, private_key: hodlSpBytesToHex(privateKey) };
     } finally {
       if (node) node.wipePrivateData();
     }

--- a/src/js/bip352.js
+++ b/src/js/bip352.js
@@ -373,14 +373,20 @@ const normalizeVin = (vin) => ({
 export function eligibleInputKeys(vins) {
   const pubkeys = [];
   const privkeys = [];
-  for (const raw of vins) {
+  for (const [index, raw] of vins.entries()) {
     const vin = normalizeVin(raw);
     const extracted = extractInputPubKey(vin);
     if (!extracted) continue;
     pubkeys.push(extracted);
     if (vin.private_key) {
+      const scalar = scalarFromBytes(typeof vin.private_key === "string" ? hexToBytes(vin.private_key) : vin.private_key);
+      const suppliedPoint = Point.fromBytes(secp256k1.getPublicKey(bigToBytes32(scalar), true));
+      const matches = extracted.isTaproot
+        ? equalBytes(pointToXOnly(suppliedPoint), pointToXOnly(extracted.point))
+        : equalBytes(pointToCompressed(suppliedPoint), pointToCompressed(extracted.point));
+      if (!matches) throw new Error(`Input ${index} private key does not match its eligible input public key.`);
       privkeys.push({
-        scalar: scalarFromBytes(typeof vin.private_key === "string" ? hexToBytes(vin.private_key) : vin.private_key),
+        scalar,
         isTaproot: extracted.isTaproot,
       });
     }

--- a/src/js/bip352.js
+++ b/src/js/bip352.js
@@ -370,6 +370,20 @@ const normalizeVin = (vin) => ({
   private_key: vin.private_key,
 });
 
+// BIP-352 spends a taproot input with "the private key corresponding to the
+// taproot output key (i.e. the tweaked private key)": the BIP-341 key-path
+// tweak of the even-Y internal key. Supplying the raw internal key instead
+// produces outputs the recipient can never detect.
+export function taprootOutputPrivateKey(secret) {
+  const internal = scalarFromBytes(secret instanceof Uint8Array ? secret : hexToBytes(secret));
+  const even = pointHasEvenY(Point.fromBytes(secp256k1.getPublicKey(bigToBytes32(internal), true))) ? internal : ORDER - internal;
+  const xonly = pointToXOnly(Point.fromBytes(secp256k1.getPublicKey(bigToBytes32(even), true)));
+  const tweak = scalarFromBytes(taggedHash("TapTweak", xonly));
+  const output = (even + tweak) % ORDER;
+  if (output === 0n) throw new Error("Taproot key-path tweak produced an invalid key.");
+  return bigToBytes32(output);
+}
+
 export function eligibleInputKeys(vins) {
   const pubkeys = [];
   const privkeys = [];

--- a/test/bip352.test.mjs
+++ b/test/bip352.test.mjs
@@ -230,6 +230,15 @@ test("future SegWit inputs fail sending and make v0 receivers skip the transacti
   assert.deepEqual(result, { outputs: [], inputPubKeySum: null, tweak: null, sharedSecret: null });
 });
 
+test("sender rejects a private key that does not match its eligible input", () => {
+  const given = structuredClone(vectors[0].sending[0].given);
+  given.vin[0].private_key = "00".repeat(31) + "01";
+  assert.throws(
+    () => createSilentPaymentOutputs(given.vin, given.recipients, { hrp: "sp" }),
+    /input 0 private key does not match/i,
+  );
+});
+
 test("generateLabel is deterministic", () => {
   const scan = hexToBytes("0f694e068028a717f8af6b9411f9a133dd3565258714cc226594b34db90c1f2c");
   const a = generateLabel(scan, 0);

--- a/test/sp-send-session.test.mjs
+++ b/test/sp-send-session.test.mjs
@@ -21,6 +21,8 @@ import {
   isP2sh,
   isP2tr,
   isP2wpkh,
+  scanSilentPaymentOutputs,
+  taprootOutputPrivateKey,
   vinPrevoutScript,
   bytesToHex,
 } from "../src/js/bip352.js";
@@ -54,11 +56,13 @@ const hodlSpDeriveVinKeys = new Function(
   "indexHdKey", "matchOwnership", "extractInputPubKey", "vinPrevoutScript",
   "isP2pkh", "isP2sh", "isP2tr", "isP2wpkh",
   "p2pkhScript", "p2shP2wpkhScript", "p2trKeyScript", "p2wpkhScript",
+  "taprootOutputPrivateKey",
   `${loadSlice("hodlFingerprintHex")}; ${loadSlice("hodlSpDeriveVinKeys")}; return hodlSpDeriveVinKeys;`,
 )(
   indexHdKey, matchOwnership, extractInputPubKey, vinPrevoutScript,
   isP2pkh, isP2sh, isP2tr, isP2wpkh,
   p2pkhScript, p2shP2wpkhScript, p2trKeyScript, p2wpkhScript,
+  taprootOutputPrivateKey,
 );
 
 const vinOf = (scriptHex, extra = {}) => ({
@@ -83,8 +87,10 @@ test("an owned input resolves through the ownership index, and the derived key m
   const [resolved] = hodlSpDeriveVinKeys([vinOf(OWNED_SCRIPT)]);
   assert.ok(resolved.private_key, "no key injected");
   const pub = secp256k1.getPublicKey(hexToBytes_(resolved.private_key), true);
-  // The derived key really does produce the prevout script (BIP-341 tweak).
-  assert.equal(bytesToHex(p2trKeyScript(pub.slice(1))), OWNED_SCRIPT);
+  // The injected key is the key of the taproot OUTPUT key (BIP-341 tweaked,
+  // as BIP-352 sending requires): its x-only public key is the prevout
+  // program itself, which is what the recipient extracts from the input.
+  assert.equal(bytesToHex(pub.slice(1)), OWNED_SCRIPT.slice(4));
   // Same result via an explicit path.
   const [byPath] = hodlSpDeriveVinKeys([vinOf(OWNED_SCRIPT, { path: "m/86'/1'/0'/0/0" })]);
   assert.equal(byPath.private_key, resolved.private_key);
@@ -114,6 +120,26 @@ test("a session-resolved send equals the same inputs keyed by hand (vector-mode 
   const byHand = createSilentPaymentOutputs([vinOf(OWNED_SCRIPT, { private_key: resolved.private_key })], [{ address: recipient, count: 1 }], { hrp: "tsp" });
   assert.deepEqual(bySession.outputs, byHand.outputs);
   assert.equal(bySession.outputs.length, 1);
+});
+
+test("a session send spending a tweaked P2TR input is detectable by the recipient", () => {
+  // Regression: the injected key must be the key of the taproot OUTPUT key
+  // (BIP-341 tweaked) — the raw internal key produced outputs scanning could
+  // never find (silent funds loss), and the input-key match check rejects it.
+  setup();
+  const [resolved] = hodlSpDeriveVinKeys([vinOf(OWNED_SCRIPT)]);
+  const keys = deriveSilentPaymentKeys(SEED, { coinType: 1, account: 0 });
+  const recipient = encodeSilentPaymentAddress(keys.scanPoint, keys.spendPoint, "tsp");
+  const send = createSilentPaymentOutputs([resolved], [{ address: recipient, count: 1 }], { hrp: "tsp" });
+  assert.equal(send.outputs.length, 1);
+  const scan = scanSilentPaymentOutputs({
+    scanPriv: keys.scanPriv,
+    spendPub: keys.spendPoint,
+    vins: [resolved],
+    outputs: send.outputs,
+    labels: [],
+  });
+  assert.equal(scan.outputs.length, 1, "the recipient cannot detect the output: the input key is not the output key's");
 });
 
 // The library keeps raw private_key support for the published BIP-352


### PR DESCRIPTION
## Summary

Two coupled commits, re-landed for a proper review trail (they briefly sat on `rock` directly):

1. **`edff94a` — @Rob1Ham's #319 validation** (authorship preserved): `eligibleInputKeys` now derives the public point from every supplied BIP-352 input private key and requires it to match the key extracted from that input (x-only comparison for taproot, so parity-equivalent scalars stay valid). Before this, a valid but unrelated scalar produced a plausible-looking silent payment output the receiver could never detect — a funds-loss path if funded.

2. **`6348fad` — the companion fix that validation forces**: the session-derived send flow (`hodlSpDeriveVinKeys`, #372) injected the *raw internal key* for P2TR inputs. BIP-352 requires *"the private key corresponding to the taproot output key (i.e. the tweaked private key)"*, and the receiver extracts the output key from the prevout — so a raw key computes a shared secret the recipient can never reproduce. Verified empirically before the fix: send produced 1 output, the recipient's scan found 0. `hodlSpDeriveVinKeys` now injects `taprootOutputPrivateKey(node)` (even-Y-adjusted, TapTweak-tagged BIP-341 key-path scalar) for P2TR inputs.

## Why one PR

The two are inseparable: with only the validation, the app's own taproot session send throws (the raw key fails the match check); with only the tweak, the library still accepts mismatched pasted scalars in vector mode. The temporary reverts on `rock` (`e4ce9c5`, `f527e2f`) document this and keep every pushed commit green.

## Tests

- New regression: send → scan roundtrip over the session's own *tweaked* P2TR output proves the recipient detects the output (`test/sp-send-session.test.mjs`).
- #319's negative test: a mismatched scalar is rejected (`test/bip352.test.mjs`).
- All 60 published BIP-352 vectors pass unchanged — every eligible taproot input in them has an output key equal to the raw key's x-only form, and the two mismatching vector-19 inputs are NUMS-point script-path spends, skipped as ineligible before the check.
- Full suite: `npm test` 1163 pass / 0 fail; `npm run build` + `verify` clean; browser suite 78/78 in Firefox and Chrome (the SP Station E2E self-payment included).