### PR TITLE
feat: add all pending Journal keys to Key Station

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,9 @@ Official website: [entropylab.online](https://entropylab.online)
   ignored-key metadata into an encrypted `.elkeys` file. It reuses the
   unlocked Journal password keys, so it adds no password prompt, random salt,
   or random nonce. Imported keys remain in Key Manager until the user chooses
-  **Use in Key Station**; deleting a Key Station tab while a Journal is open
+  **Use in Key Station** for one key or **Add all to Key Station** for every
+  waiting key. Adding all skips keys already in the station and leaves ignored
+  keys untouched. Deleting a Key Station tab while a Journal is open
   likewise removes it from the station without discarding it from Key Manager.
   The Journal also includes a paged notepad. Pages use
   the Key Station's numbered naming convention, can be added or removed with

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -10147,6 +10147,11 @@ function hodlKeyManagerRender() {
   let tabs = document.getElementById("journal-keymanager-tabs"), panel = document.getElementById("journal-keymanager-panel");
   if (!tabs || !panel) return;
   let states = hodlKeyManagerStates();
+  let addAll = document.getElementById("journal-keymanager-add-all");
+  if (addAll) {
+    addAll.disabled = !states.some((state) => !hodlKeys.includes(state));
+    addAll.onclick = hodlKeyManagerUseAllInStation;
+  }
   tabs.replaceChildren();
   panel.replaceChildren();
   if (!states.length) {
@@ -10280,6 +10285,21 @@ function hodlKeyManagerUseInStation(state) {
   }
   hodlRenderKeyTabs();
   hodlJournalLog("key-manager-use", identity, "journal");
+  hodlShowWorkspace("calc");
+}
+function hodlKeyManagerUseAllInStation() {
+  let states = hodlKeyManagerStates().filter((state) => !hodlKeys.includes(state));
+  if (!states.length) return;
+  states.forEach((state) => {
+    let pending = hodlKeyManagerPending.indexOf(state);
+    if (pending < 0) return;
+    hodlKeyManagerPending.splice(pending, 1);
+    hodlKeys.push(state);
+    hodlJournalLog("key-manager-use", keyVaultIdentity(state), "journal");
+  });
+  hodlActiveKey = hodlKeys.indexOf(states[0]);
+  hodlRenderKeyTabs();
+  hodlKeyManagerRender();
   hodlShowWorkspace("calc");
 }
 function hodlKeyManagerIgnore(state) {
@@ -12307,7 +12327,7 @@ async function hodlKeyManagerImportFile(file) {
     });
     hodlKeyManagerActiveId = hodlKeyManagerActiveId || keyVaultIdentity(hodlKeyManagerStates()[0]);
     hodlKeyManagerRender();
-    hodlKeyManagerStatus(`${added} new key${added === 1 ? "" : "s"} imported${duplicates ? `; ${duplicates} duplicate${duplicates === 1 ? "" : "s"} kept unchanged` : ""}. Use “Use in Key Station” to load one.`);
+    hodlKeyManagerStatus(`${added} new key${added === 1 ? "" : "s"} imported${duplicates ? `; ${duplicates} duplicate${duplicates === 1 ? "" : "s"} kept unchanged` : ""}. ` + hodlTText("Use “Use in Key Station” to load one, or “Add all to Key Station” to load every waiting key."));
     hodlJournalLog("key-manager-import", `${added} keys; ${duplicates} duplicates`, "journal");
   } catch (error) {
     hodlKeyManagerStatus(error?.message || "The key file could not be imported.", true);

--- a/src/shell.html
+++ b/src/shell.html
@@ -772,6 +772,7 @@ words, pick one of the checksum words.</span></span>
         <h2>Key manager</h2>
         <p class="muted tool-intro-note" data-i18n-rich>Collect derived Key Station keys in one encrypted <code>.elkeys</code> file. Imported keys stay here until you explicitly load one into Key Station. The file uses this Journal's password and never leaves your machine.</p>
       </div>
+      <div class="row tool-actions"><button class="btn secondary" id="journal-keymanager-add-all" type="button" disabled>Add all to Key Station</button></div>
       <div class="key-tab-strip journal-keymanager-tab-strip"><div class="key-tabs" id="journal-keymanager-tabs" role="tablist" aria-label="Managed keys"></div></div>
       <div class="journal-keymanager-panel" id="journal-keymanager-panel"></div>
       <section class="journal-keymanager-ignored" id="journal-keymanager-ignored" hidden>

--- a/test/keymanager.test.mjs
+++ b/test/keymanager.test.mjs
@@ -1,5 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { runInNewContext } from "node:vm";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -16,6 +17,64 @@ import { createDocument, openExport, sealExport } from "../src/js/journal.js";
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const read = (path) => readFileSync(join(root, path), "utf8");
 const password = "correct horse battery staple";
+
+function stationHarness(keys, pending, ignored = []) {
+  const source = read("src/js/app.js");
+  const slice = (name, next) => source.slice(source.indexOf(`function ${name}(`), source.indexOf(`function ${next}(`));
+  const calls = [];
+  const context = {
+    hodlKeys: keys, hodlKeyManagerPending: pending, hodlKeyManagerIgnored: ignored,
+    hodlActiveKey: 0, keyVaultIdentity,
+    hodlJournalLog: (...args) => calls.push(args),
+    hodlRenderKeyTabs: () => calls.push(["tabs"]),
+    hodlKeyManagerRender: () => calls.push(["manager"]),
+    hodlShowWorkspace: (id) => calls.push(["workspace", id]),
+  };
+  runInNewContext(slice("hodlKeyManagerStates", "hodlKeyManagerEntry") +
+    slice("hodlKeyManagerUseAllInStation", "hodlKeyManagerIgnore"), context);
+  return { context, calls };
+}
+
+test("Add all transfers pending keys once, preserving existing and ignored keys", () => {
+  const existing = key(), first = key({ result: { masterFingerprint: "11111111" } }),
+    second = key({ result: { masterFingerprint: "22222222" } }), ignored = key({ name: "Ignored" });
+  const lab = { isLab: true, fields: { seed: "unfinished input" } };
+  const keys = [lab, existing], pending = [first, second], ignoredKeys = [ignored];
+  const before = JSON.stringify([first, second, lab, ignored]);
+  const { context, calls } = stationHarness(keys, pending, ignoredKeys);
+  context.hodlKeyManagerUseAllInStation();
+  assert.deepEqual(keys, [lab, existing, first, second]);
+  assert.equal(pending.length, 0);
+  assert.equal(context.hodlActiveKey, 2);
+  assert.equal(JSON.stringify([first, second, lab, ignored]), before);
+  assert.deepEqual(ignoredKeys, [ignored]);
+  assert.deepEqual(calls, [
+    ["key-manager-use", "11111111", "journal"], ["key-manager-use", "22222222", "journal"],
+    ["tabs"], ["manager"], ["workspace", "calc"],
+  ]);
+  context.hodlKeyManagerUseAllInStation();
+  assert.equal(keys.length, 4);
+  assert.equal(calls.length, 5, "repeated activation does nothing");
+});
+
+test("Add all ignores duplicate identities and does nothing without pending keys", () => {
+  const existing = key(), duplicate = key({ name: "Duplicate" });
+  const { context, calls } = stationHarness([existing], [duplicate]);
+  context.hodlKeyManagerUseAllInStation();
+  assert.equal(context.hodlKeys.length, 1);
+  assert.equal(context.hodlActiveKey, 0);
+  assert.deepEqual(calls, []);
+  const empty = stationHarness([], []);
+  empty.context.hodlKeyManagerUseAllInStation();
+  assert.deepEqual(empty.calls, []);
+});
+
+test("Add all is disabled initially and refreshed from available managed keys", () => {
+  assert.match(read("src/shell.html"), /id="journal-keymanager-add-all" type="button" disabled>Add all to Key Station/);
+  const source = read("src/js/app.js");
+  assert.match(source, /addAll\.disabled = !states\.some\(\(state\) => !hodlKeys\.includes\(state\)\)/);
+  assert.match(source, /addAll\.onclick = hodlKeyManagerUseAllInStation/);
+});
 
 function key(overrides = {}) {
   return {


### PR DESCRIPTION
## Summary

Closes #393.

- Add an explicit **Add all to Key Station** action for every waiting Key Manager key, disabled when there are none.
- Preserve existing station keys, ignore duplicate identities, leave ignored keys untouched, and switch to Key Station once with the first added key selected.
- Keep single-key actions and encryption/storage unchanged; update import guidance and README.
- Add regression coverage for batching, state preservation, duplicates, empty/repeated activation, and button wiring.

## Validation

- `npm run build`: passed.
- Focused Key Manager and UI-default tests: 100 passed.
- Final Key Manager and translation-attribute tests: 13 passed.
- `npm test`: 1,205 passed, 4 skipped, 1 failed. The browser harness failed before running browser assertions because its Snap Firefox staging directory is read-only (EROFS).
- `git diff --check`: passed.

Full interactive browser validation remains for CI/reviewer. No generated artifacts or locale catalogs are included; new English strings follow the existing translation sweep/helper path and post-merge translation automation.
