### PR TITLE
Hand SP sender keys around as zeroable bytes, and wipe them after use

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -9128,11 +9128,14 @@ function hodlRenderSpReceive() {
 }
 // Resolve every eligible vin's input key from the loaded SP session root —
 // never from a pasted scalar (issue #331). A vin may name its derivation
-// path explicitly ("path": "m/84'/1'/0'/0/5", plus an optional "fingerprint"
+// path explicitly ("path": "m/84'/1'/0'/0/0/5", plus an optional "fingerprint"
 // that must equal the session root's) or be resolved through the session
 // ownership index by its prevout script. Either way the derived key is
-// verified against the prevout script before use, and every derived node is
-// wiped after output construction.
+// verified against the prevout script before use, every derived node is
+// wiped immediately, and the scalar leaves here only as a zeroable byte copy
+// that the send flow wipes after output construction (hodlSpWipeVinKeys).
+// What no wipe can cover: the BigInt scalars the BIP-352 math materialises
+// are immutable JavaScript values and live until the GC takes them.
 function hodlSpDeriveVinKeys(vins) {
   hodlSpEnsureHd();
   const root = hodlSpHd, network = hodlSpNetwork(), fingerprint = hodlFingerprintHex(root.fingerprint);
@@ -9178,18 +9181,35 @@ function hodlSpDeriveVinKeys(vins) {
         throw new Error(`Input ${i}: the key derived at ${path} does not produce the prevout's scriptPubKey.`);
       }
       if (expected === null) throw new Error(`Input ${i}: unrecognized prevout script type.`);
-      return { ...vin, private_key: hodlSpBytesToHex(node.privateKey) };
+      // A zeroable byte copy, not a hex string: a string is immutable and
+      // would outlive the node wipe below (issue #331).
+      return { ...vin, private_key: new Uint8Array(node.privateKey) };
     } finally {
       if (node) node.wipePrivateData();
     }
   });
