### PR TITLE
Preserve journal entropy method variants

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -54,7 +54,7 @@ import { hodlSanitizeCatalogHtml } from "./i18n-sanitize.js";
 import hodlShellHtml from "../shell.html";
 import { hodlKeyModeLabels, hodlNetworkNames, hodlHexFormatLabels, hodlScriptBeginnerTexts, hodlFairnessVerdictLabels } from "./i18n-labels.js";
 import {
-  METHOD_LABELS as hodlJournalMethodLabels,
+  entryMethodLabel as hodlJournalEntryMethodLabel,
   PASSWORD_MIN_LENGTH as hodlJournalPasswordMinLength,
   addEntry as hodlJournalAddEntry,
   appendLog as hodlJournalAppend,
@@ -12773,7 +12773,11 @@ function hodlScheduleJournalStateRefresh() {
 }
 // The encrypted entropy notebook gates the Journal tools and keeps its
 // document and Web Crypto keys apart from the session notepad.
-var hodlJournalKeys = null, hodlJournalDoc = null, hodlJournalFileText = "", hodlJournalDirty = false, hodlJournalGate = "create", hodlJournalReveal = false, hodlJournalEditingId = null, hodlJournalDeleteArmed = false;
+var hodlJournalKeys = null, hodlJournalDoc = null, hodlJournalFileText = "", hodlJournalDirty = false, hodlJournalGate = "create", hodlJournalReveal = false, hodlJournalEditingId = null, hodlJournalDeleteArmed = false, hodlJournalEntryVariants = {};
+function hodlJournalReadEntryVariants(entry) {
+  if (!entry) return {};
+  return Object.fromEntries(["diceMethod", "entropyFormat", "cardMethod", "seedMethod"].filter((field) => entry[field]).map((field) => [field, entry[field]]));
+}
 // Bumped by every notebook teardown (clear, lock, lifecycle disposal). An
 // async unlock/create that completes against an older generation must discard
 // its decrypted material, not install it over a wiped session (issue #389).
@@ -12989,7 +12993,7 @@ function hodlJournalRenderList() {
   box.innerHTML = entries.map((entry) => `<button type="button" class="journal-item" data-journal-id="${entry.id}">
       <img class="journal-item-lifehash" alt="" width="32" height="32" hidden>
       <span class="journal-item-label">${hodlEscapeHtml(entry.label)}</span>
-      <span class="journal-item-meta">${hodlEscapeHtml(hodlJournalMethodLabels[entry.method] || entry.method)} \xB7 ${hodlEscapeHtml(String(entry.created).slice(0, 10))}</span>
+      <span class="journal-item-meta">${hodlEscapeHtml(hodlJournalEntryMethodLabel(entry))} \xB7 ${hodlEscapeHtml(String(entry.created).slice(0, 10))}</span>
     </button>`).join("");
   [...box.querySelectorAll(".journal-item")].forEach((button, index) => {
     let entry = entries[index];
@@ -13012,6 +13016,7 @@ function hodlJournalHideEditor() {
   }
   let method = document.getElementById("journal-method");
   if (method) method.value = "dice";
+  hodlJournalEntryVariants = {};
   hodlJournalFillWallets("");
 }
 function hodlJournalApplySnapshot(snapshot) {
@@ -13026,6 +13031,7 @@ function hodlJournalApplySnapshot(snapshot) {
   if (label && !label.value.trim()) label.value = snapshot.label;
   let notes = document.getElementById("journal-entry-notes");
   if (notes && !notes.value.trim()) notes.value = snapshot.notes;
+  hodlJournalEntryVariants = hodlJournalReadEntryVariants(snapshot);
   hodlJournalFillWallets(snapshot.walletId ?? "");
 }
 function hodlJournalShowEditor(entry) {
@@ -13041,6 +13047,7 @@ function hodlJournalShowEditor(entry) {
   document.getElementById("journal-phrase").value = entry?.phrase || "";
   document.getElementById("journal-label").value = entry?.label || "";
   document.getElementById("journal-entry-notes").value = entry?.notes || "";
+  hodlJournalEntryVariants = hodlJournalReadEntryVariants(entry);
   hodlJournalFillWallets(entry?.walletId ?? "");
 }
 function hodlJournalPrivateValue(value) {
@@ -13079,7 +13086,7 @@ function hodlJournalOpenView(id) {
         <button class="btn secondary" id="journal-back" type="button">Back</button>
       </div>
       <div class="wallet-data-fields">
-        ${hodlPublicFieldHtml("Method", hodlJournalMethodLabels[entry.method] || entry.method)}
+        ${hodlPublicFieldHtml("Method", hodlJournalEntryMethodLabel(entry))}
         ${hodlPublicFieldHtml("Recorded", entry.created)}
         ${wallet ? hodlPublicFieldHtml("Session wallet", wallet) : ""}
         ${entry.fingerprint ? hodlPublicFieldHtml("Master fingerprint", entry.fingerprint) : ""}
@@ -13191,6 +13198,7 @@ function hodlJournalCommit() {
     let state = walletId == null ? null : hodlKeys.find((item) => item.id === walletId);
     let fields = {
       method: document.getElementById("journal-method")?.value || "dice",
+      ...hodlJournalEntryVariants,
       input: document.getElementById("journal-input")?.value || "",
       phrase: document.getElementById("journal-phrase")?.value || "",
       label: document.getElementById("journal-label")?.value || "",
@@ -13255,6 +13263,7 @@ function hodlInitJournalNotebook() {
   document.getElementById("journal-global-download")?.addEventListener("click", hodlJournalSaveFile);
   document.getElementById("journal-global-clear")?.addEventListener("click", hodlJournalWipeMem);
   document.getElementById("journal-commit")?.addEventListener("click", hodlJournalCommit);
+  document.getElementById("journal-method")?.addEventListener("change", () => { hodlJournalEntryVariants = {}; });
   document.getElementById("journal-use-calc")?.addEventListener("click", hodlJournalUseActiveKey);
   document.getElementById("journal-cancel")?.addEventListener("click", () => {
     hodlJournalHideEditor();

--- a/src/js/journal.js
+++ b/src/js/journal.js
@@ -353,6 +353,25 @@ export const METHOD_LABELS = Object.freeze({
   seed: "Manual seed",
   cards: "Playing cards",
 });
+const ENTRY_VARIANTS = Object.freeze({
+  diceMethod: Object.freeze({ coldcard: "COLDCARD / SeedSigner", coleman: "Ian Coleman / Keystone", bitbox: "BitBox diceware", dplus: "D++ direct word selection" }),
+  entropyFormat: Object.freeze({ bin: "Binary (Base 2)", base4: "Base 4", base8: "Base 8", hex: "Hexadecimal (Base 16)", base32: "Crockford Base32", base64: "Base64" }),
+  cardMethod: Object.freeze({ hashed: "Hashed transcript", direct: "Direct word selection" }),
+  seedMethod: Object.freeze({ words: "Direct words", numbers: "BIP39 word numbers" }),
+});
+
+function normalizeEntryVariant(field, value) {
+  const variant = String(value ?? "");
+  return Object.hasOwn(ENTRY_VARIANTS[field], variant) ? variant : "";
+}
+
+export function entryMethodLabel(entry) {
+  const method = String(entry?.method || "");
+  const base = METHOD_LABELS[method] || method;
+  const field = method === "dice" ? "diceMethod" : method === "hex" ? "entropyFormat" : method === "cards" ? "cardMethod" : method === "seed" ? "seedMethod" : "";
+  const variant = field ? ENTRY_VARIANTS[field][normalizeEntryVariant(field, entry?.[field])] : "";
+  return variant ? `${method === "hex" ? "Number bases" : base} · ${variant}` : base;
+}
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -447,7 +466,7 @@ export function normalizeEntry(entry, now = new Date()) {
   if (!/^\d{4}-\d{2}-\d{2}T/.test(created)) throw new Error("Journal timestamp must be ISO-8601.");
   const walletId = entry?.walletId == null || entry.walletId === "" ? null : Number(entry.walletId);
   if (walletId != null && (!Number.isInteger(walletId) || walletId < 0)) throw new Error("Session wallet id must be a whole number.");
-  return {
+  const normalized = {
     id: Number.isInteger(entry?.id) && entry.id > 0 ? entry.id : 0,
     method,
     input: String(entry?.input ?? ""),
@@ -459,6 +478,11 @@ export function normalizeEntry(entry, now = new Date()) {
     walletName: String(entry?.walletName ?? ""),
     fingerprint: String(entry?.fingerprint ?? "").toLowerCase(),
   };
+  for (const field of Object.keys(ENTRY_VARIANTS)) {
+    const variant = normalizeEntryVariant(field, entry?.[field]);
+    if (variant) normalized[field] = variant;
+  }
+  return normalized;
 }
 
 export function addEntry(doc, fields, now = new Date()) {
@@ -505,18 +529,23 @@ export function snapshotFromKeyState(state) {
   const mode = state.mode || "";
   let method = "seed";
   let input = "";
+  let variants = {};
   if (mode === "dice") {
     method = "dice";
+    variants.diceMethod = normalizeEntryVariant("diceMethod", state.diceMethod) || "coldcard";
     input = state.diceMethod === "dplus" ? fields.dplusDice || "" : state.diceMethod === "bitbox" ? fields.bitboxDice || "" : fields.dice || "";
   } else if (mode === "cards") {
     method = "cards";
+    variants.cardMethod = normalizeEntryVariant("cardMethod", state.cardMethod) || "hashed";
     input = state.cardMethod === "direct" ? fields.directCards || "" : fields.cards || "";
   } else if (mode === "hex") {
     method = "hex";
     const format = state.entropyFormat || "hex";
     input = fields[format] || fields.hex || "";
+    variants.entropyFormat = fields[format] ? normalizeEntryVariant("entropyFormat", format) || "hex" : "hex";
   } else if (mode === "seed") {
     method = "seed";
+    variants.seedMethod = normalizeEntryVariant("seedMethod", state.seedMethod) || "words";
     input = state.seedMethod === "numbers" ? fields.seedNumbers || "" : fields.seed || "";
   } else if (mode === "key") {
     const kind = fields.keyKind || "";
@@ -532,6 +561,7 @@ export function snapshotFromKeyState(state) {
   if (!String(input).trim() && !String(phrase).trim()) return null;
   return {
     method,
+    ...variants,
     input: String(input),
     phrase: String(phrase),
     label: String(state.name || state.result?.masterFingerprint || "").trim(),

--- a/test/journal-backup.test.mjs
+++ b/test/journal-backup.test.mjs
@@ -27,6 +27,7 @@ import {
   createJournal,
   deriveJournalKeys,
   emptyDocument,
+  entryMethodLabel,
   encodeFile,
   formatLog,
   formatNotebook,
@@ -311,18 +312,42 @@ test("the snapshot captures each input method's live transcript", () => {
   const base = { id: 1, isLab: false, name: "", fields: {}, result: null };
   const dplus = snapshotFromKeyState({ ...base, mode: "dice", diceMethod: "dplus", fields: { dplusDice: "⚁⚂⚄", dice: "1 2 3" } });
   assert.equal(dplus.input, "⚁⚂⚄");
+  assert.equal(dplus.diceMethod, "dplus");
+  assert.equal(entryMethodLabel(dplus), "Dice rolls · D++ direct word selection");
   const bitbox = snapshotFromKeyState({ ...base, mode: "dice", diceMethod: "bitbox", fields: { bitboxDice: "bb", dice: "1 2 3" } });
   assert.equal(bitbox.input, "bb");
+  assert.equal(bitbox.diceMethod, "bitbox");
   const direct = snapshotFromKeyState({ ...base, mode: "cards", cardMethod: "direct", fields: { directCards: "AS KD", cards: "hashed" } });
   assert.equal(direct.method, "cards");
   assert.equal(direct.input, "AS KD");
+  assert.equal(direct.cardMethod, "direct");
+  assert.equal(entryMethodLabel(direct), "Playing cards · Direct word selection");
   const binary = snapshotFromKeyState({ ...base, mode: "hex", entropyFormat: "bin", fields: { bin: "0101", hex: "aa" } });
   assert.equal(binary.method, "hex");
   assert.equal(binary.input, "0101");
+  assert.equal(binary.entropyFormat, "bin");
+  assert.equal(entryMethodLabel(binary), "Number bases · Binary (Base 2)");
   const hexFallback = snapshotFromKeyState({ ...base, mode: "hex", entropyFormat: "base64", fields: { hex: "aa" } });
   assert.equal(hexFallback.input, "aa"); // an empty chosen format falls back to hex
+  assert.equal(hexFallback.entropyFormat, "hex");
   const numbers = snapshotFromKeyState({ ...base, mode: "seed", seedMethod: "numbers", fields: { seedNumbers: "1 2 3", seed: "words" } });
   assert.equal(numbers.input, "1 2 3");
+  assert.equal(numbers.seedMethod, "numbers");
+  assert.equal(entryMethodLabel(numbers), "Manual seed · BIP39 word numbers");
+});
+
+test("journal entry variants survive encryption while old and unknown variants stay safe", async () => {
+  const doc = emptyDocument();
+  addEntry(doc, sampleEntry({ method: "dice", diceMethod: "coleman" }), fixedNow);
+  const opened = await openDocument(pack(await sealDocument(doc, keys)), password);
+  assert.equal(opened.doc.entries[0].diceMethod, "coleman");
+  assert.equal(entryMethodLabel(opened.doc.entries[0]), "Dice rolls · Ian Coleman / Keystone");
+  const oldEntry = normalizeEntry(sampleEntry({ method: "seed" }), fixedNow);
+  assert.equal(entryMethodLabel(oldEntry), "Manual seed");
+  const hostile = normalizeEntry(sampleEntry({ method: "cards", cardMethod: "exfil", entropyFormat: "javascript:" }), fixedNow);
+  assert.equal(hostile.cardMethod, undefined);
+  assert.equal(hostile.entropyFormat, undefined);
+  assert.equal(entryMethodLabel(hostile), "Playing cards");
 });
 
 test("the snapshot captures private-key modes and the passphrase warning", () => {
@@ -648,6 +673,11 @@ test("an .elkeys backup is opaque until opened with the journal password", async
 
 test("the app routes every journal backup through the sealed primitives", () => {
   const app = read("src/js/app.js");
+  // A Key Station snapshot carries its method variant through the editor and
+  // both journal labels render that persisted variant.
+  assert.match(app, /hodlJournalEntryVariants = hodlJournalReadEntryVariants\(snapshot\)/);
+  assert.match(app, /method: document\.getElementById\("journal-method"\)\?\.value \|\| "dice",\s+\.\.\.hodlJournalEntryVariants,/);
+  assert.equal((app.match(/hodlJournalEntryMethodLabel\(entry\)/g) || []).length, 2);
   // Downloads encrypt with the unlocked journal keys by default and mark the
   // file as encrypted.
   assert.match(app, /async function hodlJournalDownloadContent\(kind, filename, text[\s\S]*?hodlJournalSealExport\(kind, text, hodlJournalKeys\)/);


### PR DESCRIPTION
Fixes #398.

Journal snapshots now retain the selected `diceMethod`, `entropyFormat`, `cardMethod`, or `seedMethod` alongside the raw transcript. The encrypted entry normalizer accepts only known variant values, preserves older entries that have no variant, and drops unknown values.

The Journal list and entry detail show the variant in the method label, so a transcript is not replayed under the default method by mistake. The editor carries snapshot metadata through Save and clears it when the user manually changes the broad method. BIP39 passphrases remain excluded.

Tests:
- `npm run build`
- `node --test test/journal-backup.test.mjs` (40/40)
- `npm test` (1,203 passed, 4 skipped; only failure was the host Snap Firefox launcher attempting to create its profile under the read-only `/home/stancan321/snap/firefox/common` mount before browser startup)