### PR TITLE
PSBT inspector: upload and download the file

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ Official website: [entropylab.online](https://entropylab.online)
   indexes and hardening choices. Addresses are derived from the exported
   output descriptor itself by rust-miniscript (in the WASM crate), so the two
   cannot drift.
-- Inspects PSBT v0 transactions, reports PSBT-provided amounts and fees, checks
+- Inspects PSBT v0 transactions (paste, or upload a binary .psbt / hex or
+  base64 text export; the loaded bytes download as .psbt or .txn), reports
+  PSBT-provided amounts and fees, checks
   for repeated ECDSA nonces from the same public key — including signatures
   carried by finalized scriptSig/witness fields, which are decoded and analyzed
   rather than skipped — verifies optional Jade

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -8111,6 +8111,34 @@ function hodlPsbtBytes(raw) {
   if (bytes.length > 5e6) throw new Error("This file is too large to inspect safely.");
   return bytes;
 }
+function hodlPsbtInspectorBytesFromUpload(bytes) {
+  let decoded, uploadError;
+  try {
+    decoded = psbtBytesFromUpload(bytes);
+  } catch (error) {
+    uploadError = error;
+  }
+  if (decoded) {
+    if (isPsbtMagic(decoded)) return decoded;
+    try {
+      parseRawTx(decoded);
+      return decoded;
+    } catch {
+      // A binary transaction can happen to decode as text. Validate the
+      // original bytes below before rejecting the upload.
+    }
+  }
+  if (bytes instanceof Uint8Array && bytes.length && bytes.length <= 5e6) {
+    try {
+      parseRawTx(bytes);
+      return bytes;
+    } catch {
+      // Keep the shared decoder's bounded, user-facing rejection below.
+    }
+  }
+  if (uploadError) throw uploadError;
+  throw new Error("That does not look like a PSBT or raw transaction in base64, hex, or binary form.");
+}
 function hodlReadMap(bytes, offset) {
   let entries = [], keys = /* @__PURE__ */ new Set();
   for (; ; ) {
@@ -8668,7 +8696,7 @@ function hodlInitPsbt() {
     if (!chosen) return;
     (async () => {
       try {
-        const bytes = psbtBytesFromUpload(new Uint8Array(await chosen.arrayBuffer()));
+        const bytes = hodlPsbtInspectorBytesFromUpload(new Uint8Array(await chosen.arrayBuffer()));
         document.getElementById("psbt-text").value = hodlBytesToB64(bytes);
         hodlRunPsbt();
       } catch (exception) {

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -43,7 +43,7 @@ import { entropyToMnemonic as hodlEntropyToMnemonic, mnemonicToEntropy as hodlMn
 import { wordlist as bip39English } from "./bip39-english.js";
 // The PSBT editor (its own workspace tab) drives the rust-bitcoin WASM
 // bindings in psbt-wasm.js; heavy lifting lives in psbt-editor.js.
-import { initPsbtEditor } from "./psbt-editor.js";
+import { initPsbtEditor, psbtBytesFromUpload } from "./psbt-editor.js";
 import { hodlTapKeySigs, hodlTapScriptSigs, hodlTapSighashProblems } from "./psbt-schnorr.js";
 import { initQrReferences } from "./qr-references.js";
 import { renderSVG as hodlUqrRenderSvg } from "uqr";
@@ -8092,6 +8092,11 @@ function hodlB64(value) {
   for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
   return bytes;
 }
+function hodlBytesToB64(bytes) {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  return btoa(binary);
+}
 function hodlPsbtBytes(raw) {
   let value = raw.trim(), compact = value.replace(/\s/g, "");
   if (!value) throw new Error("Paste a PSBT v0 or a raw Bitcoin transaction.");
@@ -8615,6 +8620,14 @@ function hodlUseActiveKeyForPsbt() {
   hodlPsbtSource = "active";
   hodlPsbtSessionSpec = state.name ? { key: "Session key from {name}. Kept in page memory only.", vars: { name: state.name } } : { key: "Session key from the active key. Kept in page memory only." };
 }
+function hodlDownloadBytes(bytes, name) {
+  const url = URL.createObjectURL(new Blob([bytes], { type: "application/octet-stream" }));
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = name;
+  link.click();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
 function hodlInitPsbt() {
   let go = document.getElementById("psbt-go");
   if (!go) return;
@@ -8643,6 +8656,36 @@ function hodlInitPsbt() {
     document.getElementById("psbt-out").innerHTML = "";
     hodlSetPsbtError(null);
     document.getElementById("psbt-session").textContent = hodlPsbtSessionText();
+  };
+  // Same load path as the editor: Sparrow/Coldcard binary .psbt, or a
+  // base64/hex text export saved to disk. The textarea mirrors the file as
+  // base64 so Inspect and Download keep working without a second parser.
+  const file = document.getElementById("psbt-file");
+  document.getElementById("psbt-upload").onclick = () => file.click();
+  file.addEventListener("change", () => {
+    const chosen = file.files?.[0];
+    file.value = "";
+    if (!chosen) return;
+    (async () => {
+      try {
+        const bytes = psbtBytesFromUpload(new Uint8Array(await chosen.arrayBuffer()));
+        document.getElementById("psbt-text").value = hodlBytesToB64(bytes);
+        hodlRunPsbt();
+      } catch (exception) {
+        hodlSetPsbtError({ raw: exception.message || String(exception) });
+      }
+    })();
+  });
+  document.getElementById("psbt-download").onclick = () => {
+    hodlSetPsbtError(null);
+    try {
+      const raw = document.getElementById("psbt-text").value;
+      if (!String(raw || "").trim()) throw new Error("Paste or upload a PSBT or raw transaction first.");
+      const bytes = hodlPsbtBytes(raw);
+      hodlDownloadBytes(bytes, isPsbtMagic(bytes) ? "inspected.psbt" : "inspected.txn");
+    } catch (exception) {
+      hodlSetPsbtError({ raw: exception.message || String(exception) });
+    }
   };
   let clearSecretFields = () => {
     hodlPsbtWipeMem();
@@ -12005,6 +12048,8 @@ var hodlJournalAuditedClicks = {
   "sp-wipe": ["sp", "clear", "session"],
   "psbt-use-calc": ["psbt", "use-session-key", "active-key"],
   "psbt-wipe": ["psbt", "clear", "session"],
+  "psbt-upload": ["psbt", "upload", "psbt-file"],
+  "psbt-download": ["psbt", "download", "inspected-psbt"],
   "psbted-load": ["psbt", "load", "editor-text"],
   "psbted-upload": ["psbt", "upload", "psbt-file"],
   "psbted-wipe": ["psbt", "clear", "editor"],

--- a/src/shell.html
+++ b/src/shell.html
@@ -564,7 +564,7 @@ words, pick one of the checksum words.</span></span>
     <div class="tool-intro active" id="psbt-tool-intro" aria-hidden="false">
         <div class="kicker">Inspect first. Sign elsewhere.</div>
         <h2>Read a PSBT or a signed transaction.</h2>
-        <p class="muted tool-intro-note">Inspecting a PSBT v0 or a raw Bitcoin transaction does not require a private key. EntropyLab can show outputs, PSBT-provided input amounts and fees, signatures, and repeated ECDSA nonce values. Optional Jade anti-exfil transcripts (host nonce ρ and signer opening R) are checked without a key. Finalized taproot witnesses and tap-leaf scripts are scanned for inscription envelopes (OP_FALSE OP_IF "ord"); this does not number sats or fetch content from the chain. Loading a matching key additionally labels which outputs belong to this wallet (change vs receive vs not yours) and checks whether supported signatures match plain RFC 6979 or Bitcoin Core-style low-r grinding; a mismatch alone is not evidence of a compromised signer.</p>
+        <p class="muted tool-intro-note">Inspecting a PSBT v0 or a raw Bitcoin transaction does not require a private key. EntropyLab can show outputs, PSBT-provided input amounts and fees, signatures, and repeated ECDSA nonce values. Optional Jade anti-exfil transcripts (host nonce ρ and signer opening R) are checked without a key. Finalized taproot witnesses and tap-leaf scripts are scanned for inscription envelopes (OP_FALSE OP_IF "ord"); this does not number sats or fetch content from the chain. A binary .psbt file as saved by Sparrow, Coldcard or another wallet uploads directly, and the loaded bytes can be downloaded as a .psbt (or .txn for a raw transaction). Loading a matching key additionally labels which outputs belong to this wallet (change vs receive vs not yours) and checks whether supported signatures match plain RFC 6979 or Bitcoin Core-style low-r grinding; a mismatch alone is not evidence of a compromised signer.</p>
       </div>
     <div class="tool-intro" id="psbted-tool-intro" aria-hidden="true">
         <div class="kicker">Full-fidelity editor. Sign elsewhere.</div>
@@ -600,6 +600,9 @@ words, pick one of the checksum words.</span></span>
       </label>
       <div class="row psbt-actions tool-actions">
         <button class="btn primary" id="psbt-go" type="button">Inspect</button>
+        <button class="btn secondary" id="psbt-upload" type="button">Upload .psbt file</button>
+        <input type="file" id="psbt-file" accept=".psbt,.txn,.txt,.hex" hidden>
+        <button class="btn secondary" id="psbt-download" type="button">Download .psbt</button>
         <button class="btn secondary" id="psbt-use-calc" type="button">Use active key this session</button>
         <button class="btn secondary" id="psbt-wipe" type="button">End session / clear fields</button>
       </div>

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -2745,8 +2745,27 @@
     document.querySelector('#psbt-tool-tabs [data-psbt-tool="nonce"]').click();
     await until(() => !document.getElementById("psbt-card").hidden, "PSBT / Nonce tab");
     const box = await until(() => document.getElementById("psbt-text"), "PSBT input");
-    input(box, vector);
-    document.getElementById("psbt-go").click();
+    const fileInput = document.getElementById("psbt-file");
+    const upload = (bytes, name) => {
+      Object.defineProperty(fileInput, "files", {
+        configurable: true,
+        value: [new File([bytes], name, { type: "application/octet-stream" })],
+      });
+      fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+    };
+    const downloadedBytes = async (name) => {
+      state.lastBlob = null;
+      state.downloadName = "";
+      document.getElementById("psbt-download").click();
+      const blob = await until(() => state.downloadName === name && state.lastBlob, `${name} download`);
+      return new Uint8Array(await blob.arrayBuffer());
+    };
+    const sameBytes = (actual, expected, description) => {
+      assert(actual.length === expected.length && actual.every((byte, index) => byte === expected[index]), description);
+    };
+    const vectorBytes = Uint8Array.from(atob(vector), (char) => char.charCodeAt(0));
+    upload(vectorBytes, "wallet.psbt");
+    await until(() => box.value === vector, "binary PSBT upload");
     await until(() => document.getElementById("psbt-out").textContent.includes("ECDSA nonce check") || document.getElementById("psbt-error").textContent, "inspector report");
     equal(document.getElementById("psbt-error").textContent, "", "inspector rejected a valid vector");
     const out = document.getElementById("psbt-out").textContent;
@@ -2760,6 +2779,7 @@
     assert(out.includes("Output ownership / derivation — Incomplete"), "missing session-key coverage was not exposed");
     assert(out.includes("Nonce analysis — Incomplete"), "single-signature nonce limitation was not exposed");
     assert(!out.includes("LISTED CHECKS COMPLETE"), "an incomplete report was presented as complete");
+    sameBytes(await downloadedBytes("inspected.psbt"), vectorBytes, "downloaded PSBT differs from its binary upload");
     // Change the finalized signature's SIGHASH_ALL suffix to SIGHASH_NONE.
     // The report remains incomplete for unverified prevouts, but the real
     // policy problem must dominate the overall banner and its severity.
@@ -2799,6 +2819,15 @@
     assert(rawOut.includes("Where this transaction sends bitcoin"), "raw transaction outputs section missing");
     assert(rawOut.includes("1Cu32FVupVCgHkMMRJdYJugxwo2Aprgk7H"), "mainnet output address missing");
     assert(rawOut.includes("r values:"), "raw transaction signatures were not inspected");
+    const rawBytes = Uint8Array.from(rawTx.match(/../g), (pair) => parseInt(pair, 16));
+    const txnDownload = await downloadedBytes("inspected.txn");
+    sameBytes(txnDownload, rawBytes, "downloaded transaction differs from the inspected bytes");
+    input(box, "");
+    document.getElementById("psbt-out").innerHTML = "";
+    upload(txnDownload, "inspected.txn");
+    await until(() => document.getElementById("psbt-out").textContent.includes("Raw Bitcoin transaction.") || document.getElementById("psbt-error").textContent, "downloaded transaction re-upload");
+    equal(document.getElementById("psbt-error").textContent, "", "inspector rejected its binary .txn download");
+    sameBytes(await downloadedBytes("inspected.txn"), rawBytes, "transaction bytes changed after download and re-upload");
     // The header network picker must reach the render as well.
     document.getElementById("network-picker-button").click();
     document.querySelector('#network-picker-menu [data-network="testnet"]').click();

--- a/test/psbt-upload.test.mjs
+++ b/test/psbt-upload.test.mjs
@@ -73,6 +73,25 @@ test("both markups carry the upload control, and the editor wires it", () => {
   assert.match(editor, /psbtBytesFromUpload\(new Uint8Array\(await chosen\.arrayBuffer\(\)\)\)/);
 });
 
+test("the PSBT / Nonce inspector also uploads and downloads the file", () => {
+  const shell = read("src/shell.html");
+  const app = read("src/js/app.js");
+  assert.match(shell, /<button class="btn secondary" id="psbt-upload" type="button">Upload \.psbt file<\/button>/);
+  assert.match(shell, /<input type="file" id="psbt-file" accept="\.psbt,\.txn,\.txt,\.hex" hidden>/);
+  assert.match(shell, /<button class="btn secondary" id="psbt-download" type="button">Download \.psbt<\/button>/);
+  assert.match(app, /import \{ initPsbtEditor, psbtBytesFromUpload \} from "\.\/psbt-editor\.js"/);
+  assert.match(app, /getElementById\("psbt-upload"\)/);
+  assert.match(app, /getElementById\("psbt-file"\)/);
+  assert.match(app, /getElementById\("psbt-download"\)/);
+  assert.match(app, /psbtBytesFromUpload\(new Uint8Array\(await chosen\.arrayBuffer\(\)\)\)/);
+  assert.match(app, /hodlBytesToB64\(bytes\)/);
+  assert.match(app, /"inspected\.psbt"/);
+  assert.match(app, /"inspected\.txn"/);
+  assert.match(app, /Paste or upload a PSBT or raw transaction first/);
+  assert.match(app, /"psbt-upload": \["psbt", "upload", "psbt-file"\]/);
+  assert.match(app, /"psbt-download": \["psbt", "download", "inspected-psbt"\]/);
+});
+
 test("the result panel offers a binary .psbt download", () => {
   const editor = read("src/js/psbt-editor.js");
   assert.match(editor, /id="psbted-download"/);

--- a/test/psbt-upload.test.mjs
+++ b/test/psbt-upload.test.mjs
@@ -83,7 +83,7 @@ test("the PSBT / Nonce inspector also uploads and downloads the file", () => {
   assert.match(app, /getElementById\("psbt-upload"\)/);
   assert.match(app, /getElementById\("psbt-file"\)/);
   assert.match(app, /getElementById\("psbt-download"\)/);
-  assert.match(app, /psbtBytesFromUpload\(new Uint8Array\(await chosen\.arrayBuffer\(\)\)\)/);
+  assert.match(app, /hodlPsbtInspectorBytesFromUpload\(new Uint8Array\(await chosen\.arrayBuffer\(\)\)\)/);
   assert.match(app, /hodlBytesToB64\(bytes\)/);
   assert.match(app, /"inspected\.psbt"/);
   assert.match(app, /"inspected\.txn"/);

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -1639,7 +1639,7 @@ test("one PSBT workspace contains PSBT / Nonce and PSBT Editor tabs", () => {
   }
   assert.match(css, /\.psbted-actions \{ align-items: flex-end; \}/);
   assert.match(css, /\.psbted-actions \.btn, \.psbted-actions \.custom-select-button \{ min-height: 36px; padding: 6px 10px; border-radius: 8px; \}/);
-  assert.match(appSource, /import \{ initPsbtEditor \} from "\.\/psbt-editor\.js"/);
+  assert.match(appSource, /import \{ initPsbtEditor, psbtBytesFromUpload \} from "\.\/psbt-editor\.js"/);
   // The editor reads the header picker's network through the passed getter.
   assert.match(appSource, /initPsbtEditor\(\{ networkDefault: \(\) => hodlNetworkDefault \}\)/);
   assert.match(css, /#psbted-card\[hidden\]/);


### PR DESCRIPTION
The PSBT Editor already loads a Sparrow/Coldcard binary `.psbt` (and a hex/base64 text export saved to disk). The PSBT / Nonce inspector still required a paste.

This gives the inspector the same file path:

- **Upload .psbt file** uses the shared `psbtBytesFromUpload` decoder (magic sniff, then the paste-box rules).
- The textarea still shows base64, so Inspect and the rest of the inspector do not grow a second parser.
- **Download .psbt** writes the loaded bytes as `.psbt`, or `.txn` when the payload is a raw transaction.
- Journal audit covers both clicks. Empty download asks for a paste/upload first.

No signing, no CSPRNG, no network. Generated `entropylab.html` is left to CI.

## Tests

- `npm run build`
- `npm test` — 1,203 passed, 4 skipped (`bitcoind` not installed), 1 failed (`test/browser.test.mjs`: no Firefox/Chrome/Edge in this environment)
- Targeted: `node --test test/psbt-upload.test.mjs test/ui-defaults.test.mjs` — 101/101