### PR TITLE
Count only parseable Schnorr signatures as present (issue #333)

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -9562,8 +9562,12 @@ function hodlRenderPsbt(psbt) {
       signatures = signatures.concat(finalMaterial.signatures);
       uninspected += finalMaterial.uninspected + (finalMaterial.malformed ? 1 : 0);
     }
-    tapSignatureCount += tapSignatures.length;
-    html.push("<p class='psbt-kv'><strong>Input " + index + "</strong> \xB7 " + hodlHexRev(previous.txid) + " : " + previous.vout + (claim ? " \xB7 " + hodlSats(claim.amount) + " BTC claimed" : "") + "<br>" + hodlEscapeHtml(destination) + "<br>" + (signatures.length + tapSignatures.length ? signatures.length + tapSignatures.length + " signature(s) present" : finalized ? "Finalized input data present" : "Not signed yet") + (declaredSighashError ? "<br>Declared sighash policy unreadable: " + hodlEscapeHtml(declaredSighashError) : "<br>Signature policy: " + hodlEscapeHtml(declaredLabel)) + "</p>");
+    // Only a Schnorr signature that parses under BIP341 counts as present: an
+    // unparseable one is flagged as a policy problem below, not silently
+    // counted (issue #333).
+    let parsedTapSignatures = tapSignatures.reduce((count, tapSig) => count + (tapSig.r ? 1 : 0), 0);
+    tapSignatureCount += parsedTapSignatures;
+    html.push("<p class='psbt-kv'><strong>Input " + index + "</strong> \xB7 " + hodlHexRev(previous.txid) + " : " + previous.vout + (claim ? " \xB7 " + hodlSats(claim.amount) + " BTC claimed" : "") + "<br>" + hodlEscapeHtml(destination) + "<br>" + (signatures.length + parsedTapSignatures ? signatures.length + parsedTapSignatures + " signature(s) present" : finalized ? "Finalized input data present" : "Not signed yet") + (declaredSighashError ? "<br>Declared sighash policy unreadable: " + hodlEscapeHtml(declaredSighashError) : "<br>Signature policy: " + hodlEscapeHtml(declaredLabel)) + "</p>");
     if (claimConflict) html.push("<p class='psbt-bad'><strong>Conflicting previous-output claims:</strong> input " + index + " declares " + hodlSats(witnessUtxo.amount) + " BTC in its witness UTXO but " + hodlSats(nonWitnessUtxo.amount) + " BTC in its non-witness UTXO (checked against the embedded previous transaction). Neither amount is trusted and the fee is left unknown.</p>");
     if (nonWitnessError) html.push("<p class='psbt-bad'><strong>Non-witness UTXO problem:</strong> input " + index + ": " + hodlEscapeHtml(nonWitnessError) + " That field claims nothing.</p>");
     let inputEnvelopes = (inscriptionReport.inputs[index] && inscriptionReport.inputs[index].envelopes) || [];

--- a/test/psbt-schnorr-nonce.test.mjs
+++ b/test/psbt-schnorr-nonce.test.mjs
@@ -1,6 +1,11 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { hodlLooksSchnorr, hodlParseSchnorr, hodlTapSighashProblems, hodlCompareSchnorrNonces, hodlTapKeySigs, hodlTapScriptSigs } from "../src/js/psbt-schnorr.js";
+
+const root = dirname(fileURLToPath(import.meta.url));
 
 const eq = (a, b) => a.length === b.length && a.every((x, i) => x === b[i]);
 const rA = new Uint8Array(32).fill(0x11);
@@ -132,4 +137,23 @@ test("nonce compare ignores same-input pairs, key mismatches, and missing r valu
   ], eq);
   assert.equal(flagged.possible.length, 3, "every cross-input pair of the shared R is reported");
   assert.deepEqual(flagged.reused, [], "definite proof is left to the ECDSA comparison");
+});
+
+test("the report counts only parseable Schnorr signatures as present (issue #333)", () => {
+  // Unparseable values stay in the collection (with r null) so the policy
+  // analysis can flag them…
+  const keys = hodlTapKeySigs([
+    { type: 19, keydata: new Uint8Array(), val: new Uint8Array(64) },
+    { type: 19, keydata: new Uint8Array(), val: new Uint8Array(10) },
+  ], (e, t) => e.filter((x) => x.type === t));
+  assert.equal(keys.length, 2);
+  assert.equal(keys.filter((sig) => sig.r).length, 1, "exactly one parses under BIP341");
+  // …but the inspector's count lines run on the parseable subset: the
+  // per-input "signature(s) present" line and the Taproot total both use the
+  // parsed count, and the unparseable entry only shows in the policy problem.
+  const app = readFileSync(join(root, "..", "src/js/app.js"), "utf8");
+  assert.match(app, /let parsedTapSignatures = tapSignatures\.reduce/);
+  assert.match(app, /tapSignatureCount \+= parsedTapSignatures/);
+  assert.match(app, /signatures\.length \+ parsedTapSignatures \? signatures\.length \+ parsedTapSignatures \+ " signature\(s\) present"/);
+  assert.doesNotMatch(app, /tapSignatureCount \+= tapSignatures\.length/);
 });


### PR DESCRIPTION
## Problem

Follow-up to #333. The parser deliberately keeps unparseable Schnorr values in `tapSignatures` (with `r: null`) so the policy loop can flag them — "an unparseable Schnorr signature is flagged, not silently counted" (app.js). But the count lines ran on the raw collection length:

- the per-input header: `signatures.length + tapSignatures.length + " signature(s) present"`;
- the totals: `tapSignatureCount += tapSignatures.length`, feeding "This PSBT also contains N Taproot / Schnorr signature(s)" and the nonce-analysis completeness gate.

A 32-byte garbage value in a `PSBT_IN_TAP_KEY_SIG` field was thus counted as a present signature *and* flagged as "not valid under BIP341" — the count line contradicted the warning.

## Change (src/js/app.js)

Both count sites now run on the parseable subset: `parsedTapSignatures = tapSignatures.reduce((count, tapSig) => count + (tapSig.r ? 1 : 0), 0)`. An input whose only Taproot sig is unparseable now reads "Not signed yet" plus the policy problem, instead of "1 signature(s) present" plus the policy problem. The unparseable entry still feeds the incomplete-policy verdict through the existing `uninspected` path; `policyIncomplete` handling is untouched.

## Tests (test/psbt-schnorr-nonce.test.mjs)

- Unit: a 64-byte and a 10-byte `PSBT_IN_TAP_KEY_SIG` together — the collection keeps both records, exactly one has `r`.
- Source-level: the two count sites are pinned to `parsedTapSignatures`, and the old `tapSignatureCount += tapSignatures.length` form is asserted gone. Verified the test fails without the fix.

## Ran

`npm run build`, `npm test` — green apart from two pre-existing headless-Firefox journal layout flakes ("Journal notepad…", "Journal embeds a Key Station LifeHash…") that fail intermittently in this environment (clean `rock` included) and pass in isolated runs; neither touches the PSBT report.