### PR TITLE
fix: tweak P2TR Silent Payment sender keys so the recipient can scan

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -70,6 +70,12 @@ material. Its security posture rests on the following model:
 - Wallet security depends on the quality and secrecy of the entropy, seed
   phrase, passphrase, or private key supplied by the user, and on the
   integrity of the machine it runs on.
+- Silent Payment sender inputs use BIP-341 tweaked output-key scalars for
+  P2TR key-path spends. Session-derived sender keys are handed over as byte
+  buffers and wiped on success, construction failure, and partial resolution
+  failure. The UI suppresses the vector API's private-key-sum diagnostic.
+  Immutable BigInts and internal curve-library representations still depend
+  on garbage collection; this is best-effort cleanup, not guaranteed erasure.
 - Silent Payments (BIP-352) support is a calculator: it derives reusable
   addresses, sender outputs, and spend tweaks from user-supplied keys and
   pasted transaction data. It does not connect to a node, Electrum server, or

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -9142,69 +9142,91 @@ function hodlRenderSpReceive() {
 // path explicitly ("path": "m/84'/1'/0'/0/5", plus an optional "fingerprint"
 // that must equal the session root's) or be resolved through the session
 // ownership index by its prevout script. Either way the derived key is
-// verified against the prevout script before use, and every derived node is
-// wiped after output construction.
+// verified against the prevout script before use. Nodes are wiped immediately;
+// returned byte copies are wiped after sending or any partial-resolution failure.
+// BIP-352 BigInts remain immutable, GC-managed values: this is not full erasure.
 function hodlSpDeriveVinKeys(vins) {
   hodlSpEnsureHd();
   const root = hodlSpHd, network = hodlSpNetwork(), fingerprint = hodlFingerprintHex(root.fingerprint);
   let index = null;
-  return vins.map((vin, i) => {
-    // The published BIP-352 vectors carry raw per-input scalars; the UI flow
-    // derives from the session instead. (The library function keeps vector
-    // support for the test suite.)
-    if (vin && typeof vin === "object" && "private_key" in vin) {
-      throw new Error(`Input ${i} carries a "private_key" field. The send flow derives each input's key from the loaded session — remove it (that field exists for the published BIP-352 test vectors).`);
-    }
-    // Only inputs of the eligible script types take part; anything else is
-    // skipped by the sender and needs no key.
-    const extracted = extractInputPubKey(vin);
-    if (!extracted) return vin;
-    if (vin.fingerprint !== undefined && String(vin.fingerprint).toLowerCase().replace(/^0x/, "") !== fingerprint) {
-      throw new Error(`Input ${i}: origin fingerprint ${vin.fingerprint} is not this session's ${fingerprint}.`);
-    }
-    let path = typeof vin.path === "string" && vin.path.trim() ? vin.path.trim() : null;
-    if (!path) {
-      if (!index) index = indexHdKey(root, network);
-      const hit = matchOwnership(index, vinPrevoutScript(vin));
-      if (hit.state !== "ours") {
-        throw new Error(`Input ${i}: the prevout script was not found under this session's keys. Add a "path" field (e.g. "m/84'/…") to name the input's derivation path.`);
+  const derived = [];
+  let complete = false;
+  try {
+    const resolved = vins.map((vin, i) => {
+      // The published BIP-352 vectors carry raw per-input scalars; the UI flow
+      // derives from the session instead. (The library function keeps vector
+      // support for the test suite.)
+      if (vin && typeof vin === "object" && "private_key" in vin) {
+        throw new Error(`Input ${i} carries a "private_key" field. The send flow derives each input's key from the loaded session — remove it (that field exists for the published BIP-352 test vectors).`);
       }
-      path = hit.path;
-    }
-    if (!/^m(\/|$)/.test(path)) throw new Error(`Input ${i}: path must start at the session root ("m/…").`);
-    let node = null;
-    try {
-      node = root.derive(path);
-      if (!node.privateKey) throw new Error(`Input ${i}: path ${path} names a watch-only node.`);
-      // The derived key must actually produce the prevout script — the "lie"
-      // check, including the BIP-341 tweak for P2TR inputs.
-      const scriptBytes = vinPrevoutScript(vin);
-      const pubkey = node.publicKey;
-      let expected = null;
-      if (isP2pkh(scriptBytes)) expected = p2pkhScript(pubkey);
-      else if (isP2wpkh(scriptBytes)) expected = p2wpkhScript(pubkey);
-      else if (isP2sh(scriptBytes)) expected = p2shP2wpkhScript(pubkey);
-      else if (isP2tr(scriptBytes)) expected = p2trKeyScript(pubkey.slice(1));
-      if (expected && hodlSpBytesToHex(expected) !== hodlSpBytesToHex(scriptBytes)) {
-        throw new Error(`Input ${i}: the key derived at ${path} does not produce the prevout's scriptPubKey.`);
+      // Only inputs of the eligible script types take part; anything else is
+      // skipped by the sender and needs no key.
+      const extracted = extractInputPubKey(vin);
+      if (!extracted) return vin;
+      if (vin.fingerprint !== undefined && String(vin.fingerprint).toLowerCase().replace(/^0x/, "") !== fingerprint) {
+        throw new Error(`Input ${i}: origin fingerprint ${vin.fingerprint} is not this session's ${fingerprint}.`);
       }
-      if (expected === null) throw new Error(`Input ${i}: unrecognized prevout script type.`);
-      // BIP-352 spends a taproot input with the key of its output key, so the
-      // P2TR case injects the BIP-341-tweaked scalar; anything less would
-      // produce outputs the recipient can never detect.
-      const privateKey = isP2tr(scriptBytes) ? taprootOutputPrivateKey(node.privateKey) : node.privateKey;
-      return { ...vin, private_key: hodlSpBytesToHex(privateKey) };
-    } finally {
-      if (node) node.wipePrivateData();
-    }
-  });
+      let path = typeof vin.path === "string" && vin.path.trim() ? vin.path.trim() : null;
+      if (!path) {
+        if (!index) index = indexHdKey(root, network);
+        const hit = matchOwnership(index, vinPrevoutScript(vin));
+        if (hit.state !== "ours") {
+          throw new Error(`Input ${i}: the prevout script was not found under this session's keys. Add a "path" field (e.g. "m/84'/…") to name the input's derivation path.`);
+        }
+        path = hit.path;
+      }
+      if (!/^m(\/|$)/.test(path)) throw new Error(`Input ${i}: path must start at the session root ("m/…").`);
+      let node = null;
+      try {
+        node = root.derive(path);
+        if (!node.privateKey) throw new Error(`Input ${i}: path ${path} names a watch-only node.`);
+        // The derived key must actually produce the prevout script — the "lie"
+        // check, including the BIP-341 tweak for P2TR inputs.
+        const scriptBytes = vinPrevoutScript(vin);
+        const pubkey = node.publicKey;
+        let expected = null;
+        if (isP2pkh(scriptBytes)) expected = p2pkhScript(pubkey);
+        else if (isP2wpkh(scriptBytes)) expected = p2wpkhScript(pubkey);
+        else if (isP2sh(scriptBytes)) expected = p2shP2wpkhScript(pubkey);
+        else if (isP2tr(scriptBytes)) expected = p2trKeyScript(pubkey.slice(1));
+        if (expected && hodlSpBytesToHex(expected) !== hodlSpBytesToHex(scriptBytes)) {
+          throw new Error(`Input ${i}: the key derived at ${path} does not produce the prevout's scriptPubKey.`);
+        }
+        if (expected === null) throw new Error(`Input ${i}: unrecognized prevout script type.`);
+        // BIP-352 spends a taproot input with the key of its output key, so the
+        // P2TR case injects the BIP-341-tweaked scalar; anything less would
+        // produce outputs the recipient can never detect.
+        const privateKey = isP2tr(scriptBytes) ? taprootOutputPrivateKey(node.privateKey) : new Uint8Array(node.privateKey);
+        const resolved = { ...vin, private_key: privateKey };
+        derived.push(resolved);
+        return resolved;
+      } finally {
+        if (node) node.wipePrivateData();
+      }
+    });
+    complete = true;
+    return resolved;
+  } finally {
+    if (!complete) hodlSpWipeVinKeys(derived);
+  }
+}
+function hodlSpWipeVinKeys(vins) {
+  for (const vin of vins) {
+    if (vin?.private_key instanceof Uint8Array) vin.private_key.fill(0);
+  }
 }
 function hodlRenderSpSend() {
   let parsed = hodlSpParseRecipients(document.getElementById("sp-recipients")?.value);
   let recipients = parsed.recipients;
   let hrp = hodlSpHrp(hodlSpNetwork());
   for (const recipient of recipients) decodeSilentPaymentAddress(recipient.address, hrp);
-  let result = createSilentPaymentOutputs(hodlSpDeriveVinKeys(hodlSpParseVins(document.getElementById("sp-send-vins")?.value)), recipients, { hrp });
+  let keyedVins = [], result;
+  try {
+    keyedVins = hodlSpDeriveVinKeys(hodlSpParseVins(document.getElementById("sp-send-vins")?.value));
+    result = createSilentPaymentOutputs(keyedVins, recipients, { hrp, includePrivateKeySum: false });
+  } finally {
+    hodlSpWipeVinKeys(keyedVins);
+  }
   if (!result.outputs.length) {
     document.getElementById("sp-out").innerHTML = `<p class="psbt-warn">No silent payment outputs. Eligible inputs may be missing, the private-key sum may be zero, or a scan-key group exceeded K<sub>max</sub> = 2323.</p>`;
     return;

--- a/src/js/bip352.js
+++ b/src/js/bip352.js
@@ -24,12 +24,26 @@ const hexToBytes = (hex) => {
   return out;
 };
 const bytesToHex = (bytes) => [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
-const bytesToBig = (bytes) => BigInt("0x" + bytesToHex(bytes));
+// Avoid immutable hex intermediates for sender scalars. BigInts themselves
+// cannot be wiped; callers must still erase the byte buffers they own.
+const bytesToBig = (bytes) => {
+  let value = 0n;
+  for (const byte of bytes) value = (value << 8n) | BigInt(byte);
+  return value;
+};
 const bigToBytes32 = (value) => {
-  if (value < 0n) throw new Error("Negative scalar.");
-  const hex = value.toString(16).padStart(64, "0");
-  if (hex.length > 64) throw new Error("Scalar does not fit in 32 bytes.");
-  return hexToBytes(hex);
+  if (value < 0n || value >= (1n << 256n)) throw new Error("Scalar does not fit in 32 bytes.");
+  const bytes = new Uint8Array(32);
+  for (let i = 31; i >= 0; i--) {
+    bytes[i] = Number(value & 255n);
+    value >>= 8n;
+  }
+  return bytes;
+};
+const publicKeyForScalar = (scalar) => {
+  const bytes = bigToBytes32(scalar);
+  try { return secp256k1.getPublicKey(bytes, true); }
+  finally { bytes.fill(0); }
 };
 const equalBytes = (a, b) => {
   if (a.length !== b.length) return false;
@@ -376,9 +390,14 @@ const normalizeVin = (vin) => ({
 // produces outputs the recipient can never detect.
 export function taprootOutputPrivateKey(secret) {
   const internal = scalarFromBytes(secret instanceof Uint8Array ? secret : hexToBytes(secret));
-  const even = pointHasEvenY(Point.fromBytes(secp256k1.getPublicKey(bigToBytes32(internal), true))) ? internal : ORDER - internal;
-  const xonly = pointToXOnly(Point.fromBytes(secp256k1.getPublicKey(bigToBytes32(even), true)));
-  const tweak = scalarFromBytes(taggedHash("TapTweak", xonly));
+  const even = pointHasEvenY(Point.fromBytes(publicKeyForScalar(internal))) ? internal : ORDER - internal;
+  const xonly = pointToXOnly(Point.fromBytes(publicKeyForScalar(even)));
+  // BIP-341 permits a zero tweak, but not a hash >= the group order.
+  const tweakBytes = taggedHash("TapTweak", xonly);
+  let tweak;
+  try { tweak = bytesToBig(tweakBytes); }
+  finally { tweakBytes.fill(0); }
+  if (tweak >= ORDER) throw new Error("Taproot key-path tweak is out of range.");
   const output = (even + tweak) % ORDER;
   if (output === 0n) throw new Error("Taproot key-path tweak produced an invalid key.");
   return bigToBytes32(output);
@@ -394,7 +413,7 @@ export function eligibleInputKeys(vins) {
     pubkeys.push(extracted);
     if (vin.private_key) {
       const scalar = scalarFromBytes(typeof vin.private_key === "string" ? hexToBytes(vin.private_key) : vin.private_key);
-      const suppliedPoint = Point.fromBytes(secp256k1.getPublicKey(bigToBytes32(scalar), true));
+      const suppliedPoint = Point.fromBytes(publicKeyForScalar(scalar));
       const matches = extracted.isTaproot
         ? equalBytes(pointToXOnly(suppliedPoint), pointToXOnly(extracted.point))
         : equalBytes(pointToCompressed(suppliedPoint), pointToCompressed(extracted.point));
@@ -408,7 +427,8 @@ export function eligibleInputKeys(vins) {
   return { pubkeys, privkeys };
 }
 
-export function createSilentPaymentOutputs(vins, recipients, { hrp = "sp" } = {}) {
+// The UI opts out of the vector API's secret scalar-sum diagnostic.
+export function createSilentPaymentOutputs(vins, recipients, { hrp = "sp", includePrivateKeySum = true } = {}) {
   if (vins.some((vin) => isFutureSegwit(vinPrevoutScript(vin)))) {
     throw new Error("BIP-352 v0 cannot send with an input that spends a future SegWit version.");
   }
@@ -418,7 +438,7 @@ export function createSilentPaymentOutputs(vins, recipients, { hrp = "sp" } = {}
   const negated = privkeys.map(({ scalar, isTaproot }) => {
     let k = scalar;
     if (isTaproot) {
-      const pub = Point.fromBytes(secp256k1.getPublicKey(bigToBytes32(k), true));
+      const pub = Point.fromBytes(publicKeyForScalar(k));
       if (!pointHasEvenY(pub)) k = ORDER - k;
     }
     return k;
@@ -429,7 +449,7 @@ export function createSilentPaymentOutputs(vins, recipients, { hrp = "sp" } = {}
     return {
       outputs: [],
       inputPubKeys: pubkeys.map((entry) => bytesToHex(pointToCompressed(entry.point))),
-      inputPrivateKeySum: "0".repeat(64),
+      inputPrivateKeySum: includePrivateKeySum ? "0".repeat(64) : null,
       sharedSecrets: [],
     };
   }
@@ -458,7 +478,7 @@ export function createSilentPaymentOutputs(vins, recipients, { hrp = "sp" } = {}
     return {
       outputs: [],
       inputPubKeys: pubkeys.map((entry) => bytesToHex(pointToCompressed(entry.point))),
-      inputPrivateKeySum: bytesToHex(bigToBytes32(aSum)),
+      inputPrivateKeySum: includePrivateKeySum ? bytesToHex(bigToBytes32(aSum)) : null,
       sharedSecrets: null,
     };
   }
@@ -490,7 +510,7 @@ export function createSilentPaymentOutputs(vins, recipients, { hrp = "sp" } = {}
     // list is returned as-is and never deduplicated (issue #332).
     outputs,
     inputPubKeys: pubkeys.map((entry) => bytesToHex(pointToCompressed(entry.point))),
-    inputPrivateKeySum: bytesToHex(bigToBytes32(aSum)),
+    inputPrivateKeySum: includePrivateKeySum ? bytesToHex(bigToBytes32(aSum)) : null,
     sharedSecrets,
   };
 }
@@ -568,7 +588,7 @@ export function spendPrivForOutput(spendPriv, tweak) {
   const t = tweak instanceof Uint8Array ? scalarFromBytes(tweak) : typeof tweak === "string" ? scalarFromBytes(hexToBytes(tweak)) : tweak;
   let full = (spend + t) % ORDER;
   if (full === 0n) throw new Error("Spend key + tweak is zero.");
-  const pub = Point.fromBytes(secp256k1.getPublicKey(bigToBytes32(full), true));
+  const pub = Point.fromBytes(publicKeyForScalar(full));
   if (!pointHasEvenY(pub)) full = ORDER - full;
   return bigToBytes32(full);
 }

--- a/test/sp-send-session.test.mjs
+++ b/test/sp-send-session.test.mjs
@@ -23,6 +23,7 @@ import {
   isP2wpkh,
   scanSilentPaymentOutputs,
   taprootOutputPrivateKey,
+  spendPrivForOutput,
   vinPrevoutScript,
   bytesToHex,
 } from "../src/js/bip352.js";
@@ -52,18 +53,20 @@ const SESSION = HDKey.fromMasterSeed(SEED); // fingerprint 73c5da0a
 const OWNED_SCRIPT = "51203b82b2b2a9185315da6f80da5f06d0440d8a5e1457fa93387c2d919c86ec8786";
 
 // Drive the app's resolver with the module globals it reads faked in.
-const hodlSpDeriveVinKeys = new Function(
+const makeResolver = (tweak = taprootOutputPrivateKey) => new Function(
   "indexHdKey", "matchOwnership", "extractInputPubKey", "vinPrevoutScript",
   "isP2pkh", "isP2sh", "isP2tr", "isP2wpkh",
   "p2pkhScript", "p2shP2wpkhScript", "p2trKeyScript", "p2wpkhScript",
   "taprootOutputPrivateKey",
-  `${loadSlice("hodlFingerprintHex")}; ${loadSlice("hodlSpDeriveVinKeys")}; return hodlSpDeriveVinKeys;`,
+  `${loadSlice("hodlFingerprintHex")}; ${loadSlice("hodlSpWipeVinKeys")}; ${loadSlice("hodlSpDeriveVinKeys")}; return hodlSpDeriveVinKeys;`,
 )(
   indexHdKey, matchOwnership, extractInputPubKey, vinPrevoutScript,
   isP2pkh, isP2sh, isP2tr, isP2wpkh,
   p2pkhScript, p2shP2wpkhScript, p2trKeyScript, p2wpkhScript,
-  taprootOutputPrivateKey,
+  tweak,
 );
+const hodlSpDeriveVinKeys = makeResolver();
+const hodlSpWipeVinKeys = new Function(`${loadSlice("hodlSpWipeVinKeys")}; return hodlSpWipeVinKeys;`)();
 
 const vinOf = (scriptHex, extra = {}) => ({
   txid: "00".repeat(32),
@@ -85,18 +88,19 @@ const setup = () => {
 test("an owned input resolves through the ownership index, and the derived key matches the prevout", () => {
   setup();
   const [resolved] = hodlSpDeriveVinKeys([vinOf(OWNED_SCRIPT)]);
-  assert.ok(resolved.private_key, "no key injected");
-  const pub = secp256k1.getPublicKey(hexToBytes_(resolved.private_key), true);
+  assert.ok(resolved.private_key instanceof Uint8Array);
+  assert.equal(resolved.private_key.length, 32);
+  const pub = secp256k1.getPublicKey(resolved.private_key, true);
   // The injected key is the key of the taproot OUTPUT key (BIP-341 tweaked,
   // as BIP-352 sending requires): its x-only public key is the prevout
   // program itself, which is what the recipient extracts from the input.
   assert.equal(bytesToHex(pub.slice(1)), OWNED_SCRIPT.slice(4));
   // Same result via an explicit path.
   const [byPath] = hodlSpDeriveVinKeys([vinOf(OWNED_SCRIPT, { path: "m/86'/1'/0'/0/0" })]);
-  assert.equal(byPath.private_key, resolved.private_key);
+  assert.deepEqual(byPath.private_key, resolved.private_key);
   // And the fingerprint guard accepts the session's own fingerprint.
   const [byOrigin] = hodlSpDeriveVinKeys([vinOf(OWNED_SCRIPT, { path: "m/86'/1'/0'/0/0", fingerprint: "73c5da0a" })]);
-  assert.equal(byOrigin.private_key, resolved.private_key);
+  assert.deepEqual(byOrigin.private_key, resolved.private_key);
 });
 
 test("session derivation refuses pasted scalars, foreign origins, and unowned scripts (issue #331)", () => {
@@ -135,11 +139,24 @@ test("a session send spending a tweaked P2TR input is detectable by the recipien
   const scan = scanSilentPaymentOutputs({
     scanPriv: keys.scanPriv,
     spendPub: keys.spendPoint,
-    vins: [resolved],
+    vins: [vinOf(OWNED_SCRIPT)],
     outputs: send.outputs,
     labels: [],
   });
   assert.equal(scan.outputs.length, 1, "the recipient cannot detect the output: the input key is not the output key's");
+  const spend = spendPrivForOutput(keys.spendPriv, scan.outputs[0].priv_key_tweak);
+  try { assert.equal(bytesToHex(secp256k1.getPublicKey(spend, true).slice(1)), send.outputs[0]); }
+  finally { spend.fill(0); hodlSpWipeVinKeys([resolved]); }
+  // Current rock already rejects the old untweaked input. Keep that guard;
+  // a pre-guard sender would use the internal public key in its ECDH sum.
+  const node = SESSION.derive("m/86'/1'/0'/0/0");
+  try {
+    assert.throws(() => createSilentPaymentOutputs([vinOf(OWNED_SCRIPT, {private_key: node.privateKey})], [{address: recipient}], {hrp:"tsp"}), /does not match/);
+    // Emulate the old sender's internal-key ECDH via a synthetic internal-key
+    // prevout; scan against the REAL tweaked prevout, which must find nothing.
+    const old = createSilentPaymentOutputs([vinOf("5120" + bytesToHex(node.publicKey.slice(1)), {private_key: node.privateKey})], [{address: recipient}], {hrp:"tsp"});
+    assert.equal(scanSilentPaymentOutputs({scanPriv:keys.scanPriv, spendPub:keys.spendPoint, vins:[vinOf(OWNED_SCRIPT)], outputs:old.outputs}).outputs.length, 0);
+  } finally { node.wipePrivateData(); }
 });
 
 // The library keeps raw private_key support for the published BIP-352
@@ -150,6 +167,72 @@ test("the shell copy points at session-derived inputs, not pasted keys", () => {
   assert.match(shell, /derived from the loaded session key/);
 });
 
-function hexToBytes_(hex) {
-  return new Uint8Array(hex.match(/../g).map((b) => parseInt(b, 16)));
-}
+
+
+test("partial resolution wipes earlier copies and leaves the session usable", () => {
+  setup(); const copies=[];
+  const resolve=makeResolver(key=>{const copy=taprootOutputPrivateKey(key);copies.push(copy);return copy;});
+  assert.throws(()=>resolve([vinOf(OWNED_SCRIPT),vinOf(OWNED_SCRIPT,{fingerprint:"deadbeef"})]),/not this session/);
+  assert.equal(copies.length,1);
+  assert.ok(copies[0].every(b=>b===0));
+  const resolved=resolve([vinOf(OWNED_SCRIPT)]);
+  assert.ok(resolved[0].private_key.some(b=>b!==0));
+  hodlSpWipeVinKeys(resolved);
+  assert.ok(copies.every(copy=>copy.every(b=>b===0)));
+});
+
+test("UI construction wipes byte keys on success and throw, and suppresses the scalar sum", () => {
+  setup();
+  for(const fail of [false,true]){
+    let saved;
+    const render=new Function("hodlSpParseRecipients","hodlSpHrp","decodeSilentPaymentAddress","hodlSpParseVins","hodlSpDeriveVinKeys","hodlSpWipeVinKeys","createSilentPaymentOutputs",
+      `${loadSlice("hodlRenderSpSend")}; return hodlRenderSpSend;`)(
+      ()=>({recipients:[]}),()=>"tsp",()=>{},()=>[vinOf(OWNED_SCRIPT)],hodlSpDeriveVinKeys,hodlSpWipeVinKeys,
+      (vins,recipients,options)=>{saved=vins;assert.equal(options.includePrivateKeySum,false);if(fail)throw new Error("construction failed");return {outputs:[]};});
+    const original=document.getElementById;document.getElementById=id=>id==="sp-out"?{}:original(id);
+    if(fail)assert.throws(render,/construction failed/);else render();
+    assert.ok(saved[0].private_key.every(b=>b===0));
+  }
+});
+
+test("non-Taproot session scalars retain their exact bytes", () => {
+  setup();
+  const path="m/84'/1'/0'/0/0", node=SESSION.derive(path), pub=node.publicKey;
+  try {
+    for(const [script,scriptSig,witness] of [
+      [p2pkhScript(pub),"21"+bytesToHex(pub),""],
+      [p2wpkhScript(pub),"","0121"+bytesToHex(pub)],
+      [p2shP2wpkhScript(pub),"16"+bytesToHex(p2wpkhScript(pub)),"0121"+bytesToHex(pub)],
+    ]){
+      const vins=hodlSpDeriveVinKeys([vinOf(bytesToHex(script),{path,scriptSig,txinwitness:witness})]);
+      assert.deepEqual(vins[0].private_key,node.privateKey);
+      hodlSpWipeVinKeys(vins);
+    }
+  } finally {node.wipePrivateData();}
+});
+
+test("UI send mode never returns the private scalar sum", () => {
+  setup();const vins=hodlSpDeriveVinKeys([vinOf(OWNED_SCRIPT)]);
+  const keys=deriveSilentPaymentKeys(SEED,{coinType:1});const address=encodeSilentPaymentAddress(keys.scanPoint,keys.spendPoint,"tsp");
+  try{
+    for(const count of [1,2324]){
+      const result=createSilentPaymentOutputs(vins,[{address,count}],{hrp:"tsp",includePrivateKeySum:false});
+      assert.equal(result.inputPrivateKeySum,null);
+    }
+  }finally{hodlSpWipeVinKeys(vins);}
+});
+
+test("P2TR tweak matches BIP-86 output scripts for both internal parities", () => {
+  const parities = new Set();
+  for (const n of [1, 6]) {
+    const secret = new Uint8Array(32); secret[31] = n;
+    const pub = secp256k1.getPublicKey(secret, true);
+    parities.add(pub[0]);
+    const tweaked = taprootOutputPrivateKey(secret);
+    try {
+      assert.equal(bytesToHex(secp256k1.getPublicKey(tweaked, true).slice(1)), bytesToHex(p2trKeyScript(pub.slice(1))).slice(4));
+      assert.equal(secret[31], n, "tweaking must not mutate the caller's key");
+    } finally { secret.fill(0); tweaked.fill(0); }
+  }
+  assert.deepEqual([...parities].sort(), [2, 3]);
+});


### PR DESCRIPTION
Session-derived Silent Payment sends now inject the BIP-341 tweaked P2TR output-key scalar, not the internal key, so the recipient can scan and spend. Keys stay as byte buffers and are wiped on success, construction failure, and partial resolution failure. The UI does not print the vector API private-key-sum diagnostic.

Tests cover recipient scan, spend, both internal parities, non-Taproot byte identity, wipe on partial failure, and suppression of the scalar sum.

Rock already rejected an untweaked P2TR private_key against a tweaked prevout. This keeps that guard and adds the scan/spend path plus cleanup.

Closes #331 only if CI shows the recipient-scan test passing.