### PR TITLE
Drop stale journal variants and align the number-bases method label

### DIFF
--- a/src/js/journal.js
+++ b/src/js/journal.js
@@ -348,7 +348,7 @@ const JOURNAL_EXPORT_KINDS = new Set(["notebook", "key-manager", "session-state"
 export const METHOD_LABELS = Object.freeze({
   dice: "Dice rolls",
   coin: "Coin flips",
-  hex: "Hex",
+  hex: "Number bases",
   brain: "Brain-wallet text",
   seed: "Manual seed",
   cards: "Playing cards",
@@ -360,6 +360,16 @@ const ENTRY_VARIANTS = Object.freeze({
   seedMethod: Object.freeze({ words: "Direct words", numbers: "BIP39 word numbers" }),
 });
 
+// Each entry method owns at most one variant field. normalizeEntry keeps only
+// the field that belongs to the entry's method, so a stale variant cannot
+// survive a method switch through replaceEntry's merge of the previous entry.
+const METHOD_VARIANT_FIELD = Object.freeze({
+  dice: "diceMethod",
+  hex: "entropyFormat",
+  cards: "cardMethod",
+  seed: "seedMethod",
+});
+
 function normalizeEntryVariant(field, value) {
   const variant = String(value ?? "");
   return Object.hasOwn(ENTRY_VARIANTS[field], variant) ? variant : "";
@@ -368,9 +378,9 @@ function normalizeEntryVariant(field, value) {
 export function entryMethodLabel(entry) {
   const method = String(entry?.method || "");
   const base = METHOD_LABELS[method] || method;
-  const field = method === "dice" ? "diceMethod" : method === "hex" ? "entropyFormat" : method === "cards" ? "cardMethod" : method === "seed" ? "seedMethod" : "";
+  const field = METHOD_VARIANT_FIELD[method] || "";
   const variant = field ? ENTRY_VARIANTS[field][normalizeEntryVariant(field, entry?.[field])] : "";
-  return variant ? `${method === "hex" ? "Number bases" : base} · ${variant}` : base;
+  return variant ? `${base} · ${variant}` : base;
 }
 
 const encoder = new TextEncoder();
@@ -478,8 +488,9 @@ export function normalizeEntry(entry, now = new Date()) {
     walletName: String(entry?.walletName ?? ""),
     fingerprint: String(entry?.fingerprint ?? "").toLowerCase(),
   };
+  const variantField = METHOD_VARIANT_FIELD[method] || "";
   for (const field of Object.keys(ENTRY_VARIANTS)) {
-    const variant = normalizeEntryVariant(field, entry?.[field]);
+    const variant = field === variantField ? normalizeEntryVariant(field, entry?.[field]) : "";
     if (variant) normalized[field] = variant;
   }
   return normalized;

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -1299,7 +1299,7 @@
       document.getElementById("journal-commit").click();
       await until(() => [...document.querySelectorAll("#journal-list .journal-item-label")].some((el) => el.textContent === entryLabel), "committed entry in the list");
       assert(document.getElementById("journal-editor").hidden, "Committing should close the editor");
-      assert([...document.querySelectorAll("#journal-list .journal-item-meta")].some((el) => el.textContent.startsWith("Hex · ")), "The entry should list its method and date");
+      assert([...document.querySelectorAll("#journal-list .journal-item-meta")].some((el) => el.textContent.startsWith("Number bases · ")), "The entry should list its method and date");
 
       // Store: the Save file button downloads the sealed journal.
       const journalText = await captureDownload("entropylab-journal.json", "journal file download", () => document.getElementById("journal-save").click());

--- a/test/journal-backup.test.mjs
+++ b/test/journal-backup.test.mjs
@@ -348,6 +348,25 @@ test("journal entry variants survive encryption while old and unknown variants s
   assert.equal(hostile.cardMethod, undefined);
   assert.equal(hostile.entropyFormat, undefined);
   assert.equal(entryMethodLabel(hostile), "Playing cards");
+  // The hex method is labeled "Number bases" with or without a variant,
+  // matching the method pickers in the rest of the app.
+  assert.equal(entryMethodLabel(normalizeEntry(sampleEntry({ method: "hex" }), fixedNow)), "Number bases");
+});
+
+test("a variant that belongs to another method is dropped, even through an edit", () => {
+  // replaceEntry merges the previous entry, so a stale diceMethod would
+  // survive a method switch if normalizeEntry did not drop it.
+  const doc = emptyDocument();
+  const entry = addEntry(doc, sampleEntry({ method: "dice", diceMethod: "coldcard" }), fixedNow);
+  const replaced = replaceEntry(doc, entry.id, sampleEntry({ method: "cards", cardMethod: "direct" }));
+  assert.equal(replaced.method, "cards");
+  assert.equal(replaced.diceMethod, undefined);
+  assert.equal(replaced.cardMethod, "direct");
+  assert.equal(entryMethodLabel(replaced), "Playing cards · Direct word selection");
+  // Methods with no variant field (coin, brain) drop every variant.
+  const coin = normalizeEntry(sampleEntry({ method: "coin", diceMethod: "coldcard", seedMethod: "numbers" }), fixedNow);
+  assert.equal(coin.diceMethod, undefined);
+  assert.equal(coin.seedMethod, undefined);
 });
 
 test("the snapshot captures private-key modes and the passphrase warning", () => {


### PR DESCRIPTION
Stacked on #400 — merge that first; this diff then shrinks to the single commit `a6b155f`.

Resolves the two review nits from #400:

1. **Stale variant survives a method switch on edit.** `replaceEntry` merges `{ ...previous, ...fields }`, so editing a `dice` entry into `cards` kept a hidden `diceMethod: "coldcard"` on the cards entry (the editor clears its variant state on method change, but the previous entry's field survived the merge). `normalizeEntry` now keeps only the variant field that belongs to the entry's method — `diceMethod` for dice, `entropyFormat` for hex, `cardMethod` for cards, `seedMethod` for seed, none for coin/brain. The same `METHOD_VARIANT_FIELD` map now drives `entryMethodLabel`, replacing its inline ternary chain.

2. **Inconsistent hex base label.** Entries with a variant rendered "Number bases · …" while legacy hex entries rendered "Hex". `METHOD_LABELS.hex` is now "Number bases", matching the Key Station method picker (`hodlKeyModeLabels.hex`) and `hodlKeySummaryMethod`, and the hardcoded special case in `entryMethodLabel` is gone. The browser suite's journal drill follows the rename.

No new dependencies, no locale catalog changes (the journal method labels are English-only today, same as the existing `METHOD_LABELS` pattern).

Tests:
- `npm run build`
- `node --test test/journal-backup.test.mjs` (41/41, incl. a new `replaceEntry` regression test for the stale variant)
- `npm test` (1,211 passed, 1 skipped — Edge binary absent; Firefox and Chrome journal drills both pass)