### PR TITLE
docs: document workspace integration checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,9 @@ Guidelines for AI coding agents.
 - The page body lives once in `src/shell.html`: the build injects it into
   `index.html`, and `app.js` assigns it at boot. Edit markup there, never in
   two places.
+- When adding a workspace, follow the [workspace integration checklist in
+  CONTRIBUTING.md](CONTRIBUTING.md#adding-a-workspace), including the explicit
+  workspace lists and expectations in the UI and browser tests.
 - Translations are content-keyed: the English text at the call site is the
   catalog key (`t("Save watch-only sheet")`); there is no `en.json`. Static
   markup needs nothing — a content sweep translates text nodes and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,6 +176,38 @@ meaningful group, and `tool-actions` separates actions from the content they
 operate on. Compact tables, grids, and visualizations may use tighter local
 spacing internally, but their outer boundary should still follow this rhythm.
 
+## Adding a workspace
+
+Use this checklist when adding a tool to the top-level workspace strip:
+
+- **Markup:** add the tab and its panel, introduction, and controls in
+  `src/shell.html`. Keep IDs consistent with the runtime code; the build and
+  boot render both use this shell, so do not duplicate the body in `index.html`.
+- **Registration and switching:** update `hodlWorkspaceTabs` in
+  `src/js/app.js` (ID, full label, short label). `hodlInitWorkspace` builds
+  the runtime strip; `hodlShowWorkspace` controls panel/manager and intro
+  visibility and entry/exit behavior. Wire initialization and event handlers
+  into the existing boot flow. Check keyboard navigation and switching away
+  from the new tool as well as opening it. PSBT and Journal have separate
+  subtool synchronization; a subtool is not necessarily a new workspace.
+- **Styles:** use `src/css/styles.css` and the shared classes described above.
+  Check hidden panels, narrow-screen labels, overflow, and print behavior.
+- **Bundling:** ordinary imports from `src/js/app.js` are bundled by
+  `scripts/build.mjs`. Check `src/index.html` and that build script if adding
+  a separate script or resource; keep the output self-contained and offline.
+  Rust/WASM changes also need the relevant crate and `scripts/build-wasm.mjs`
+  integration. Never hand-edit or submit generated artifacts.
+- **Explicit test expectations:** review `test/ui-defaults.test.mjs`
+  (workspace order, labels, panel containment, and switcher assertions) and
+  `test/browser-suite.html` (tab count/names, keyboard navigation, visibility,
+  and layout checks). Search these files for `workspace`, `data-workspace`,
+  and `tool-intro`. An intentional addition may require updating their
+  hard-coded lists/counts together; retain coverage for existing tools and
+  add checks for the new one, rather than removing assertions.
+- **Finish:** update user-facing documentation as required above, then run
+  `npm run build && npm test`. Run `npm run test:browser` with an installed
+  browser to exercise the workspace interactions.
+
 ## A final sanity check
 
 1. Does this keep EntropyLab a calculator that never invents entropy?

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -1015,7 +1015,11 @@
   await test("tool tabs answer the arrow keys and name themselves in full", async () => {
     const strip = document.getElementById("workspace-tabs");
     const tabs = [...strip.querySelectorAll("[data-workspace]")];
-    assert(tabs.length === 7, `Expected seven tool tabs, found ${tabs.length}`);
+    assert(tabs.length === 7,
+      `Expected seven tool tabs, found ${tabs.length} (${tabs.map(tab => tab.dataset.workspace).join(", ")}). ` +
+      "Check src/shell.html and hodlWorkspaceTabs in src/js/app.js. If adding a workspace intentionally, " +
+      "update this count and names list plus test/ui-defaults.test.mjs expectations; " +
+      "see CONTRIBUTING.md#adding-a-workspace.");
     // The visible label may be abbreviated; the accessible name never is.
     const names = ["Keys", "Vanity", "BIP-85", "Multi Signature", "Silent Payments", "PSBT", "Journal"];
     tabs.forEach((tab, i) => {


### PR DESCRIPTION
## Summary

Closes #394.

- Add a contributor checklist covering workspace markup, runtime registration/switching, styling, bundling, and explicit UI/browser expectations.
- Link the checklist from AGENTS.md.
- Make the existing browser tab-count failure report observed workspace IDs and point to the registration, expectations, and checklist. Keep the expected count and architecture unchanged.

## Validation

- `npm run build`: passed.
- `npm test`: 1,202 passed, 4 skipped, 1 failed. The browser harness cannot create its Snap Firefox staging directory in this environment (EROFS); it fails before browser assertions run.
- Exercised the changed assertion directly: seven tabs pass; eight tabs fail with workspace IDs and checklist guidance.
- `git diff --check`: passed.

No generated build artifacts or runtime application changes included.
