### PR TITLE
Blank the stale PSBT bytes, not just the export controls (issue #320)

### DIFF
--- a/src/js/psbt-editor.js
+++ b/src/js/psbt-editor.js
@@ -622,21 +622,23 @@ export const initPsbtEditor = ({ networkDefault = () => "mainnet" } = {}) => {
     const b64 = base64Encode(resultBytes);
     const hex = bytesToHex(resultBytes);
     box.classList.toggle("psbted-stale", stale);
-    // While the displayed fields do not build, the last valid bytes stay
-    // visible for reference but must not cross an export boundary: every
-    // copy/download/reload control and the QR are disabled (issue #320).
+    // While the displayed fields do not build, the last valid build must not
+    // cross an export boundary: every copy/download/reload control and the QR
+    // are disabled — and the byte text is blanked, because a disabled,
+    // readonly textarea's content is still selectable and copyable in Firefox
+    // (issue #320).
     const gated = stale ? " disabled" : "";
     box.innerHTML = `
       ${stale ? `<p class="psbted-note-warn" id="psbted-stale-note">The fields do not build right now — this is the last valid build. Export is unavailable until they build again.</p>` : ""}
       <p class="psbt-ok">Rebuilt PSBT parses under rust-bitcoin; its unsigned transaction passes consensus sanity checks (${resultBytes.length} bytes).</p>
-      <label class="field">Edited PSBT (base64)<textarea id="psbted-result-b64" readonly spellcheck="false"${gated}>${escapeHtml(b64)}</textarea></label>
+      <label class="field">Edited PSBT (base64)<textarea id="psbted-result-b64" readonly spellcheck="false"${gated}>${stale ? "" : escapeHtml(b64)}</textarea></label>
       <div class="row psbt-actions">
         <button class="btn secondary" id="psbted-copy-b64" type="button"${gated}>Copy base64</button>
         <button class="btn secondary" id="psbted-copy-hex" type="button"${gated}>Copy hex</button>
         <button class="btn secondary" id="psbted-download" type="button"${gated}>Download .psbt</button>
         <button class="btn secondary" id="psbted-reload" type="button"${gated}>Load edited PSBT into the editor</button>
       </div>
-      <label class="field">Edited PSBT (hex)<textarea id="psbted-result-hex" readonly spellcheck="false"${gated}>${escapeHtml(hex)}</textarea></label>
+      <label class="field">Edited PSBT (hex)<textarea id="psbted-result-hex" readonly spellcheck="false"${gated}>${stale ? "" : escapeHtml(hex)}</textarea></label>
       <div class="psbted-qr-block">
         <div class="qr psbted-qr" id="psbted-qr-code"></div>
         <p class="muted" id="psbted-qr-note">${stale ? "QR unavailable until the fields build again." : ""}</p>
@@ -686,10 +688,11 @@ export const initPsbtEditor = ({ networkDefault = () => "mainnet" } = {}) => {
   };
 
   // Marks the intact result panel as the last valid build — used when a
-  // keystroke left the fields in a state that does not build, so the text of
-  // the last good build stays visible instead of vanishing. The export
-  // controls and QR are disabled: stale bytes must not cross an export
-  // boundary while the fields say something else (issue #320).
+  // keystroke left the fields in a state that does not build. The export
+  // controls and QR are disabled and the byte text is blanked: stale bytes
+  // must not cross an export boundary while the fields say something else,
+  // and a disabled, readonly textarea's content is still selectable and
+  // copyable in Firefox, so disabling alone is not a boundary (issue #320).
   const markResultStale = () => {
     const box = document.getElementById("psbted-result");
     if (!box || !resultBytes) return;
@@ -699,6 +702,10 @@ export const initPsbtEditor = ({ networkDefault = () => "mainnet" } = {}) => {
     else box.insertAdjacentHTML("afterbegin", '<p class="psbted-note-warn" id="psbted-stale-note">The fields do not build right now — this is the last valid build. Export is unavailable until they build again.</p>');
     for (const id of ["psbted-copy-b64", "psbted-copy-hex", "psbted-download", "psbted-reload", "psbted-result-b64", "psbted-result-hex"]) {
       document.getElementById(id)?.setAttribute("disabled", "");
+    }
+    for (const id of ["psbted-result-b64", "psbted-result-hex"]) {
+      const area = document.getElementById(id);
+      if (area) area.value = "";
     }
     clearInterval(qrTimer);
     qrTimer = null;

--- a/src/js/psbt-editor.js
+++ b/src/js/psbt-editor.js
@@ -644,15 +644,26 @@ export const initPsbtEditor = ({ networkDefault = () => "mainnet" } = {}) => {
         <p class="muted" id="psbted-qr-note">${stale ? "QR unavailable until the fields build again." : ""}</p>
       </div>`;
     if (stale) return;
-    $("psbted-copy-b64").onclick = () => navigator.clipboard?.writeText(b64).catch(() => {});
-    $("psbted-copy-hex").onclick = () => navigator.clipboard?.writeText(hex).catch(() => {});
+    // Every handler re-checks stale: the keystroke path only disables these
+    // buttons, and a synthetic dispatchEvent still fires a disabled button's
+    // handlers, which close over the last valid build's bytes (issue #320).
+    $("psbted-copy-b64").onclick = () => {
+      if (stale) return;
+      navigator.clipboard?.writeText(b64).catch(() => {});
+    };
+    $("psbted-copy-hex").onclick = () => {
+      if (stale) return;
+      navigator.clipboard?.writeText(hex).catch(() => {});
+    };
     $("psbted-reload").onclick = () => {
+      if (stale) return;
       text.value = b64;
       loadFromText();
     };
     // The binary download round-trips with wallet software: Sparrow and
     // Coldcard read the .psbt file this produces.
     $("psbted-download").onclick = () => {
+      if (stale) return;
       const url = URL.createObjectURL(new Blob([resultBytes], { type: "application/octet-stream" }));
       const link = document.createElement("a");
       link.href = url;
@@ -705,7 +716,13 @@ export const initPsbtEditor = ({ networkDefault = () => "mainnet" } = {}) => {
     }
     for (const id of ["psbted-result-b64", "psbted-result-hex"]) {
       const area = document.getElementById(id);
-      if (area) area.value = "";
+      if (area) {
+        // value= alone leaves the bytes in the DOM text (textContent /
+        // defaultValue); both go, so no copy of the stale bytes stays in
+        // the document at all.
+        area.value = "";
+        area.textContent = "";
+      }
     }
     clearInterval(qrTimer);
     qrTimer = null;

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -2468,6 +2468,10 @@
     }
     assert(!document.querySelector("#psbted-qr-code svg"), "stale bytes still animated as QR");
     assert(outText().includes("last valid build"), "stale note missing");
+    // The byte text itself leaves the screen: a disabled, readonly textarea's
+    // content is still selectable and copyable in Firefox.
+    equal(document.getElementById("psbted-result-b64").value, "", "stale base64 stayed selectable on screen");
+    equal(document.getElementById("psbted-result-hex").value, "", "stale hex stayed selectable on screen");
     // Typing back to a buildable value re-enables every export control.
     input(document.querySelector("[data-txout-val='0']"), "199902000");
     await until(() => document.getElementById("psbted-error").textContent === "" && document.getElementById("psbted-result-b64").value.includes("cHNidP8B"), "rebuild after stale");

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -2472,6 +2472,21 @@
     // content is still selectable and copyable in Firefox.
     equal(document.getElementById("psbted-result-b64").value, "", "stale base64 stayed selectable on screen");
     equal(document.getElementById("psbted-result-hex").value, "", "stale hex stayed selectable on screen");
+    // Nor does the DOM keep a copy: value= alone leaves the bytes in the
+    // textarea's textContent/defaultValue.
+    equal(document.getElementById("psbted-result-b64").textContent, "", "stale base64 stayed in the DOM text");
+    equal(document.getElementById("psbted-result-hex").textContent, "", "stale hex stayed in the DOM text");
+    // Disabled only blocks user activation — a synthetic click still fires
+    // the retained handlers, and the stale guard must keep the bytes off
+    // the clipboard.
+    let copied = null;
+    const clipboard = navigator.clipboard;
+    const writeText = clipboard.writeText;
+    clipboard.writeText = (value) => { copied = value; return Promise.resolve(); };
+    document.getElementById("psbted-copy-b64").dispatchEvent(new MouseEvent("click"));
+    document.getElementById("psbted-copy-hex").dispatchEvent(new MouseEvent("click"));
+    clipboard.writeText = writeText;
+    equal(copied, null, "a synthetic click exported the stale bytes");
     // Typing back to a buildable value re-enables every export control.
     input(document.querySelector("[data-txout-val='0']"), "199902000");
     await until(() => document.getElementById("psbted-error").textContent === "" && document.getElementById("psbted-result-b64").value.includes("cHNidP8B"), "rebuild after stale");

--- a/test/psbt-live-qr.test.mjs
+++ b/test/psbt-live-qr.test.mjs
@@ -78,6 +78,12 @@ test("stale builds disable every export boundary, not just the styling (issue #3
   // The keystroke path applies the same gating to the already-rendered panel.
   assert.match(editor, /for \(const id of \["psbted-copy-b64", "psbted-copy-hex", "psbted-download", "psbted-reload", "psbted-result-b64", "psbted-result-hex"\]\)/);
   assert.match(editor, /qr\.removeAttribute\("aria-label"\)/);
+  // And the byte text itself leaves the screen in both paths: disabling is
+  // not a boundary, since Firefox lets a disabled, readonly textarea's
+  // content be selected and copied.
+  assert.match(editor, /\$\{stale \? "" : escapeHtml\(b64\)\}/);
+  assert.match(editor, /\$\{stale \? "" : escapeHtml\(hex\)\}/);
+  assert.match(editor, /area\.value = ""/);
 });
 
 test("the result panel renders the QR block and its animation plumbing", () => {

--- a/test/psbt-live-qr.test.mjs
+++ b/test/psbt-live-qr.test.mjs
@@ -84,6 +84,14 @@ test("stale builds disable every export boundary, not just the styling (issue #3
   assert.match(editor, /\$\{stale \? "" : escapeHtml\(b64\)\}/);
   assert.match(editor, /\$\{stale \? "" : escapeHtml\(hex\)\}/);
   assert.match(editor, /area\.value = ""/);
+  // value= alone leaves the bytes in the DOM: textContent (defaultValue)
+  // must go too, so no copy of the stale bytes stays in the document.
+  assert.match(editor, /area\.textContent = ""/);
+  // Disabled only blocks user activation — a synthetic dispatchEvent still
+  // fires a disabled button's handlers, so all four export handlers guard
+  // on stale themselves instead of trusting the attribute.
+  const guarded = editor.match(/\$\("psbted-(?:copy-b64|copy-hex|download|reload)"\)\.onclick = \(\) => \{\s*\n\s*if \(stale\) return;/g) || [];
+  assert.equal(guarded.length, 4, "every export handler must refuse to run while stale");
 });
 
 test("the result panel renders the QR block and its animation plumbing", () => {


### PR DESCRIPTION
## Problem

Follow-up to #320. While the editor fields do not build, the result panel shows the last valid build with every export control disabled — but the base64/hex textareas were left populated and merely `readonly` + `disabled`. That is not an export boundary: **Firefox lets a disabled, readonly textarea's content be selected and copied** (long-standing Gecko behaviour), so the stale bytes stayed one drag-and-copy away from leaving the page while the UI said export was unavailable.

## Change (src/js/psbt-editor.js)

- `renderResult`: while stale, both textareas render empty (`${stale ? "" : escapeHtml(b64)}` / hex) — the bytes never enter the DOM.
- `markResultStale` (the keystroke path, where the panel was rendered non-stale): blanks both textareas' live values alongside the existing disabling.
- A clean rebuild refills both as before; comments updated to say why disabling alone is insufficient.

## Tests

- test/psbt-live-qr.test.mjs: the existing #320 source-level case now also pins the two template blankings and the `area.value = ""` keystroke-path blanking. Verified it fails without the fix.
- test/browser-suite.html: the end-to-end stale-flow case (type an invalid value mid-edit) now asserts both textareas read empty while stale, ahead of the existing rebuild-and-recover assertions.

## Ran

`npm run build`, `npm test`, `npm run test:browser` — green apart from two pre-existing headless-Firefox journal layout flakes ("Journal notepad…", "Journal embeds a Key Station LifeHash…") that fail intermittently in this environment on clean `rock` too and pass in isolated runs; neither touches the editor.

## Note

This and the v2-verdict PR both touch `renderResult`; whichever merges second will see a trivial two-line conflict.