### PR TITLE
Fix remaining mobile derive overflow

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -626,7 +626,7 @@ details.lab-entropy .wallet-result-messages { margin-top: var(--space-control); 
 .table-private-field-value { display: inline-grid; white-space: nowrap; }
 .private-field-value:not(.secret-placeholder),
 .table-private-field-value:not(.secret-placeholder) { color: var(--blue); }
-.secret-placeholder { display: grid; min-width: 0; max-width: 100%; color: var(--muted); }
+.secret-placeholder { position: relative; display: grid; min-width: 0; max-width: 100%; color: var(--muted); }
 .secret-placeholder > .secret-placeholder-mask,
 .secret-placeholder > .secret-placeholder-message { grid-area: 1 / 1; }
 .secret-placeholder-mask { min-width: 0; max-width: 100%; visibility: hidden; overflow-wrap: anywhere; word-break: break-all; user-select: none; }

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -3017,6 +3017,11 @@
     assert(!document.getElementById("error").textContent, "Wallet derivation failed");
     const mobileResult = document.querySelector(".key-result");
     mobileResult.style.width = "220px";
+    const tablePrivateValue = mobileResult.querySelector(".table-private-field-value.secret-placeholder");
+    assert(
+      tablePrivateValue?.querySelector(".secret-placeholder-label")?.offsetParent === tablePrivateValue,
+      "The hidden WIF label escaped its horizontally scrolling table",
+    );
     assert(
       mobileResult.scrollWidth <= mobileResult.clientWidth,
       `Derived wallet widened a mobile layout to ${mobileResult.scrollWidth}px from ${mobileResult.clientWidth}px`,

--- a/test/psbt-editor-fuzz.test.mjs
+++ b/test/psbt-editor-fuzz.test.mjs
@@ -304,15 +304,16 @@ const valueOk = (text, doc, index) => {
   return total <= MAX_MONEY;
 };
 
-// …and prevouts must be unique (bad-txns-inputs-duplicate): an edit that
-// points a second input at an existing outpoint is rejected. The candidate
-// values are passed explicitly — the doc may still hold the invalid text the
-// candidate would replace, so comparing against the doc's current value could
-// never see the candidate (a repair loop would spin forever on it).
+// …and prevouts must be non-null and unique (bad-txns-prevout-null /
+// bad-txns-inputs-duplicate). The candidate values are passed explicitly —
+// the doc may still hold the invalid text the candidate would replace, so
+// comparing against the doc's current value could never see the candidate (a
+// repair loop would spin forever on it).
 const outpointFree = (doc, index, txid, vout) => {
   const candidateTxid = String(txid).toLowerCase();
   if (!integerText(String(vout))) return true; // moot on an unbuildable doc
   const candidateVout = String(Number(BigInt(String(vout))));
+  if (candidateTxid === "0".repeat(64) && candidateVout === String(U32_MAX)) return false;
   for (const [at, other] of doc.tx.inputs.entries()) {
     if (at === index || !integerText(String(other.vout))) continue; // a mid-edit poison compares as no duplicate
     if (String(other.txid).toLowerCase() === candidateTxid && String(Number(BigInt(String(other.vout)))) === candidateVout) return false;
@@ -913,6 +914,24 @@ test("an unbuildable field blocks structural edits until repaired", () => {
   assert.ok(recovered, "deleting the poisoned element was rejected");
   assert.equal(state.poisoned, null, "deleting the poisoned element did not recover the document");
   assert.equal(state.doc.tx.inputs.length, inputsBefore, "the poisoned input survived its own delete");
+});
+
+test("the field oracle rejects and repairs both ways of creating a null prevout", () => {
+  const zeroTxid = "0".repeat(64);
+
+  const byVout = { doc: structuredClone(HEALTHY.doc), poisoned: null, anchor: JSON.stringify(HEALTHY.doc.tx) };
+  writeField(byVout, "null prevout setup txid", fieldTargets(byVout).find((target) => target.kind === "txid"), zeroTxid);
+  writeField(byVout, "null prevout through vout", fieldTargets(byVout).find((target) => target.kind === "vout"), "4294967295");
+  assert.equal(byVout.poisoned?.kind, "vout", "the null-prevout vout was not rejected");
+  writeField(byVout, "repair null-prevout vout", fieldTargets(byVout).find((target) => target.kind === "vout"), "0");
+  assert.equal(byVout.poisoned, null, "the null-prevout vout did not repair");
+
+  const byTxid = { doc: structuredClone(HEALTHY.doc), poisoned: null, anchor: JSON.stringify(HEALTHY.doc.tx) };
+  writeField(byTxid, "null prevout setup vout", fieldTargets(byTxid).find((target) => target.kind === "vout"), "4294967295");
+  writeField(byTxid, "null prevout through txid", fieldTargets(byTxid).find((target) => target.kind === "txid"), zeroTxid);
+  assert.equal(byTxid.poisoned?.kind, "txid", "the null-prevout txid was not rejected");
+  writeField(byTxid, "repair null-prevout txid", fieldTargets(byTxid).find((target) => target.kind === "txid"), "0123456789abcdef".repeat(4));
+  assert.equal(byTxid.poisoned, null, "the null-prevout txid did not repair");
 });
 
 // The fuzzer guards itself: with a dead pool or a swallowed oracle these

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -2055,7 +2055,7 @@ test("derived key results put private recovery before script type and addresses"
 test("derived wallet results stay within the mobile layout (#238)", () => {
   assert.match(css, /\.key-result \{ min-width: 0; max-width: 100%;/);
   assert.match(css, /\.key-result-main \{ min-width: 0; max-width: 100%;/);
-  assert.match(css, /\.secret-placeholder \{ display: grid; min-width: 0; max-width: 100%;/);
+  assert.match(css, /\.secret-placeholder \{ position: relative; display: grid; min-width: 0; max-width: 100%;/);
   assert.match(css, /\.secret-placeholder-mask \{[^}]*max-width: 100%;[^}]*overflow-wrap: anywhere;[^}]*word-break: break-all;/);
   assert.match(css, /\.qr \{ max-width: 100%;/);
   assert.match(css, /\.qr svg \{[^}]*max-width: 100%;[^}]*height: auto;[^}]*aspect-ratio: 1;/);


### PR DESCRIPTION
Fixes #238.

Follow-up to #291. That PR constrained the visible result content, but the mobile page could still widen when the absolutely positioned accessible label for a hidden WIF was laid out inside the horizontally scrolling address table. Give each private placeholder its own positioning context so that label remains inside the table's scroll/clipping context.

The browser regression now verifies that the WIF label is contained by its private-value placeholder. In a focused Chromium mobile-emulation reproduction at 390 CSS pixels, deriving the same 24-word wallet changed the document width from 390px to 548px before this patch; after the patch it stays 390px before and after derivation.

The first CI run also exposed a stale PSBT-editor fuzz oracle after #373 added null-prevout validation. The application correctly rejects an all-zero txid paired with vout `0xffffffff`, but the oracle still classified every u32 vout as valid. The oracle now mirrors the production rule, with deterministic coverage for creating and repairing a null prevout through either field.

Tests:

- `npm run build && npm test` (1,184 passed, 0 failed, 2 skipped)
- `node --test test/psbt-editor-fuzz.test.mjs` (8 passed)
- `node --test test/ui-defaults.test.mjs` (89 passed)
- `npm run test:browser` (78 Chrome integration checks passed; Firefox and Edge are not installed locally)
- Focused Chrome mobile emulation at 390x844 (document remains 390px before and after Derive)