+}
+// Zeroes every derived input key hodlSpDeriveVinKeys attached. Called by the
+// send flow once output construction is done with them.
+function hodlSpWipeVinKeys(vins) {
+  for (const vin of vins) {
+    if (vin && vin.private_key instanceof Uint8Array) vin.private_key.fill(0);
+  }
 }
 function hodlRenderSpSend() {
   let parsed = hodlSpParseRecipients(document.getElementById("sp-recipients")?.value);
   let recipients = parsed.recipients;
   let hrp = hodlSpHrp(hodlSpNetwork());
   for (const recipient of recipients) decodeSilentPaymentAddress(recipient.address, hrp);
-  let result = createSilentPaymentOutputs(hodlSpDeriveVinKeys(hodlSpParseVins(document.getElementById("sp-send-vins")?.value)), recipients, { hrp });
+  // The derived per-input keys are wiped as soon as output construction is
+  // done with them, on the error path too (issue #331).
+  const keyedVins = hodlSpDeriveVinKeys(hodlSpParseVins(document.getElementById("sp-send-vins")?.value));
+  let result;
+  try {
+    result = createSilentPaymentOutputs(keyedVins, recipients, { hrp });
+  } finally {
+    hodlSpWipeVinKeys(keyedVins);
+  }
   if (!result.outputs.length) {
     document.getElementById("sp-out").innerHTML = `<p class="psbt-warn">No silent payment outputs. Eligible inputs may be missing, the private-key sum may be zero, or a scan-key group exceeded K<sub>max</sub> = 2323.</p>`;
     return;

--- a/test/sp-send-session.test.mjs
+++ b/test/sp-send-session.test.mjs
@@ -78,19 +78,37 @@ const setup = () => {
   globalThis.hodlSpBytesToHex = bytesToHex;
 };
 
+const hodlSpWipeVinKeys = new Function(`${loadSlice("hodlSpWipeVinKeys")}; return hodlSpWipeVinKeys;`)();
+
 test("an owned input resolves through the ownership index, and the derived key matches the prevout", () => {
   setup();
   const [resolved] = hodlSpDeriveVinKeys([vinOf(OWNED_SCRIPT)]);
-  assert.ok(resolved.private_key, "no key injected");
-  const pub = secp256k1.getPublicKey(hexToBytes_(resolved.private_key), true);
+  // The scalar is handed over as a zeroable byte copy, not an immutable hex
+  // string that would outlive the node wipe (issue #331).
+  assert.ok(resolved.private_key instanceof Uint8Array, "key must be zeroable bytes");
+  assert.equal(resolved.private_key.length, 32);
+  const pub = secp256k1.getPublicKey(resolved.private_key, true);
   // The derived key really does produce the prevout script (BIP-341 tweak).
   assert.equal(bytesToHex(p2trKeyScript(pub.slice(1))), OWNED_SCRIPT);
   // Same result via an explicit path.
   const [byPath] = hodlSpDeriveVinKeys([vinOf(OWNED_SCRIPT, { path: "m/86'/1'/0'/0/0" })]);
-  assert.equal(byPath.private_key, resolved.private_key);
+  assert.deepEqual(byPath.private_key, resolved.private_key);
   // And the fingerprint guard accepts the session's own fingerprint.
   const [byOrigin] = hodlSpDeriveVinKeys([vinOf(OWNED_SCRIPT, { path: "m/86'/1'/0'/0/0", fingerprint: "73c5da0a" })]);
-  assert.equal(byOrigin.private_key, resolved.private_key);
+  assert.deepEqual(byOrigin.private_key, resolved.private_key);
+});
+
+test("the send flow wipes the derived byte copies after output construction (issue #331)", () => {
+  setup();
+  const [resolved] = hodlSpDeriveVinKeys([vinOf(OWNED_SCRIPT)]);
+  assert.ok(resolved.private_key.some((byte) => byte !== 0));
+  hodlSpWipeVinKeys([resolved]);
+  assert.ok(resolved.private_key.every((byte) => byte === 0), "derived copy zeroed");
+  // Missing or non-byte keys are simply skipped.
+  hodlSpWipeVinKeys([{ private_key: "00".repeat(32) }, {}]);
+  // The wiring: construction runs inside try, the wipe in finally, so the
+  // error path wipes too.
+  assert.match(app, /try \{\s*result = createSilentPaymentOutputs\(keyedVins, recipients, \{ hrp \}\);\s*\} finally \{\s*hodlSpWipeVinKeys\(keyedVins\);\s*\}/);
 });
 
 test("session derivation refuses pasted scalars, foreign origins, and unowned scripts (issue #331)", () => {
@@ -123,7 +141,3 @@ test("the shell copy points at session-derived inputs, not pasted keys", () => {
   assert.doesNotMatch(shell, /Each eligible input needs its private key/);
   assert.match(shell, /derived from the loaded session key/);
 });
-
-function hexToBytes_(hex) {
-  return new Uint8Array(hex.match(/../g).map((b) => parseInt(b, 16)));
-}


### PR DESCRIPTION
## Problem

Follow-up to #331. `hodlSpDeriveVinKeys` verified and wiped the derived hdkey node — and simultaneously returned the same scalar as `private_key: hodlSpBytesToHex(node.privateKey)`, an immutable JS string that no `wipePrivateData()` can touch. The derive-verify-wipe story was therefore cosmetic for the scalar itself, and `eligibleInputKeys` (src/js/bip352.js) then materialised it again as `hexToBytes` output plus BigInt scalars.

## Change (src/js/app.js only)

- The derived key leaves the resolver as `new Uint8Array(node.privateKey)` — a zeroable copy made before the node wipe — instead of a hex string. (`eligibleInputKeys` accepts bytes, which also removes the `hexToBytes` re-materialisation.)
- `hodlRenderSpSend` runs `createSilentPaymentOutputs` inside `try/finally` so the new `hodlSpWipeVinKeys` zeroes every derived copy on the success and error paths alike.
- The resolver comment now states the residual honestly: the BigInt scalars inside the BIP-352 math are immutable JavaScript values and cannot be wiped; they live until GC. (The library keeps returning `inputPrivateKeySum` for the published-vector API; the UI flow never reads it.)

## Tests (test/sp-send-session.test.mjs)

- The resolver now must return 32-byte `Uint8Array` keys (deep-equal across the index/path/fingerprint resolution paths — the previous string-equality assertions are updated).
- New: `hodlSpWipeVinKeys` zeroes derived byte copies and skips non-byte entries; the `try { createSilentPaymentOutputs … } finally { hodlSpWipeVinKeys(keyedVins) }` wiring is pinned at source level.

## Ran

`npm run build`, `npm test` — green apart from two pre-existing headless-Firefox journal layout flakes ("Journal notepad…", "Journal embeds a Key Station LifeHash…") that fail intermittently in this environment on clean `rock` too and pass in isolated runs; neither touches the SP code paths changed here.