### PR TITLE
Refine Key Station journal and entropy UX

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1576,12 +1576,6 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .vanity-source label.field { margin-top: var(--space-control); }
 .vanity-source-from { color: var(--muted); font-weight: 400; }
 .vanity-source #vanity-pass { color: var(--fg); background: var(--bg); cursor: text; }
-/* The stop-on-first-find toggle reads as switched on, not merely hovered. */
-#vanity-first.is-pressed {
-  border-color: var(--selection-accent); color: var(--fg);
-  background: color-mix(in oklab, var(--selection-accent) 16%, var(--surface-2));
-  box-shadow: inset 0 0 0 1px var(--selection-accent);
-}
 .vanity-apply-cell { white-space: nowrap; }
 .vanity-key { display: inline-flex; align-items: center; gap: 8px; font-family: var(--mono); font-size: 13px; white-space: nowrap; }
 .vanity-key code { font-family: var(--mono); }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -75,6 +75,7 @@ import {
   searchEntries as hodlJournalSearch,
   sealDocument as hodlJournalSealDocument,
   sealExport as hodlJournalSealExport,
+  syncKeySnapshots as hodlJournalSyncKeySnapshots,
   snapshotFromKeyState as hodlJournalKeySnapshot,
   snapshotSession as hodlJournalSnapshot,
   wipeBytes as hodlJournalWipeBytes,
@@ -2234,7 +2235,7 @@ var hodlEntropyFormats = Object.freeze({
   base4: Object.freeze({ id: "base4", base: 4, bitsPerDigit: 2, alphabet: "0123", ...hodlHexFormatLabels.base4, method: "base4" }),
   base8: Object.freeze({ id: "base8", base: 8, bitsPerDigit: 3, alphabet: "01234567", ...hodlHexFormatLabels.base8, method: "base8" }),
   hex: Object.freeze({ id: "hex", base: 16, bitsPerDigit: 4, alphabet: "0123456789ABCDEF", ...hodlHexFormatLabels.hex, method: "hex" }),
-  base32: Object.freeze({ id: "base32", base: 32, bitsPerDigit: 5, alphabet: "0123456789ABCDEFGHJKMNPQRSTVWXYZ", ...hodlHexFormatLabels.base32, method: "base32", binaryRemainder: true }),
+  base32: Object.freeze({ id: "base32", base: 32, bitsPerDigit: 5, alphabet: "qpzry9x8gf2tvdw0s3jn54khce6mua7l", ...hodlHexFormatLabels.base32, method: "base32" }),
   base64: Object.freeze({ id: "base64", base: 64, bitsPerDigit: 6, alphabet: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/", ...hodlHexFormatLabels.base64, method: "base64", binaryRemainder: true })
 });
 var hodlBip39WordSet = new Set(hodlBip39Wordlist), hodlBip39WordIndex = new Map(hodlBip39Wordlist.map((word, index) => [word, index])), hodlLastWordCache = /* @__PURE__ */ new Map();
@@ -2919,12 +2920,7 @@ function hodlBinaryDigits(value) {
 function hodlNormalizeEntropyCharacter(character, format) {
   let id = hodlNormalizeEntropyFormat(format), normalized = String(character ?? "");
   if (id === "base64") return normalized;
-  normalized = normalized.toUpperCase();
-  if (id === "base32") {
-    if (normalized === "O") return "0";
-    if (normalized === "I" || normalized === "L") return "1";
-  }
-  return normalized;
+  return id === "base32" ? normalized.toLowerCase() : normalized.toUpperCase();
 }
 function hodlFilterNumberBase(value, format) {
   let meta = hodlEntropyFormatConfig(format), filtered = "";
@@ -3715,15 +3711,18 @@ function hodlPrivateKeyKeyboardToggleMarkup() {
 function hodlBase64KeyboardToggleMarkup() {
   return hodlKeyboardToggleMarkup("base64-keyboard-toggle", "on-screen Base64 keyboard", "base64-keyboard");
 }
+function hodlBase32KeyboardToggleMarkup() {
+  return hodlKeyboardToggleMarkup("base32-keyboard-toggle", "on-screen Bech32 keyboard", "base32-keyboard");
+}
 var hodlSeedKeyboardLayouts = { lower: ["abcdefghij", "klmnopqrs", "tuvwxyz"], upper: ["ABCDEFGHIJ", "KLMNOPQRS", "TUVWXYZ"], number: ["1234567890", "!@#$%^&*()", "-_+=/?\\"] };
-function hodlKeyboardMarkup(passphraseOnly = false, inputName = passphraseOnly ? "passphrase" : "seed phrase", keyboardId = "seed-keyboard", privateInitialOptions = false) {
+function hodlKeyboardMarkup(passphraseOnly = false, inputName = passphraseOnly ? "passphrase" : "seed phrase", keyboardId = "seed-keyboard", privateInitialOptions = false, modeLabel = "aA1") {
   let letters = hodlSeedKeyboardLayouts.lower.map((row, index) => `<div class="seed-keyboard-row" data-seed-keyboard-row="${index + 1}">${Array.from({ length: hodlSeedKeyboardLayouts.number[index].length }, (_, keyIndex) => {
     let letter = row[keyIndex];
     return `<button type="button" class="seed-keyboard-key" data-seed-character-key${letter ? ` data-seed-key="${letter}" aria-label="Enter ${letter}"` : ` hidden disabled aria-hidden="true"`}>${letter || ""}</button>`;
   }).join("")}${index === 2 ? `<button type="button" class="seed-keyboard-key seed-keyboard-delete" data-seed-delete aria-label="Delete previous character"><svg viewBox="0 0 24 18" aria-hidden="true" focusable="false"><path d="M9 2h11a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H9L2 9l7-7Z"/><path d="m12 6 6 6m0-6-6 6"/></svg></button>` : ""}</div>`).join("");
   let initialOptions = privateInitialOptions ? `<div class="seed-keyboard-initial-row" data-private-key-initial-row aria-label="Valid first characters" hidden>${Array.from({ length: 3 }, () => `<button type="button" class="seed-keyboard-key" data-seed-character-key data-private-key-initial disabled hidden></button>`).join("")}</div>` : "";
   let hexKeypad = privateInitialOptions ? `<div class="private-key-hex-keypad" data-private-key-hex-keypad aria-label="Hexadecimal keypad" hidden><div class="private-key-hex-row" aria-label="Hexadecimal numbers">${[..."0123456789"].map((character) => `<button type="button" class="seed-keyboard-key" data-seed-character-key data-private-key-hex-character data-seed-key="${character}" aria-label="Enter ${character}">${character}</button>`).join("")}</div><div class="private-key-hex-row" aria-label="Hexadecimal letters">${[..."abcdef"].map((character) => `<button type="button" class="seed-keyboard-key" data-seed-character-key data-private-key-hex-character data-seed-key="${character}" aria-label="Enter ${character}">${character}</button>`).join("")}<button type="button" class="seed-keyboard-key seed-keyboard-delete" data-seed-delete data-private-key-hex-delete aria-label="Delete previous character"><svg viewBox="0 0 24 18" aria-hidden="true" focusable="false"><path d="M9 2h11a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H9L2 9l7-7Z"/><path d="m12 6 6 6m0-6-6 6"/></svg></button></div></div>` : "";
-  return `<div class="seed-keyboard" id="${keyboardId}" data-on-screen-keyboard role="group" aria-label="On-screen lowercase ${inputName} keyboard" data-seed-keyboard-layout="lower"${hodlOnScreenKeyboardOpen ? "" : " hidden"}>${initialOptions}${letters}${hexKeypad}<div class="seed-keyboard-space-row"><button type="button" class="seed-keyboard-mode" data-seed-keyboard-mode="lower" aria-label="${passphraseOnly ? `Change ${inputName} character mode` : "Character mode switching is available for the passphrase"}"${passphraseOnly ? "" : " disabled"}>aA1</button><button type="button" class="seed-keyboard-space" data-seed-key=" " aria-label="Enter space">space</button></div></div>`;
+  return `<div class="seed-keyboard" id="${keyboardId}" data-on-screen-keyboard role="group" aria-label="On-screen lowercase ${inputName} keyboard" data-seed-keyboard-layout="lower"${hodlOnScreenKeyboardOpen ? "" : " hidden"}>${initialOptions}${letters}${hexKeypad}<div class="seed-keyboard-space-row"><button type="button" class="seed-keyboard-mode" data-seed-keyboard-mode="lower" aria-label="${passphraseOnly ? `Change ${inputName} character mode` : "Character mode switching is available for the passphrase"}"${passphraseOnly ? "" : " disabled"}>${modeLabel}</button><button type="button" class="seed-keyboard-space" data-seed-key=" " aria-label="Enter space">space</button></div></div>`;
 }
 function hodlSeedKeyboardMarkup() {
   return hodlKeyboardMarkup(false);
@@ -3737,11 +3736,14 @@ function hodlPrivateKeyKeyboardMarkup() {
 function hodlBase64KeyboardMarkup() {
   return hodlKeyboardMarkup(true, "Base64 entropy", "base64-keyboard");
 }
+function hodlBase32KeyboardMarkup() {
+  return hodlKeyboardMarkup(true, "Bech32 entropy", "base32-keyboard", false, "a1");
+}
 function hodlSetOnScreenKeyboardOpen(open) {
   hodlOnScreenKeyboardOpen = Boolean(open);
   document.querySelectorAll("[data-on-screen-keyboard-toggle]").forEach((toggle) => {
     toggle.setAttribute("aria-expanded", String(hodlOnScreenKeyboardOpen));
-    let target = toggle.id === "passphrase-keyboard-toggle" ? "passphrase" : toggle.id === "private-keyboard-toggle" ? "private key" : toggle.id === "base64-keyboard-toggle" ? "Base64" : "seed";
+    let target = toggle.id === "passphrase-keyboard-toggle" ? "passphrase" : toggle.id === "private-keyboard-toggle" ? "private key" : toggle.id === "base64-keyboard-toggle" ? "Base64" : toggle.id === "base32-keyboard-toggle" ? "Bech32" : "seed";
     toggle.setAttribute("aria-label", `${hodlOnScreenKeyboardOpen ? "Hide" : "Show"} on-screen ${target} keyboard`);
   });
   document.querySelectorAll("[data-on-screen-keyboard]").forEach((keyboard) => {
@@ -3851,6 +3853,20 @@ function hodlUpdateBase64KeyboardKeys(input) {
   keyboard.querySelectorAll("[data-seed-character-key]").forEach((button) => {
     let character = button.dataset.seedKey || "", remainder = definition.remainderBits && analysis.count >= definition.fullDigits, invalid = !definition.alphabet.includes(character) || analysis.count >= definition.digits || remainder && !definition.finalCharacters.includes(character);
     button.disabled = invalid;
+  });
+  let space = keyboard.querySelector(".seed-keyboard-space");
+  if (space) space.disabled = !input.value || /\s$/.test(input.value) || analysis.count >= definition.digits;
+  let remove = keyboard.querySelector("[data-seed-delete]"), start = input.selectionStart ?? input.value.length, end = input.selectionEnd ?? start;
+  if (remove) remove.disabled = start === end && start === 0;
+}
+function hodlUpdateBase32KeyboardKeys(input) {
+  let keyboard = document.getElementById("base32-keyboard");
+  if (!keyboard || !input) return;
+  let analysis = hodlAnalyzeEntropyInput(input.value, "base32", hodlTargetWordCount), definition = analysis.meta;
+  keyboard.querySelectorAll("[data-seed-character-key]").forEach((button) => {
+    let character = button.dataset.seedKey || "", available = definition.alphabet.includes(character), finalCharacter = definition.remainderBits && analysis.count >= definition.fullDigits;
+    button.hidden = keyboard.dataset.seedKeyboardLayout === "lower" && !available;
+    button.disabled = !available || analysis.count >= definition.digits || finalCharacter && !definition.finalCharacters.includes(character);
   });
   let space = keyboard.querySelector(".seed-keyboard-space");
   if (space) space.disabled = !input.value || /\s$/.test(input.value) || analysis.count >= definition.digits;
@@ -4361,6 +4377,31 @@ function hodlBindBase64Keyboard(input) {
     };
   }
   ;
+  ["input", "focus", "click", "keyup", "select"].forEach((type) => input.addEventListener(type, refresh));
+  refresh();
+}
+function hodlBindBase32Keyboard(input) {
+  let toggle = document.getElementById("base32-keyboard-toggle"), keyboard = document.getElementById("base32-keyboard"), modeButton = keyboard?.querySelector("[data-seed-keyboard-mode]");
+  if (!toggle || !keyboard || !input) return;
+  let refresh = () => hodlUpdateBase32KeyboardKeys(input);
+  toggle.onclick = () => {
+    hodlSetOnScreenKeyboardOpen(!hodlOnScreenKeyboardOpen);
+    refresh();
+  };
+  hodlBindKeypadPointer(keyboard.querySelectorAll("button"), () => input);
+  keyboard.querySelectorAll("[data-seed-character-key],.seed-keyboard-space").forEach((button) => {
+    button.onclick = () => hodlApplySeedKeyboardKey(input, button.dataset.seedKey || "");
+  });
+  keyboard.querySelectorAll("[data-seed-delete]").forEach((button) => hodlBindSeedKeyboardDelete(() => input, button));
+  if (modeButton) {
+    modeButton.disabled = false;
+    modeButton.onclick = () => {
+      let next = keyboard.dataset.seedKeyboardLayout === "lower" ? "number" : "lower";
+      hodlSetSeedKeyboardLayout(keyboard, modeButton, next);
+      keyboard.setAttribute("aria-label", `On-screen ${next === "lower" ? "lowercase" : "number"} Bech32 entropy keyboard`);
+      refresh();
+    };
+  }
   ["input", "focus", "click", "keyup", "select"].forEach((type) => input.addEventListener(type, refresh));
   refresh();
 }
@@ -5390,18 +5431,19 @@ function hodlRenderKeyForm() {
       return `<label class="choice"><input type="radio" name="entropy-format" value="${id}" ${format.id === id ? "checked" : ""} /><span><strong>${hodlT(hodlHexFormatLabels[id].label)}</strong><span class="desc">${hodlT(hodlHexFormatLabels[id].desc)}</span></span></label>`;
     }).join("");
     let formatLabel = hodlT(format.label), formatShort = hodlT(format.shortLabel), formatUnit = hodlT(format.unit);
-    let entropyPad = format.id === "base64" ? "" : `<div class="dice-input-pad entropy-keypad entropy-keypad-${format.id}" role="group" aria-label="${hodlT("{label} keypad", { label: formatLabel })}">${[...format.alphabet].map((character) => `<button type="button"${format.id === "bin" ? ' class="coin-button"' : ""} data-entropy-digit="${character}" aria-label="${format.id === "bin" ? character === "0" ? hodlT("Enter Heads as binary 0") : hodlT("Enter Tails as binary 1") : hodlT("Enter {shortLabel} {character}", { shortLabel: formatShort, character })}">${format.id === "bin" ? character === "0" ? hodlT("Heads (0)") : hodlT("Tails (1)") : character}</button>`).join("")}</div>`;
-    let remainderHelp = format.remainderBits ? format.binaryRemainder ? hodlT(" Enter {fullDigits} complete {shortLabel} characters; the controls and progress message then switch to {n} coin flip(s), using Heads (0) or Tails (1).", { fullDigits: format.fullDigits, shortLabel: formatShort, n: format.remainderBits }) : hodlT(" The final character is mixed-radix: it contributes only {n} bit(s) and must be one of {chars}.", { n: format.remainderBits, chars: [...format.finalCharacters].join(", ") }) : "", base64Tools = format.id === "base64" ? `<div class="seed-entry-tools base64-entry-tools">${hodlBase64KeyboardToggleMarkup()}</div>` : "", base64Keyboard = format.id === "base64" ? hodlBase64KeyboardMarkup() : "";
+    let usesKeyboard = format.id === "base32" || format.id === "base64";
+    let entropyPad = usesKeyboard ? "" : `<div class="dice-input-pad entropy-keypad entropy-keypad-${format.id}" role="group" aria-label="${hodlT("{label} keypad", { label: formatLabel })}">${[...format.alphabet].map((character) => `<button type="button"${format.id === "bin" ? ' class="coin-button"' : ""} data-entropy-digit="${character}" aria-label="${format.id === "bin" ? character === "0" ? hodlT("Enter Heads as binary 0") : hodlT("Enter Tails as binary 1") : hodlT("Enter {shortLabel} {character}", { shortLabel: formatShort, character })}">${format.id === "bin" ? character === "0" ? hodlT("Heads (0)") : hodlT("Tails (1)") : character}</button>`).join("")}</div>`;
+    let remainderHelp = format.remainderBits ? format.binaryRemainder ? hodlT(" Enter {fullDigits} complete {shortLabel} characters; the controls and progress message then switch to {n} coin flip(s), using Heads (0) or Tails (1).", { fullDigits: format.fullDigits, shortLabel: formatShort, n: format.remainderBits }) : hodlT(" The final character is mixed-radix: it contributes only {n} bit(s) and must be one of {chars}.", { n: format.remainderBits, chars: [...format.finalCharacters].join(", ") }) : "", keyboardTools = format.id === "base32" ? `<div class="seed-entry-tools base64-entry-tools">${hodlBase32KeyboardToggleMarkup()}</div>` : format.id === "base64" ? `<div class="seed-entry-tools base64-entry-tools">${hodlBase64KeyboardToggleMarkup()}</div>` : "", numberBaseKeyboard = format.id === "base32" ? hodlBase32KeyboardMarkup() : format.id === "base64" ? hodlBase64KeyboardMarkup() : "";
     hodlFormEl.innerHTML = `
       <p class="label">${hodlT("Number base")}</p>
       <div class="choice-grid entropy-format-grid">${formatChoices}</div>
       ${["bin", "base4", "base8", "hex"].includes(format.id) ? `<label class="seed-autocomplete-toggle number-base-calculations-toggle"><input type="checkbox" id="show-number-base-calculations" ${state?.showNumberBaseCalculations ? "checked" : ""} /><span><strong>${hodlT("Show calculations")}</strong> <span class="seed-autocomplete-note">${hodlT("(show how each BIP39 word number is calculated)")}</span></span></label>` : ""}
       <p class="label" id="entropy-input-label">${format.label} entropy for a ${config.words}-word seed</p>
       <p class="muted" id="entropy-input-help">Each complete ${format.shortLabel} character contributes ${format.bitsPerDigit} bit${format.bitsPerDigit === 1 ? "" : "s"}${format.binaryRemainder ? "" : " except for a mixed-radix final character when needed"}. Seed-word cards fill as enough bits arrive; the checksum-derived final word appears when all ${format.digits} characters are entered.${format.id === "bin" ? " Spaces are added every 11 bits." : ""}${remainderHelp} No generator \u2014 enter entropy you already created.</p>
-      ${base64Tools}
-      <div class="dice-input-shell entropy-input-shell"><pre class="dice-input-highlight" id="entropy-input-highlight" aria-hidden="true"></pre><textarea id="${inputId}" placeholder="${hodlT("Exactly {digits} {unit}", { digits: format.digits, unit: formatUnit })}" aria-labelledby="entropy-input-label" aria-describedby="entropy-input-help entropy-meta" autocomplete="off" spellcheck="false" autocapitalize="${format.id === "base64" ? "off" : format.base > 10 ? "characters" : "off"}"></textarea></div>
+      ${keyboardTools}
+      <div class="dice-input-shell entropy-input-shell"><pre class="dice-input-highlight" id="entropy-input-highlight" aria-hidden="true"></pre><textarea id="${inputId}" placeholder="${hodlT("Exactly {digits} {unit}", { digits: format.digits, unit: formatUnit })}" aria-labelledby="entropy-input-label" aria-describedby="entropy-input-help entropy-meta" autocomplete="off" spellcheck="false" autocapitalize="${usesKeyboard ? "off" : format.base > 10 ? "characters" : "off"}"></textarea></div>
       ${hodlSeedMetaRowMarkup("entropy-meta", true)}
-      ${base64Keyboard}
+      ${numberBaseKeyboard}
       ${entropyPad}
       <div id="number-base-calculations" class="number-base-calculations-panel" hidden></div>
       ${hodlSeedCopyRowMarkup()}
@@ -5433,7 +5475,8 @@ function hodlRenderKeyForm() {
       hodlFormEl.querySelectorAll("[data-entropy-digit]").forEach((button) => {
         button.onclick = () => hodlInsertEntropyControl(entropyInput, button);
       });
-      if (format.id === "base64") hodlBindBase64Keyboard(entropyInput);
+      if (format.id === "base32") hodlBindBase32Keyboard(entropyInput);
+      else if (format.id === "base64") hodlBindBase64Keyboard(entropyInput);
     }
     hodlRenderPassphraseKeyboard();
     return;
@@ -6309,6 +6352,7 @@ async function hodlCalculateKey(progress) {
     hodlJournalLog("derive", hodlWalletResult?.masterFingerprint || hodlWalletResult?.kind || "key");
     hodlSnapshotKeySummary();
     hodlCommitDerivedKey();
+    hodlJournalCaptureDerivedKey(hodlKeys[hodlActiveKey]);
     hodlFocusWalletResult();
     return true;
   } catch (error) {
@@ -10837,10 +10881,10 @@ function hodlKeySummaryMethod(state) {
     ? state.cardMethod === "direct" ? "Direct word selection" : "Hashed card transcript"
     : state.mode === "hex" ? {
       bin: "Binary (Base 2)",
-      base4: "Base 4",
+      base4: "Quaternary (Base 4)",
       base8: "Octal (Base 8)",
       hex: "Hexadecimal (Base 16)",
-      base32: "Crockford Base32",
+      base32: "Base32 (Bech32)",
       base64: "Base64 (RFC 4648 alphabet)",
     }[state.entropyFormat || "bin"]
     : state.mode === "seed" ? state.seedMethod === "numbers" ? "BIP39 word numbers" : "Direct word entry"
@@ -13210,7 +13254,7 @@ function hodlScheduleJournalStateRefresh() {
 }
 // The encrypted entropy notebook gates the Journal tools and keeps its
 // document and Web Crypto keys apart from the session notepad.
-var hodlJournalKeys = null, hodlJournalDoc = null, hodlJournalFileText = "", hodlJournalDirty = false, hodlJournalGate = "create", hodlJournalReveal = false, hodlJournalEditingId = null, hodlJournalDeleteArmed = false, hodlJournalEntryVariants = {};
+var hodlJournalKeys = null, hodlJournalDoc = null, hodlJournalFileText = "", hodlJournalDirty = false, hodlJournalGate = "create", hodlJournalReveal = false, hodlJournalEditingId = null, hodlJournalDeleteArmed = false, hodlJournalEntryVariants = {}, hodlJournalKeyEntries = new Map();
 function hodlJournalReadEntryVariants(entry) {
   if (!entry) return {};
   return Object.fromEntries(["diceMethod", "entropyFormat", "cardMethod", "seedMethod"].filter((field) => entry[field]).map((field) => [field, entry[field]]));
@@ -13236,6 +13280,7 @@ function hodlJournalWipeNotebook() {
   hodlJournalReveal = false;
   hodlJournalEditingId = null;
   hodlJournalDeleteArmed = false;
+  hodlJournalKeyEntries.clear();
 }
 // A notebook whose decryption outlived its session: the generation check in
 // create/unlock routes it here, so its plaintext and verify digest are wiped
@@ -13351,7 +13396,7 @@ function hodlJournalUnlocked() {
 function hodlJournalNoteText() {
   if (!hodlJournalDoc) return "Create a journal or open a journal file.";
   let n = hodlJournalDoc.entries.length;
-  let unsaved = hodlJournalDirty ? " Unsaved changes \u2014 download the journal file before locking." : "";
+  let unsaved = hodlJournalDirty ? " Unsaved changes \u2014 download the journal file to preserve them." : "";
   if (!n) return "No entries yet. Download the journal file after you add one." + unsaved;
   return `${n} ${n === 1 ? "entry" : "entries"} in this page only.${unsaved}`;
 }
@@ -13468,21 +13513,6 @@ function hodlJournalHideEditor() {
   hodlJournalEntryVariants = {};
   hodlJournalFillWallets("");
 }
-function hodlJournalApplySnapshot(snapshot) {
-  if (!snapshot) throw new Error("Derive a key first, then return to the journal.");
-  let method = document.getElementById("journal-method");
-  if (method) method.value = snapshot.method;
-  let input = document.getElementById("journal-input");
-  if (input) input.value = snapshot.input;
-  let phrase = document.getElementById("journal-phrase");
-  if (phrase) phrase.value = snapshot.phrase;
-  let label = document.getElementById("journal-label");
-  if (label && !label.value.trim()) label.value = snapshot.label;
-  let notes = document.getElementById("journal-entry-notes");
-  if (notes && !notes.value.trim()) notes.value = snapshot.notes;
-  hodlJournalEntryVariants = hodlJournalReadEntryVariants(snapshot);
-  hodlJournalFillWallets(snapshot.walletId ?? "");
-}
 function hodlJournalShowEditor(entry) {
   if (!hodlJournalUnlocked()) throw new Error("Create or open a journal first.");
   hodlJournalEditingId = entry?.id ?? null;
@@ -13577,6 +13607,29 @@ function hodlJournalOpenView(id) {
     hodlJournalShowWork();
   };
 }
+function hodlJournalSyncDerivedKeys(states) {
+  if (!hodlJournalUnlocked()) return { added: 0, updated: 0, matched: 0 };
+  try {
+    let snapshots = (states || []).filter((state) => state && !state.isLab && state.result).map(hodlJournalKeySnapshot).filter(Boolean);
+    let result = hodlJournalSyncKeySnapshots(hodlJournalDoc, snapshots, hodlJournalKeyEntries);
+    if (result.added || result.updated) hodlJournalDirty = true;
+    return result;
+  } catch (exception) {
+    hodlJournalError(`The key was derived, but its journal entry could not be updated: ${exception.message || String(exception)}`);
+    return { added: 0, updated: 0, matched: 0 };
+  }
+}
+function hodlJournalBackfillDerivedKeys() {
+  let result = hodlJournalSyncDerivedKeys(hodlKeys);
+  if (result.added) hodlJournalLog("entry-auto-add", `${result.added} Key Station ${result.added === 1 ? "key" : "keys"}`);
+  return result;
+}
+function hodlJournalCaptureDerivedKey(state) {
+  let result = hodlJournalSyncDerivedKeys([state]);
+  if (!result.added && !result.updated) return;
+  hodlJournalLog(result.updated ? "entry-auto-update" : "entry-auto-add", state?.result?.masterFingerprint || state?.name || "Key Station key");
+  hodlJournalShowWork();
+}
 async function hodlJournalCreate() {
   hodlJournalError("");
   let generation = hodlJournalGeneration;
@@ -13588,11 +13641,12 @@ async function hodlJournalCreate() {
     hodlJournalKeys = created.keys;
     hodlJournalDoc = created.doc;
     hodlJournalDirty = true;
+    hodlJournalBackfillDerivedKeys();
     document.getElementById("journal-create-password").value = "";
     document.getElementById("journal-create-confirm").value = "";
     hodlJournalHideEditor();
     hodlJournalShowWork();
-    hodlShowJournalTool("notes");
+    hodlShowJournalTool("book");
     hodlJournalLog("journal-create");
   } catch (exception) {
     hodlJournalError(exception.message || String(exception));
@@ -13610,12 +13664,13 @@ async function hodlJournalUnlock() {
     hodlJournalKeys = opened.keys;
     hodlJournalDoc = opened.doc;
     hodlJournalDirty = false;
+    hodlJournalBackfillDerivedKeys();
     document.getElementById("journal-open-password").value = "";
     document.getElementById("journal-file").value = "";
     hodlJournalFileText = "";
     hodlJournalHideEditor();
     hodlJournalShowWork();
-    hodlShowJournalTool("notes");
+    hodlShowJournalTool("book");
     hodlJournalLog("journal-unlock", `${opened.doc.entries.length} entries`);
   } catch (exception) {
     hodlJournalError(exception.message || String(exception));
@@ -13666,15 +13721,6 @@ function hodlJournalCommit() {
     hodlJournalError(exception.message || String(exception));
   }
 }
-function hodlJournalUseActiveKey() {
-  hodlJournalError("");
-  try {
-    if (hodlWorkspace === "calc") hodlCaptureKey();
-    hodlJournalApplySnapshot(hodlJournalKeySnapshot(hodlKeys[hodlActiveKey]));
-  } catch (exception) {
-    hodlJournalError(exception.message || String(exception));
-  }
-}
 function hodlJournalLock() {
   hodlKeyManagerReset();
   hodlJournalWipeNotebook();
@@ -13713,29 +13759,11 @@ function hodlInitJournalNotebook() {
   document.getElementById("journal-global-clear")?.addEventListener("click", hodlJournalWipeMem);
   document.getElementById("journal-commit")?.addEventListener("click", hodlJournalCommit);
   document.getElementById("journal-method")?.addEventListener("change", () => { hodlJournalEntryVariants = {}; });
-  document.getElementById("journal-use-calc")?.addEventListener("click", hodlJournalUseActiveKey);
   document.getElementById("journal-cancel")?.addEventListener("click", () => {
     hodlJournalHideEditor();
     hodlJournalRenderList();
   });
   document.getElementById("journal-search")?.addEventListener("input", hodlJournalRenderList);
-  let open = document.getElementById("journal-open");
-  if (open) open.onclick = () => {
-    if (hodlWorkspace === "calc") hodlCaptureKey();
-    hodlShowWorkspace("journal");
-    hodlShowJournalTool("book");
-    hodlJournalError("");
-    try {
-      if (!hodlJournalUnlocked()) {
-        hodlJournalError("Create or open a journal, then save this key into it.");
-        return;
-      }
-      hodlJournalShowEditor(null);
-      hodlJournalUseActiveKey();
-    } catch (exception) {
-      hodlJournalError(exception.message || String(exception));
-    }
-  };
   hodlJournalSetGate("create");
   hodlJournalShowWork();
 }
@@ -13959,9 +13987,8 @@ function hodlVanityEstimate() {
     estimateEl.textContent = "";
   }
 }
-function hodlVanityToggleStopFirst() {
-  hodlVanityStopFirst = !hodlVanityStopFirst;
-  hodlVanitySyncControls();
+function hodlVanityStopFirstChanged() {
+  hodlVanityStopFirst = Boolean(document.getElementById("vanity-first")?.checked);
 }
 // Turns the key's Keys-tab settings into the grind plan: the concrete
 // derivation path (the key's own purpose, coin type, account, branch, and
@@ -14142,22 +14169,34 @@ function hodlRenderVanityOut() {
   box.querySelectorAll("img[data-vanity-lifehash]").forEach((image) => hodlFillKeyTabLifehash(image, image.dataset.vanityLifehash));
 }
 function hodlVanitySyncControls() {
-  let go = document.getElementById("vanity-go"), stop = document.getElementById("vanity-stop"), wipe = document.getElementById("vanity-wipe"), progress = document.getElementById("vanity-progress");
+  let go = document.getElementById("vanity-go"), wipe = document.getElementById("vanity-wipe"), progress = document.getElementById("vanity-progress");
   let source = hodlVanitySourceState();
   if (go) {
-    let blocked = hodlVanityRunning || hodlVanityApplying || !source;
+    if (hodlVanityRunning) {
+      if (!go.dataset.derivationWidth) {
+        let width = go.getBoundingClientRect().width;
+        if (width > 0) {
+          go.dataset.derivationWidth = String(width);
+          go.style.width = `${width}px`;
+        }
+      }
+      go.textContent = hodlTText("Stop");
+      go.dataset.derivationState = "running";
+      go.setAttribute("aria-label", hodlTText("Stop grinding"));
+    } else {
+      go.textContent = hodlTText("Start grinding");
+      delete go.dataset.derivationState;
+      delete go.dataset.derivationWidth;
+      go.removeAttribute("aria-label");
+      go.style.removeProperty("width");
+    }
+    let blocked = hodlVanityApplying || !source;
     go.disabled = blocked;
     go.setAttribute("aria-disabled", String(blocked));
-    go.textContent = hodlVanityRunning ? "Grinding…" : "Start grinding";
     go.title = source ? "" : "Pick a Key Station key first";
   }
-  if (stop) stop.disabled = !hodlVanityRunning;
   let first = document.getElementById("vanity-first");
-  if (first) {
-    first.setAttribute("aria-pressed", String(hodlVanityStopFirst));
-    first.classList.toggle("is-pressed", hodlVanityStopFirst);
-    first.textContent = hodlVanityStopFirst ? "Stop on first find: on" : "Stop on first find";
-  }
+  if (first) first.checked = hodlVanityStopFirst;
   let dirty = hodlVanityFound > 0 && !hodlVanityRunning && !hodlVanityApplying;
   if (wipe) {
     wipe.disabled = !dirty;
@@ -14341,9 +14380,8 @@ function hodlInitVanity() {
   if (!go) return;
   let workersField = document.getElementById("vanity-workers");
   if (workersField && navigator.hardwareConcurrency) workersField.value = String(Math.max(1, Math.min(64, navigator.hardwareConcurrency)));
-  go.onclick = hodlRunVanity;
-  document.getElementById("vanity-stop").onclick = hodlVanityStop;
-  document.getElementById("vanity-first").onclick = hodlVanityToggleStopFirst;
+  go.onclick = () => hodlVanityRunning ? hodlVanityStop() : hodlRunVanity();
+  document.getElementById("vanity-first").onchange = hodlVanityStopFirstChanged;
   document.getElementById("vanity-wipe").onclick = () => hodlVanityClearResults();
   workersField?.addEventListener("input", hodlVanityEstimate);
   let prefix = document.getElementById("vanity-prefix");

--- a/src/js/i18n-labels.js
+++ b/src/js/i18n-labels.js
@@ -32,9 +32,9 @@ export const hodlHexFormatLabels = Object.freeze({
     desc: "Use one 0 or 1 for each coin flip.",
   }),
   base4: Object.freeze({
-    label: "Base 4",
-    shortLabel: "Base 4",
-    unit: "base-4 digits",
+    label: "Quaternary (Base 4)",
+    shortLabel: "Quaternary",
+    unit: "quaternary digits",
     desc: "Each digit contributes exactly two bits; useful with a fair four-sided source.",
   }),
   base8: Object.freeze({
@@ -50,10 +50,10 @@ export const hodlHexFormatLabels = Object.freeze({
     desc: "Each hexadecimal character contributes four bits.",
   }),
   base32: Object.freeze({
-    label: "Crockford Base32",
-    shortLabel: "Base32",
-    unit: "characters",
-    desc: "Uses the unambiguous Crockford alphabet, then switches to coin flips for any remaining bits; O becomes 0 and I or L becomes 1.",
+    label: "Base32 (Bech32)",
+    shortLabel: "Bech32",
+    unit: "Bech32 characters",
+    desc: "Uses the lowercase Bech32 data-character alphabet without an HRP or checksum; a restricted final character carries any remaining bits.",
   }),
   base64: Object.freeze({
     label: "Base64 (RFC 4648 alphabet)",

--- a/src/js/journal.js
+++ b/src/js/journal.js
@@ -369,7 +369,7 @@ export const METHOD_LABELS = Object.freeze({
 });
 const ENTRY_VARIANTS = Object.freeze({
   diceMethod: Object.freeze({ coldcard: "COLDCARD / SeedSigner", coleman: "Ian Coleman / Keystone", bitbox: "BitBox diceware", dplus: "D++ direct word selection" }),
-  entropyFormat: Object.freeze({ bin: "Binary (Base 2)", base4: "Base 4", base8: "Base 8", hex: "Hexadecimal (Base 16)", base32: "Crockford Base32", base64: "Base64" }),
+  entropyFormat: Object.freeze({ bin: "Binary (Base 2)", base4: "Quaternary (Base 4)", base8: "Base 8", hex: "Hexadecimal (Base 16)", base32: "Base32 (Bech32)", base64: "Base64" }),
   cardMethod: Object.freeze({ hashed: "Hashed transcript", direct: "Direct word selection" }),
   seedMethod: Object.freeze({ words: "Direct words", numbers: "BIP39 word numbers" }),
 });
@@ -597,6 +597,68 @@ export function snapshotFromKeyState(state) {
     walletName: String(state.name || ""),
     fingerprint: String(state.result?.masterFingerprint || "").toLowerCase(),
   };
+}
+
+const KEY_SNAPSHOT_MATCH_FIELDS = Object.freeze([
+  "method",
+  "diceMethod",
+  "entropyFormat",
+  "cardMethod",
+  "seedMethod",
+  "input",
+  "phrase",
+  "label",
+  "notes",
+  "walletName",
+  "fingerprint",
+]);
+
+// Session wallet ids are intentionally excluded: they are only meaningful in
+// the current page and may be reused when a journal is opened later.
+export function keySnapshotMatchesEntry(entry, snapshot) {
+  if (!entry || !snapshot) return false;
+  return KEY_SNAPSHOT_MATCH_FIELDS.every((field) => {
+    let left = String(entry[field] ?? ""), right = String(snapshot[field] ?? "");
+    if (field === "fingerprint") {
+      left = left.toLowerCase();
+      right = right.toLowerCase();
+    }
+    return left === right;
+  });
+}
+
+export function syncKeySnapshots(doc, snapshots, associations, now = new Date()) {
+  if (!doc || !Array.isArray(doc.entries)) throw new Error("Journal document is missing.");
+  if (!(associations instanceof Map)) throw new Error("Journal key associations are missing.");
+  const result = { added: 0, updated: 0, matched: 0 };
+  const claimedEntryIds = new Set();
+  for (const snapshot of snapshots || []) {
+    if (!snapshot || snapshot.walletId == null || snapshot.walletId === "") continue;
+    const stateId = Number(snapshot.walletId);
+    if (!Number.isInteger(stateId) || stateId < 0) continue;
+    let entryId = associations.get(stateId);
+    let entry = entryId == null || claimedEntryIds.has(entryId) ? null : doc.entries.find((item) => item.id === entryId);
+    if (!entry && entryId != null) associations.delete(stateId);
+    if (entry) {
+      claimedEntryIds.add(entry.id);
+      if (keySnapshotMatchesEntry(entry, snapshot)) {
+        result.matched++;
+      } else {
+        entry = replaceEntry(doc, entry.id, snapshot);
+        result.updated++;
+      }
+    } else {
+      entry = doc.entries.find((item) => !claimedEntryIds.has(item.id) && keySnapshotMatchesEntry(item, snapshot));
+      if (entry) result.matched++;
+      else {
+        entry = addEntry(doc, snapshot, now);
+        result.added++;
+      }
+      associations.set(stateId, entry.id);
+      claimedEntryIds.add(entry.id);
+    }
+  }
+  return result;
 }
 
 export function encodeFile({ iv, ciphertext, iterations = JOURNAL_ITERATIONS }) {

--- a/src/shell.html
+++ b/src/shell.html
@@ -205,7 +205,6 @@ words, pick one of the checksum words.</span></span>
       <div class="row key-action-row current-item-actions tool-actions">
         <button class="btn primary" id="go" disabled aria-disabled="true">Derive Key</button>
         <div class="derive-progress" id="derive-progress" role="progressbar" aria-label="Key derivation progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-valuetext="0% complete" hidden><span class="derive-progress-track"><span class="derive-progress-bar"></span></span><span class="derive-progress-label">0%</span></div>
-        <button class="btn secondary" id="journal-open" type="button">Save to Journal</button>
         <button class="btn clear-current-action" id="wipe" type="button" disabled aria-disabled="true">Clear Current Key</button>
       </div>
       <p class="err" id="error"></p>
@@ -288,11 +287,12 @@ words, pick one of the checksum words.</span></span>
           </label>
         </div>
         <p class="muted" id="vanity-estimate" aria-live="polite"></p>
+        <div class="switch-row vanity-first-row">
+          <label class="seed-autocomplete-toggle switch-toggle vanity-first-toggle"><input id="vanity-first" type="checkbox"><span>Stop on first find</span></label>
+        </div>
         <div class="row current-item-actions tool-actions">
           <button class="btn primary" id="vanity-go" type="button">Start grinding</button>
           <div class="derive-progress" id="vanity-progress" role="progressbar" aria-label="Vanity grinding progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-valuetext="0% complete" hidden><span class="derive-progress-track"><span class="derive-progress-bar"></span></span><span class="derive-progress-label">0%</span></div>
-          <button class="btn secondary" id="vanity-stop" type="button" disabled>Stop</button>
-          <button class="btn secondary" id="vanity-first" type="button" aria-pressed="false" title="Stop grinding as soon as the first match is found">Stop on first find</button>
           <button class="btn clear-current-action" id="vanity-wipe" type="button" disabled aria-disabled="true">Clear results</button>
         </div>
         <p class="muted" id="vanity-status" aria-live="polite">Idle. No range has been ground this session.</p>
@@ -702,6 +702,7 @@ words, pick one of the checksum words.</span></span>
     <section class="key-manager no-print" id="journal-manager" hidden>
       <div class="key-tab-strip">
         <div class="key-tabs" id="journal-tool-tabs" role="tablist" aria-label="Journal stations">
+          <button class="tab key-tab is-lab" id="journal-book-tab" type="button" role="tab" aria-selected="false" aria-controls="journal-card" aria-disabled="true" data-journal-tool="book" disabled>Entries</button>
           <button class="tab key-tab is-lab" id="journal-notes-tab" type="button" role="tab" aria-selected="false" aria-controls="journal-notes-card" aria-disabled="true" data-journal-tool="notes" disabled>Notepad</button>
           <button class="tab key-tab is-lab" id="journal-keymanager-tab" type="button" role="tab" aria-selected="false" aria-controls="journal-keymanager-card" aria-disabled="true" data-journal-tool="keymanager" disabled>Key manager</button>
           <button class="tab key-tab is-lab" id="journal-state-tab" type="button" role="tab" aria-selected="false" aria-controls="journal-state-card" aria-disabled="true" data-journal-tool="state" disabled>Session state</button>
@@ -786,7 +787,6 @@ words, pick one of the checksum words.</span></span>
           </label>
           <div class="row bip85-actions tool-actions">
             <button class="btn primary" id="journal-commit" type="button">Save entry</button>
-            <button class="btn secondary" id="journal-use-calc" type="button">Use active key</button>
             <button class="btn secondary" id="journal-cancel" type="button">Cancel</button>
           </div>
         </div>

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -709,18 +709,18 @@
     chooseSeedWords(12);
     await chooseMode("Number bases");
     const cases = [
-      ["bin", 128, "0"],
-      ["base4", 64, "0"],
-      ["base8", 43, "0"],
-      ["hex", 32, "0"],
-      ["base32", 28, "0"],
-      ["base64", 23, "A"],
+      ["bin", "0".repeat(128)],
+      ["base4", "0".repeat(64)],
+      ["base8", "0".repeat(43)],
+      ["hex", "0".repeat(32)],
+      ["base32", "q".repeat(26)],
+      ["base64", `${"A".repeat(21)}00`],
     ];
     equal(document.querySelectorAll('input[name="entropy-format"]').length, 6);
-    for (const [format, count, zero] of cases) {
+    for (const [format, value] of cases) {
       document.querySelector(`input[name="entropy-format"][value="${format}"]`).click();
       const field = await until(() => document.getElementById(format), `${format} entropy input`);
-      input(field, format === "base64" ? `${zero.repeat(21)}00` : zero.repeat(count));
+      input(field, value);
       await wait(0);
       assert(!document.getElementById("go").disabled, `${format} did not accept exact zero entropy`);
       equal(document.querySelector("#entropy-words [data-word]").textContent, "abandon");
@@ -746,22 +746,22 @@
     assert(!document.querySelector('[data-entropy-digit="2"]').disabled, "Valid final Base 8 digit was disabled");
     document.querySelector('input[name="entropy-format"][value="base32"]').click();
     const base32 = await until(() => document.getElementById("base32"), "Base32 entropy input");
-    input(base32, `o${"0".repeat(27)}`);
+    input(base32, "Q".repeat(26));
     await wait(0);
-    assert(base32.value.startsWith("0") && !document.getElementById("go").disabled, "Crockford O alias did not normalize to 0");
+    assert(base32.value === "q".repeat(26) && !document.getElementById("go").disabled, "Bech32 Base32 did not normalize uppercase input");
     chooseSeedWords(24);
     const base32For24 = await until(() => document.getElementById("base32"), "24-word Base32 input");
-    input(base32For24, "0".repeat(51));
-    assert(document.getElementById("entropy-meta").textContent.includes("coin flip 1 of 1 · Heads (0) or Tails (1)"), "Base32 progress did not switch to coin-flip guidance");
-    assert(document.querySelector(".entropy-keypad").classList.contains("coin-phase"), "Base32 keypad did not switch to its coin-flip layout");
-    equal(document.querySelector('[data-entropy-digit="0"]').textContent, "Heads (0)");
-    equal(document.querySelector('[data-entropy-digit="1"]').textContent, "Tails (1)");
-    assert(!document.querySelector('[data-entropy-digit="1"]').disabled, "Final binary 1 was disabled for 24-word Base32");
-    assert(document.querySelector('[data-entropy-digit="2"]').disabled, "A non-binary final Base32 character remained enabled");
-    input(base32For24, `${"0".repeat(51)}1`);
+    input(base32For24, "q".repeat(51));
+    assert(document.getElementById("entropy-meta").textContent.includes("51 of 52 Bech32 characters"), "Base32 progress did not retain Bech32 guidance for the final character");
+    const base32Keyboard = document.getElementById("base32-keyboard");
+    const bech32Key = (character) => [...base32Keyboard.querySelectorAll("[data-seed-character-key]")].find((key) => key.dataset.seedKey === character);
+    assert(!bech32Key("q").disabled, "Valid final Bech32 q was disabled");
+    assert(!bech32Key("p").disabled, "Valid final Bech32 p was disabled");
+    assert(bech32Key("z").disabled, "A Bech32 character outside the final one-bit range remained enabled");
+    input(base32For24, `${"q".repeat(51)}p`);
     await wait(0);
-    assert(!document.getElementById("go").disabled, "24-word Base32 did not accept a final single entropy bit");
-    input(base32For24, "0".repeat(51));
+    assert(!document.getElementById("go").disabled, "24-word Base32 did not accept a valid final one-bit Bech32 character");
+    input(base32For24, "q".repeat(51));
     assert(document.getElementById("global-entropy-sync").checked, "Global sync turned off for incomplete entropy");
     const incompleteStatus = document.getElementById("global-sync-status");
     assert(incompleteStatus.textContent.includes("Key synced") && !incompleteStatus.querySelector(".global-sync-shortfall"), "Entropy past the minimum did not report a healthy sync");
@@ -770,8 +770,40 @@
     assert(preservedHex.value.length === 63, "Global sync did not wait for a complete next hexadecimal character");
     document.querySelector('input[name="entropy-format"][value="base32"]').click();
     const preservedBase32 = await until(() => document.getElementById("base32"), "preserved incomplete Base32 input");
-    equal(preservedBase32.value, "0".repeat(51));
+    equal(preservedBase32.value, "q".repeat(51));
     input(preservedBase32, "");
+  });
+
+  await test("Base32 uses the shared lowercase and number keyboard without an uppercase mode", async () => {
+    chooseSeedWords(24);
+    await chooseMode("Number bases");
+    document.querySelector('input[name="entropy-format"][value="base32"]').click();
+    const base32 = await until(() => document.getElementById("base32"), "Base32 input");
+    input(base32, "");
+    const toggle = document.getElementById("base32-keyboard-toggle");
+    const keyboard = document.getElementById("base32-keyboard");
+    assert(toggle && keyboard, "Base32 keyboard control is missing");
+    if (keyboard.hidden) toggle.click();
+    const mode = keyboard.querySelector("[data-seed-keyboard-mode]");
+    if (keyboard.dataset.seedKeyboardLayout !== "lower") mode.click();
+    const characterKey = (character) => [...keyboard.querySelectorAll("[data-seed-character-key]")].find((key) => key.dataset.seedKey === character);
+    assert(characterKey("q") && !characterKey("q").hidden && !characterKey("q").disabled, "Bech32 q is unavailable on the lowercase keyboard");
+    assert(characterKey("b")?.hidden, "A letter outside the Bech32 alphabet remained visible");
+    characterKey("q").click();
+    mode.click();
+    equal(keyboard.dataset.seedKeyboardLayout, "number", "Base32 did not switch from lowercase to numbers");
+    assert(characterKey("2") && !characterKey("2").hidden && !characterKey("2").disabled, "Bech32 digit 2 is unavailable");
+    assert(characterKey("1") && !characterKey("1").hidden && characterKey("1").disabled, "Digit 1 did not remain visible and disabled");
+    for (const character of ["!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "-", "_", "+", "=", "/", "?", "\\"]) {
+      assert(characterKey(character) && !characterKey(character).hidden && characterKey(character).disabled, `Unsupported Base32 character ${character} did not remain visible and disabled`);
+    }
+    characterKey("2").click();
+    mode.click();
+    equal(keyboard.dataset.seedKeyboardLayout, "lower", "Base32 cycled through an uppercase keyboard");
+    equal(mode.textContent, "a1", "Base32 mode control still advertises an uppercase layout");
+    equal(base32.value, "q2");
+    if (!keyboard.hidden) toggle.click();
+    input(base32, "");
   });
 
   await test("dice methods retain separate transcripts while global sync is off", async () => {
@@ -1122,13 +1154,13 @@
         document.querySelector("#bip85-manager > .key-tab-strip"),
       );
       // End jumps to the last tool. Journal begins at its create/open gate while
-      // keeping the four destination tabs visible but unavailable.
+      // keeping the five destination tabs visible but unavailable.
       tabs[2].dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }));
       await until(() => !document.getElementById("journal-card").hidden, "End to reach the Journal tool");
       assert(document.activeElement === tabs[7], "End should move focus to the last tab");
       const journalTabs = [...document.querySelectorAll("#journal-tool-tabs [data-journal-tool]")];
-      equal(journalTabs.length, 4, "Journal should expose exactly four internal tabs");
-      equal(journalTabs.map((tab) => tab.textContent.trim()).join("|"), "Notepad|Key manager|Session state|Session log");
+      equal(journalTabs.length, 5, "Journal should expose exactly five internal tabs");
+      equal(journalTabs.map((tab) => tab.textContent.trim()).join("|"), "Entries|Notepad|Key manager|Session state|Session log");
       const journalManager = document.getElementById("journal-manager");
       assert(journalManager && !journalManager.hidden, "Journal station tabs should be visible inside the Journal tool");
       const journalIntro = document.getElementById("journal-tool-intro");
@@ -1155,7 +1187,7 @@
       assert(journalPasswordStatus.hidden && journalConfirmStatus.hidden && !journalCreateReady.hidden, "Blank Journal password fields should be ready without validation errors");
       equal(journalCreateReady.textContent.trim(), "← Ready to create without a password");
       document.getElementById("journal-create").click();
-      await until(() => !document.getElementById("journal-notes-card").hidden, "passwordless journal creation to open Notepad");
+      await until(() => !document.getElementById("journal-card").hidden && !document.getElementById("journal-work-panel").hidden, "passwordless journal creation to open Entries");
       assert(document.getElementById("journal-status-title").textContent.includes("No password protection"), "A passwordless Journal should disclose that its file has no access protection");
       journalGlobalClear.click();
       await until(() => !document.getElementById("journal-card").hidden, "Journal gate after clearing the passwordless Journal");
@@ -1183,15 +1215,15 @@
       input(journalConfirmInput, journalPassword);
       journalConfirmInput.focus();
       journalConfirmInput.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
-      await until(() => !document.getElementById("journal-notes-card").hidden, "valid journal creation to open Notepad");
-      assert(document.getElementById("journal-card").hidden, "The create/open gate should disappear after journal creation");
+      await until(() => !document.getElementById("journal-card").hidden && !document.getElementById("journal-work-panel").hidden, "valid journal creation to open Entries");
+      assert(document.getElementById("journal-locked-panel").hidden, "The create/open gate should disappear after journal creation");
       assert(!journalIntro.hidden, "Entropy Journal introduction should remain visible after journal creation");
       journalTabs.forEach((tab) => {
         assert(!tab.disabled, "Journal station tabs should enable after journal creation");
         equal(tab.getAttribute("aria-disabled"), "false", "An unlocked Journal tab should expose its enabled state");
       });
-      assert(journalTabs[0].classList.contains("active"), "A newly created journal should start on Notepad");
-      equal(journalTabs[0].getAttribute("aria-selected"), "true", "Notepad should be selected after journal creation");
+      assert(journalTabs[0].classList.contains("active"), "A newly created journal should start on Entries");
+      equal(journalTabs[0].getAttribute("aria-selected"), "true", "Entries should be selected after journal creation");
       assert(!journalGlobalDownload.disabled && !journalGlobalClear.disabled, "Journal-wide actions should enable after journal creation");
       state.lastBlob = null;
       journalGlobalDownload.click();
@@ -1207,18 +1239,20 @@
       input(document.getElementById("journal-open-password"), journalPassword);
       await wait(250);
       document.getElementById("journal-unlock").click();
-      await until(() => !document.getElementById("journal-notes-card").hidden || document.getElementById("journal-error").textContent, "successful Journal file open result");
-      assert(!document.getElementById("journal-notes-card").hidden, `Opening the encrypted Journal failed: ${document.getElementById("journal-error").textContent}`);
-      assert(document.getElementById("journal-card").hidden, "The create/open gate should disappear after opening a journal");
+      await until(() => !document.getElementById("journal-card").hidden && !document.getElementById("journal-work-panel").hidden || document.getElementById("journal-error").textContent, "successful Journal file open result");
+      assert(!document.getElementById("journal-work-panel").hidden, `Opening the encrypted Journal failed: ${document.getElementById("journal-error").textContent}`);
+      assert(document.getElementById("journal-locked-panel").hidden, "The create/open gate should disappear after opening a journal");
       assert(!journalIntro.hidden, "Entropy Journal introduction should remain visible after opening a journal");
-      journalTabs.forEach((tab) => assert(!tab.disabled, "Opening a journal should enable its four tabs"));
-      assert(journalTabs[0].classList.contains("active"), "An opened journal should start on Notepad");
+      journalTabs.forEach((tab) => assert(!tab.disabled, "Opening a journal should enable its five tabs"));
+      assert(journalTabs[0].classList.contains("active"), "An opened journal should start on Entries");
+      journalTabs[1].click();
+      await until(() => !document.getElementById("journal-notes-card").hidden, "Notepad after opening a journal");
       equal(getComputedStyle(document.getElementById("journal-notes-card")).borderTopLeftRadius, "0px", "The active Notepad card should join its folder tab");
-      journalTabs[0].focus();
-      journalTabs[0].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+      journalTabs[1].focus();
+      journalTabs[1].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
       await until(() => !document.getElementById("journal-keymanager-card").hidden, "ArrowRight to open Key manager");
       equal(documentTop(journalManager), journalManagerTop, "Key manager moved the Journal tab strip");
-      assert(document.activeElement === journalTabs[1], "Focus should follow the Journal subtab arrow key");
+      assert(document.activeElement === journalTabs[2], "Focus should follow the Journal subtab arrow key");
       const keyManagerCard = document.getElementById("journal-keymanager-card");
       const keyManagerDownload = document.getElementById("journal-keymanager-download");
       const keyManagerUpload = document.getElementById("journal-keymanager-upload");
@@ -1227,14 +1261,14 @@
       for (const property of ["backgroundColor", "color", "borderTopColor"]) equal(getComputedStyle(keyManagerDownload)[property], keyManagerDownloadReference[property], `Key Manager download should use the header download button's ${property}`);
       equal(keyManagerUpload.querySelector(".download-mark path")?.getAttribute("d"), "M12 17V5M7 10l5-5 5 5M5 21h14", "Key Manager upload should use the shared upward-arrow icon");
       assert(keyManagerUpload.getBoundingClientRect().left > keyManagerDownload.getBoundingClientRect().right, "Key Manager upload should sit at the right edge of the action row");
-      journalTabs[1].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
-      await until(() => !document.getElementById("journal-state-card").hidden, "ArrowRight to open Session state");
       journalTabs[2].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+      await until(() => !document.getElementById("journal-state-card").hidden, "ArrowRight to open Session state");
+      journalTabs[3].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
       await until(() => !document.getElementById("journal-log-card").hidden, "ArrowRight to open Session log");
-      journalTabs[3].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
+      journalTabs[4].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
       equal(documentTop(journalManager), journalManagerTop, "Session log moved the Journal tab strip");
       await until(() => !document.getElementById("journal-state-card").hidden, "ArrowLeft to open Session state");
-      assert(document.activeElement === journalTabs[2], "Focus should return to Session state");
+      assert(document.activeElement === journalTabs[3], "Focus should return to Session state");
       // PSBT stays a workspace of its own, with station tabs inside it.
       document.querySelector('#workspace [data-workspace="psbt"]').click();
       await until(() => !document.getElementById("psbt-card").hidden, "PSBT tool");
@@ -1387,9 +1421,8 @@
       input(document.getElementById("journal-create-confirm"), journalPassword);
       document.getElementById("journal-create").click();
       await until(() => !document.getElementById("journal-global-download").disabled, "Journal unlocked after creation");
-      // The entry book has no tab of its own: "Save to Journal" is the way in.
-      document.getElementById("journal-open").click();
-      await until(() => !document.getElementById("journal-card").hidden && !document.getElementById("journal-editor").hidden, "entry editor to open");
+      document.getElementById("journal-add").click();
+      await until(() => !document.getElementById("journal-editor").hidden, "entry editor to open");
       document.getElementById("journal-method").value = "hex";
       input(document.getElementById("journal-input"), entryInput);
       input(document.getElementById("journal-phrase"), entryPhrase);
@@ -1425,9 +1458,6 @@
       await until(() => !document.getElementById("journal-global-download").disabled, "Journal unlocked from the stored file");
 
       // The stored entry survived: listed, viewable, and revealed on demand.
-      document.getElementById("journal-open").click();
-      await until(() => !document.getElementById("journal-editor").hidden, "editor over the loaded journal");
-      document.getElementById("journal-cancel").click();
       const restoredItem = await until(() => [...document.querySelectorAll("#journal-list .journal-item")].find((el) => el.querySelector(".journal-item-label")?.textContent === entryLabel), "stored entry listed after load");
       restoredItem.click();
       await until(() => !document.getElementById("journal-view").hidden, "stored entry view");
@@ -1500,6 +1530,15 @@
     await until(() => !document.getElementById("go").disabled, "Derive Key to enable");
     document.getElementById("go").click();
     await until(() => [...document.querySelectorAll("#key-tabs .key-tab")].some((tab) => tab.textContent.includes("ef94d090")), "the derived key tab ef94d090");
+    document.querySelector('#workspace [data-workspace="journal"]').click();
+    document.querySelector('#journal-tool-tabs [data-journal-tool="book"]').click();
+    const capturedEntry = await until(() => document.querySelector("#journal-list .journal-item"), "automatically captured Key Station entry");
+    equal(document.querySelectorAll("#journal-list .journal-item").length, 1, "a Key Station derivation should add one journal entry");
+    assert(document.getElementById("journal-status-note").textContent.includes("download the journal file to preserve them"), "automatic capture should explain that the journal still needs downloading");
+    capturedEntry.click();
+    await until(() => !document.getElementById("journal-view").hidden, "automatically captured entry view");
+    assert(document.getElementById("journal-view").textContent.includes("passphrase was in effect"), "automatic capture should retain the passphrase-in-use note");
+    assert(!document.getElementById("journal-view").textContent.includes("correct horse battery staple"), "automatic capture must not store the BIP39 passphrase");
     document.querySelector('#workspace [data-workspace="vanity"]').click();
     await until(() => document.querySelector("#vanity-session-keys .session-key-option"), "the Key Station chip to appear");
     const vanityKeyPickerStyle = getComputedStyle(document.getElementById("vanity-session-keys"));
@@ -1537,19 +1576,37 @@
     // The device sample taken on tab entry turns the odds into a time.
     await until(() => /expect a match roughly every/.test(document.getElementById("vanity-estimate").textContent), "the estimate to be timed from the device sample", 60000);
     assert(/on 1 worker,/.test(document.getElementById("vanity-estimate").textContent), "the estimate scales by the worker count");
-    // Stop on first find is a toggle: counter 0 matches inside the first
+    const vanityGo = document.getElementById("vanity-go"), vanityGoWidth = vanityGo.getBoundingClientRect().width;
+    vanityGo.click();
+    equal(vanityGo.textContent.trim(), "Stop", "Start grinding did not become the Stop button while running");
+    assert(!vanityGo.disabled && vanityGo.dataset.derivationState === "running", "The grinding Stop button was not available");
+    assert(Math.abs(vanityGo.getBoundingClientRect().width - vanityGoWidth) < 0.5, "The grinding Stop button changed width");
+    vanityGo.click();
+    await until(() => document.getElementById("vanity-status").textContent.startsWith("Stopped:"), "the shared grinding action to stop the run", 60000);
+    equal(vanityGo.textContent.trim(), "Start grinding", "The grinder action did not return to Start grinding");
+    assert(Math.abs(vanityGo.getBoundingClientRect().width - vanityGoWidth) < 0.5, "Start grinding changed width after stopping");
+    input(document.getElementById("vanity-start"), "0");
+    // Stop on first find is a checkbox: counter 0 matches inside the first
     // (small) chunk, so the run stops there instead of grinding all 62.
     const first = document.getElementById("vanity-first");
+    const firstText = first.nextElementSibling;
+    const firstBox = first.getBoundingClientRect(), firstTextBox = firstText.getBoundingClientRect();
+    assert(Math.abs((firstBox.top + firstBox.height / 2) - (firstTextBox.top + firstTextBox.height / 2)) < 1, "the Stop on first find checkbox and label are vertically aligned");
     first.click();
     await wait(0);
-    assert(first.getAttribute("aria-pressed") === "true" && first.textContent.includes("on"), "the toggle shows it is switched on");
-    document.getElementById("vanity-go").click();
+    assert(first.checked, "the Stop on first find checkbox is checked");
+    vanityGo.click();
+    equal(vanityGo.textContent.trim(), "Stop", "Start grinding did not become the Stop button while running");
+    assert(!vanityGo.disabled && vanityGo.dataset.derivationState === "running", "The grinding Stop button was not available");
+    assert(Math.abs(vanityGo.getBoundingClientRect().width - vanityGoWidth) < 0.5, "The grinding Stop button changed width");
     await until(() => document.getElementById("vanity-status").textContent.includes("Stopped at first match"), "the grind to stop at the first match", 60000);
+    equal(vanityGo.textContent.trim(), "Start grinding", "The grinder action did not return to Start grinding");
+    assert(Math.abs(vanityGo.getBoundingClientRect().width - vanityGoWidth) < 0.5, "Start grinding changed width after the run");
     assert(document.querySelectorAll("#vanity-out table tbody tr").length === 1, "exactly one match is listed");
     assert(/1 match\b/.test(document.getElementById("vanity-status").textContent), "the status counts the single match");
     first.click();
     await wait(0);
-    assert(first.getAttribute("aria-pressed") === "false", "the toggle switches off again");
+    assert(!first.checked, "the Stop on first find checkbox switches off again");
     document.getElementById("vanity-wipe").click();
     await until(() => !document.querySelector("#vanity-out table"), "Clear results to drop the table");
     input(document.getElementById("vanity-start"), "0");

--- a/test/global-sync.test.mjs
+++ b/test/global-sync.test.mjs
@@ -28,13 +28,13 @@ const formats = {
   base4: { id: "base4", bitsPerDigit: 2, alphabet: "0123" },
   base8: { id: "base8", bitsPerDigit: 3, alphabet: "01234567" },
   hex: { id: "hex", bitsPerDigit: 4, alphabet: "0123456789ABCDEF" },
-  base32: { id: "base32", bitsPerDigit: 5, alphabet: "0123456789ABCDEFGHJKMNPQRSTVWXYZ" },
+  base32: { id: "base32", bitsPerDigit: 5, alphabet: "qpzry9x8gf2tvdw0s3jn54khce6mua7l" },
   base64: { id: "base64", bitsPerDigit: 6, alphabet: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/" },
 };
 
 const numberValue = new Function("formats", `
   function hodlEntropyFormatConfig(format) {
-    return { ...formats[format], fullDigits: Math.floor(128 / formats[format].bitsPerDigit), remainderBits: 128 % formats[format].bitsPerDigit, binaryRemainder: format === "base32" || format === "base64", seed: { bits: 128 } };
+    return { ...formats[format], fullDigits: Math.floor(128 / formats[format].bitsPerDigit), remainderBits: 128 % formats[format].bitsPerDigit, binaryRemainder: format === "base64", seed: { bits: 128 } };
   }
   function hodlGroupedBinary(value) { return value.match(/.{1,11}/g)?.join(" ") || ""; }
   ${loadSlice("hodlGlobalSyncNumberValue")}
@@ -47,7 +47,7 @@ test("global sync emits only complete destination symbols", () => {
   assert.equal(numberValue(bits, "base4", 12), "22");
   assert.equal(numberValue(bits, "base8", 12), "5");
   assert.equal(numberValue(bits, "hex", 12), "A");
-  assert.equal(numberValue(bits, "base32", 12), "N");
+  assert.equal(numberValue(bits, "base32", 12), "4");
   assert.equal(numberValue(bits, "base64", 12), "");
 });
 

--- a/test/journal-backup.test.mjs
+++ b/test/journal-backup.test.mjs
@@ -37,6 +37,7 @@ import {
   journalKeyReferenceToken,
   journalNotebookRuns,
   journalTextFromRuns,
+  keySnapshotMatchesEntry,
   mergeNotebookImport,
   normalizeEntry,
   openDocument,
@@ -51,6 +52,7 @@ import {
   serializeNotebook,
   snapshotFromKeyState,
   snapshotSession,
+  syncKeySnapshots,
   wipeBytes,
   wipeDocument,
   wipeEntry,
@@ -309,7 +311,7 @@ test("wipe helpers zero secrets in place and reset allocation", () => {
   wipeDocument(null); // must not throw
 });
 
-// --- Session-key snapshots (what "Save to Journal" captures) ----------------
+// --- Session-key snapshots (what automatic Key Station capture stores) -------
 
 test("the snapshot captures each input method's live transcript", () => {
   const base = { id: 1, isLab: false, name: "", fields: {}, result: null };
@@ -394,6 +396,56 @@ test("the snapshot captures private-key modes and the passphrase warning", () =>
   assert.equal(snapshotFromKeyState({ isLab: true, mode: "dice", fields: { dice: "1" } }), null);
   assert.equal(snapshotFromKeyState({ ...base, fields: {}, result: null }), null);
   assert.equal(snapshotFromKeyState(null), null);
+});
+
+test("derived Key Station snapshots backfill a new journal and auto-add later keys", () => {
+  const doc = emptyDocument(), associations = new Map();
+  const beforeCreate = sampleEntry({ walletId: 11, label: "Before journal", input: "1 2 3", created: undefined });
+  const afterCreate = sampleEntry({ walletId: 12, label: "After journal", input: "4 5 6", created: undefined });
+  assert.deepEqual(syncKeySnapshots(doc, [beforeCreate], associations, fixedNow), { added: 1, updated: 0, matched: 0 });
+  assert.equal(doc.entries.length, 1);
+  assert.deepEqual(syncKeySnapshots(doc, [afterCreate], associations, fixedNow), { added: 1, updated: 0, matched: 0 });
+  assert.deepEqual(doc.entries.map((entry) => entry.label), ["Before journal", "After journal"]);
+  assert.equal(associations.get(11), doc.entries[0].id);
+  assert.equal(associations.get(12), doc.entries[1].id);
+});
+
+test("re-deriving one Key Station state updates its associated entry", () => {
+  const doc = emptyDocument(), associations = new Map();
+  const first = sampleEntry({ walletId: 21, label: "Same tab", input: "first transcript", fingerprint: "11111111", created: undefined });
+  syncKeySnapshots(doc, [first], associations, fixedNow);
+  const entryId = doc.entries[0].id, created = doc.entries[0].created;
+  const next = { ...first, input: "replacement transcript", phrase: "replacement mnemonic", fingerprint: "22222222" };
+  assert.deepEqual(syncKeySnapshots(doc, [next], associations, new Date("2026-09-02T00:00:00Z")), { added: 0, updated: 1, matched: 0 });
+  assert.equal(doc.entries.length, 1);
+  assert.equal(doc.entries[0].id, entryId);
+  assert.equal(doc.entries[0].created, created);
+  assert.equal(doc.entries[0].input, "replacement transcript");
+  assert.equal(doc.entries[0].fingerprint, "22222222");
+});
+
+test("opening a journal matches meaningful snapshots and backfills only missing keys", () => {
+  const doc = emptyDocument();
+  const matching = sampleEntry({ walletId: 31, label: "Existing", input: "same transcript", created: undefined });
+  const existing = addEntry(doc, matching, fixedNow);
+  const reusedSessionId = { ...matching, walletId: 31, input: "different transcript", phrase: "different mnemonic" };
+  const missing = sampleEntry({ walletId: 32, label: "Missing", input: "new transcript", fingerprint: "cafebabe", created: undefined });
+  const reopenedAssociations = new Map();
+  assert(keySnapshotMatchesEntry(existing, { ...matching, walletId: 999 }), "session ids must not participate in meaningful matching");
+  assert(!keySnapshotMatchesEntry(existing, reusedSessionId), "a fingerprint and reused session id must not hide changed key content");
+  assert.deepEqual(syncKeySnapshots(doc, [{ ...matching, walletId: 999 }, reusedSessionId, missing], reopenedAssociations, fixedNow), { added: 2, updated: 0, matched: 1 });
+  assert.equal(doc.entries.length, 3);
+  assert.equal(reopenedAssociations.get(999), existing.id);
+  assert.notEqual(reopenedAssociations.get(31), existing.id);
+});
+
+test("automatically captured Key Station entries survive journal download and reopen", async () => {
+  const doc = emptyDocument(), associations = new Map();
+  const snapshot = sampleEntry({ walletId: 41, label: "Automatic backup", input: "saved transcript", created: undefined });
+  syncKeySnapshots(doc, [snapshot], associations, fixedNow);
+  const opened = await openDocument(pack(await sealDocument(doc, keys)), password);
+  assert.equal(opened.doc.entries.length, 1);
+  assert(keySnapshotMatchesEntry(opened.doc.entries[0], snapshot));
 });
 
 // --- Notepad backups ---------------------------------------------------------
@@ -699,9 +751,9 @@ test("an .elkeys backup is opaque until opened with the journal password", async
 
 test("the app routes every journal backup through the sealed primitives", () => {
   const app = read("src/js/app.js");
-  // A Key Station snapshot carries its method variant through the editor and
-  // both journal labels render that persisted variant.
-  assert.match(app, /hodlJournalEntryVariants = hodlJournalReadEntryVariants\(snapshot\)/);
+  // Automatic Key Station capture persists the snapshot's method variant;
+  // manual entries still keep their selected variant through the editor.
+  assert.match(app, /hodlJournalSyncKeySnapshots\(hodlJournalDoc, snapshots, hodlJournalKeyEntries\)/);
   assert.match(app, /method: document\.getElementById\("journal-method"\)\?\.value \|\| "dice",\s+\.\.\.hodlJournalEntryVariants,/);
   assert.equal((app.match(/hodlJournalEntryMethodLabel\(entry\)/g) || []).length, 2);
   // Downloads encrypt with the unlocked journal keys by default and mark the

--- a/test/journal-wipe-race.test.mjs
+++ b/test/journal-wipe-race.test.mjs
@@ -89,7 +89,7 @@ const loadApp = ({ onOpen = (file, password) => openDocument(file, password), on
     "hodlKeyManagerReset", "hodlJournalClearFields", "hodlJournalHideEditor", "hodlJournalSetGate",
     "hodlJournalSyncEncryptDownloads", "hodlJournalShowWork", "hodlSyncJournalTool",
     "hodlRenderJournalPageTabs", "hodlJournalApplyPageStyle", "hodlJournalSetStatus",
-    "hodlShowJournalTool", "hodlJournalLog",
+    "hodlShowJournalTool", "hodlJournalLog", "hodlJournalBackfillDerivedKeys",
     `${source}; return {
       unlock: hodlJournalUnlock,
       create: hodlJournalCreate,
@@ -103,7 +103,7 @@ const loadApp = ({ onOpen = (file, password) => openDocument(file, password), on
     noop, noop, noop, noop,
     noop, noop, noop,
     noop, noop, noop,
-    noop, noop,
+    noop, noop, noop,
   );
 };
 

--- a/test/number-bases.test.mjs
+++ b/test/number-bases.test.mjs
@@ -75,7 +75,7 @@ function encodeInFormat(hex, format, words) {
 test("number-base character counts preserve exact BIP39 entropy lengths", () => {
   assert.deepEqual(
     ["bin", "base4", "base8", "hex", "base32", "base64"].map((format) => api.hodlEntropyFormatConfig(format, 12).digits),
-    [128, 64, 43, 32, 28, 23],
+    [128, 64, 43, 32, 26, 23],
   );
   assert.deepEqual(
     ["bin", "base4", "base8", "hex", "base32", "base64"].map((format) => api.hodlEntropyFormatConfig(format, 15).digits),
@@ -83,11 +83,11 @@ test("number-base character counts preserve exact BIP39 entropy lengths", () => 
   );
   assert.deepEqual(
     ["bin", "base4", "base8", "hex", "base32", "base64"].map((format) => api.hodlEntropyFormatConfig(format, 18).digits),
-    [192, 96, 64, 48, 40, 32],
+    [192, 96, 64, 48, 39, 32],
   );
   assert.deepEqual(
     ["bin", "base4", "base8", "hex", "base32", "base64"].map((format) => api.hodlEntropyFormatConfig(format, 21).digits),
-    [224, 112, 75, 56, 48, 39],
+    [224, 112, 75, 56, 45, 39],
   );
   assert.deepEqual(
     ["bin", "base4", "base8", "hex", "base32", "base64"].map((format) => api.hodlEntropyFormatConfig(format, 24).digits),
@@ -113,7 +113,7 @@ test("all six formats decode to the same entropy bytes", () => {
   }
 });
 
-test("Base 8 uses a mixed-radix final character and Base32 switches to coin flips", () => {
+test("Base 8 and Base32 use restricted mixed-radix final characters", () => {
   const base8 = api.hodlEntropyFormatConfig("base8", 12);
   assert.equal(base8.remainderBits, 2);
   assert.equal(base8.finalCharacters, "0123");
@@ -125,17 +125,17 @@ test("Base 8 uses a mixed-radix final character and Base32 switches to coin flip
 
   const base32 = api.hodlEntropyFormatConfig("base32", 24);
   assert.equal(base32.remainderBits, 1);
-  assert.equal(base32.finalCharacters, "01");
-  assert.equal(api.hodlAnalyzeEntropyInput(`${"0".repeat(51)}2`, "base32", 24).finalInvalid, true);
-  assert.equal(api.hodlNumberBaseEntropy(`${"0".repeat(51)}1`, "base32", 24).ok, true);
+  assert.equal(base32.finalCharacters, "qp");
+  assert.equal(api.hodlAnalyzeEntropyInput(`${"q".repeat(51)}z`, "base32", 24).finalInvalid, true);
+  assert.equal(api.hodlNumberBaseEntropy(`${"q".repeat(51)}p`, "base32", 24).ok, true);
 
   assert.equal(api.hodlEntropyFormatConfig("base8", 24).finalCharacters, "01");
-  assert.equal(api.hodlEntropyFormatConfig("base32", 12).digits, 28);
-  assert.equal(api.hodlEntropyFormatConfig("base32", 12).finalCharacters, "01");
-  assert.equal(api.hodlAnalyzeEntropyInput(`${"0".repeat(25)}010`, "base32", 12).ready, true);
-  assert.equal(api.hodlAnalyzeEntropyInput(`${"0".repeat(25)}02`, "base32", 12).finalInvalid, true);
-  assert.equal(api.hodlEntropyFormatConfig("base32", 18).digits, 40);
-  assert.equal(api.hodlEntropyFormatConfig("base32", 18).finalCharacters, "01");
+  assert.equal(api.hodlEntropyFormatConfig("base32", 12).digits, 26);
+  assert.equal(api.hodlEntropyFormatConfig("base32", 12).finalCharacters, "qpzry9x8");
+  assert.equal(api.hodlAnalyzeEntropyInput(`${"q".repeat(25)}q`, "base32", 12).ready, true);
+  assert.equal(api.hodlAnalyzeEntropyInput(`${"q".repeat(25)}g`, "base32", 12).finalInvalid, true);
+  assert.equal(api.hodlEntropyFormatConfig("base32", 18).digits, 39);
+  assert.equal(api.hodlEntropyFormatConfig("base32", 18).finalCharacters, "qpzr");
   assert.equal(api.hodlEntropyFormatConfig("base8", 18).remainderBits, 0);
 });
 
@@ -157,7 +157,7 @@ test("binary calculation rows expose BIP39 place values and word numbers", () =>
   assert.deepEqual(rows[0].terms.map(({ place, bit, value }) => [place, bit, value]), [[1024, "0", 0], [512, "0", 0], [256, "0", 0], [128, "0", 0], [64, "0", 0], [32, "0", 0], [16, "0", 0], [8, "0", 0], [4, "0", 0], [2, "0", 0], [1, "1", 1]]);
 });
 
-test("Base 4 calculation rows use the same normalized 11-bit BIP39 mapping", () => {
+test("Quaternary (Base 4) calculation rows use the same normalized 11-bit BIP39 mapping", () => {
   const rows = api.hodlNumberBaseCalculationRows("333333", "base4", 12);
   assert.equal(rows.length, 1);
   assert.equal(rows[0].index, 2047);
@@ -169,9 +169,11 @@ test("hex conversion displays each source digit and its binary value", () => {
   assert.match(markup, />A<\/strong><b>\u2192<\/b><span>1010<\/span>/);
 });
 
-test("Crockford Base32 normalizes its documented aliases", () => {
-  assert.equal(api.hodlFilterNumberBase("o i-l", "base32"), "0 11");
-  assert.equal(api.hodlFilterNumberBase("u!", "base32"), "");
+test("Base32 uses the lowercase Bech32 alphabet", () => {
+  const alphabet = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+  assert.equal(api.hodlEntropyFormats.base32.alphabet, alphabet);
+  assert.equal(api.hodlFilterNumberBase(alphabet.toUpperCase(), "base32"), alphabet);
+  assert.equal(api.hodlFilterNumberBase("bio1!", "base32"), "");
 });
 
 test("Base64 uses the RFC 4648 alphabet followed by individual remaining bits", () => {

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -366,7 +366,7 @@ test("entropy progress messages sit next to their inputs and above keypads", () 
   // Cards reads like dice: the progress line above the transcript, so the field
   // and the card keypad below it stay together.
   assert.match(appSource, /\$\{hodlSeedMetaRowMarkup\("cards-meta"\)\}\s*<div class="dice-input-shell cards-input-shell">/);
-  assert.match(app, /<textarea id="\$\{inputId\}"[\s\S]*?<\/textarea><\/div>\s*\$\{hodlSeedMetaRowMarkup\("entropy-meta",!0\)\}\s*\$\{base64Keyboard\}\s*\$\{entropyPad\}/);
+  assert.match(app, /<textarea id="\$\{inputId\}"[\s\S]*?<\/textarea><\/div>\s*\$\{hodlSeedMetaRowMarkup\("entropy-meta",!0\)\}\s*\$\{numberBaseKeyboard\}\s*\$\{entropyPad\}/);
   assert.match(app, /<textarea id="seed"[^>]*><\/textarea><\/div><p class="muted" id="seed-meta"[^>]*><\/p>\$\{hodlSeedKeyboardMarkup\(\)\}/);
   assert.match(app, /<textarea id="key"[^>]*><\/textarea><\/div><p class="muted" id="private-key-meta"[^>]*><\/p>/);
 });
@@ -508,16 +508,16 @@ test("hashed cards can match Ian Coleman's suit-symbol SHA-256 transcript", () =
   assert.match(appSource, /input\.value = hodlFilterCards\(input\.value, hodlCardColemanSymbols\)/);
 });
 
-test("Number bases offers exact Base 2, 4, 8, 16, Crockford Base32, and Base64-alphabet input", () => {
+test("Number bases offers exact Base 2, 4, 8, 16, Bech32 Base32, and Base64-alphabet input", () => {
   assert.match(appSource, /hodlTText\(hodlKeyModeLabels\[mode\]\)/);
   assert.doesNotMatch(shell, />Hex or binary<\/button>/);
   assert.ok(app.includes('formatChoices=["bin","base4","base8","hex","base32","base64"]'));
   assert.match(app, /name="entropy-format" value="\$\{id\}"/);
   const labelsModule = read("src/js/i18n-labels.js");
-  for (const label of ["Binary (Base 2)", "Base 4", "Octal (Base 8)", "Hexadecimal (Base 16)", "Crockford Base32", "Base64 (RFC 4648 alphabet)"]) {
+  for (const label of ["Binary (Base 2)", "Quaternary (Base 4)", "Octal (Base 8)", "Hexadecimal (Base 16)", "Base32 (Bech32)", "Base64 (RFC 4648 alphabet)"]) {
     assert.ok(labelsModule.includes(`label: "${label}"`), label);
   }
-  assert.match(app, /alphabet:"0123456789ABCDEFGHJKMNPQRSTVWXYZ"/);
+  assert.match(app, /alphabet:"qpzry9x8gf2tvdw0s3jn54khce6mua7l"/);
   assert.match(app, /alphabet:"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789\+\/"/);
   assert.match(app, /function hodlNumberBaseEntropy\(value,format,targetWords=hodlTargetWordCount\)/);
   assert.match(app, /function hodlNumberBasePreviewWords\(value,format,targetWords=hodlTargetWordCount\)/);
@@ -569,6 +569,9 @@ test("Number bases offers exact Base 2, 4, 8, 16, Crockford Base32, and Base64-a
   assert.match(app, /fields:\{[\s\S]*?base4:"",base8:"",base32:"",base64:""/);
   assert.match(app, /function hodlBase64KeyboardMarkup\(\)\{return hodlKeyboardMarkup\(!0,"Base64 entropy","base64-keyboard"\)\}/);
   assert.match(app, /function hodlBindBase64Keyboard\(input\)/);
+  assert.match(app, /function hodlBase32KeyboardMarkup\(\)\{return hodlKeyboardMarkup\(!0,"Bech32 entropy","base32-keyboard",!1,"a1"\)\}/);
+  assert.match(app, /function hodlBindBase32Keyboard\(input\)/);
+  assert.match(app, /usesKeyboard=format\.id==="base32"\|\|format\.id==="base64"/);
   assert.match(app, /hodlT\("Heads \(0\)"\)/);
   assert.match(app, /hodlT\("Tails \(1\)"\)/);
   assert.match(css, /\.dice-input-pad\.entropy-keypad \{ grid-template-columns: repeat\(8[^}]*grid-auto-flow: row;/);
@@ -643,7 +646,8 @@ test("seed phrase mode has a lowercase Jade-style on-screen keyboard", () => {
   assert.match(app, /data-seed-delete aria-label="Delete previous character"/);
   assert.match(app, /data-seed-keyboard-mode="lower"/);
   assert.match(app, /passphraseOnly\?`Change \$\{inputName\} character mode`:"Character mode switching is available for the passphrase"/);
-  assert.match(app, />aA1<\/button><button[^>]*class="seed-keyboard-space"/);
+  assert.match(app, /modeLabel="aA1"/);
+  assert.match(app, />\$\{modeLabel\}<\/button><button[^>]*class="seed-keyboard-space"/);
   assert.match(app, /data-seed-key=" " aria-label="Enter space">space/);
   assert.ok(app.includes('number:["1234567890","!@#$%^&*()","-_+=/?\\\\"]'));
   assert.match(app, /Array\.from\(\{length:hodlSeedKeyboardLayouts\.number\[index\]\.length\}/);
@@ -2011,7 +2015,7 @@ test("one PSBT workspace contains PSBT / Nonce and PSBT Editor tabs", () => {
   assert.match(css, /#psbt-card:not\(\[hidden\]\), #psbted-card:not\(\[hidden\]\), #vanity-card:not\(\[hidden\]\), #ln-card:not\(\[hidden\]\) \{[^}]*border-radius: 0 0 20px 20px;/s);
 });
 
-test("Journal gates its four tools behind the local notebook", () => {
+test("Journal gates its five tools behind the local notebook", () => {
   assert.match(appSource, /\["psbt", "PSBT", "PSBT"\], \["ln", "Lightning", "LN"\], \["journal", "Journal", "Journal"\]\];/);
   assert.match(appSource, /import \{[\s\S]*wipeJournal,[\s\S]*\} from "\.\/journal\.js"/);
   assert.match(appSource, /import \{[\s\S]*sealDocument as hodlJournalSealDocument,[\s\S]*\} from "\.\/journal\.js"/);
@@ -2037,7 +2041,7 @@ test("Journal gates its four tools behind the local notebook", () => {
     assert.match(markup, /class="btn clear-current-action" id="journal-global-clear"[^>]*disabled aria-disabled="true"[^>]*>Clear journal<\/button>/);
     assert.match(markup, /<section class="key-manager no-print" id="journal-manager" hidden>/);
     assert.match(markup, /<div class="key-tabs" id="journal-tool-tabs" role="tablist" aria-label="Journal stations">/);
-    assert.doesNotMatch(markup, /id="journal-book-tab"|data-journal-tool="book"/);
+    assert.match(markup, /id="journal-book-tab"[^>]*data-journal-tool="book"[^>]*disabled>Entries<\/button>/);
     assert.match(markup, /id="journal-notes-tab"[^>]*aria-disabled="true"[^>]*data-journal-tool="notes"[^>]*disabled/);
     assert.match(markup, /id="journal-keymanager-tab"[^>]*aria-disabled="true"[^>]*data-journal-tool="keymanager"[^>]*disabled/);
     assert.match(markup, /id="journal-state-tab"[^>]*aria-disabled="true"[^>]*data-journal-tool="state"[^>]*disabled/);
@@ -2205,8 +2209,12 @@ test("Journal gates its four tools behind the local notebook", () => {
   assert.match(appSource, /function hodlJournalCreatePasswordKeydown\(event\) \{[\s\S]*event\.key !== "Enter"[\s\S]*confirm\.focus\(\)[\s\S]*confirm\.value === password\.value\) hodlJournalCreate\(\)/);
   assert.match(appSource, /\["journal-create-password", "journal-create-confirm"\][\s\S]*addEventListener\("keydown", hodlJournalCreatePasswordKeydown\)/);
   assert.match(appSource, /function hodlSyncJournalTool\(\) \{[\s\S]*unlocked = hodlJournalUnlocked\(\)[\s\S]*button\.disabled = !unlocked;[\s\S]*button\.setAttribute\("aria-disabled", String\(!unlocked\)\)[\s\S]*journal-notes-card"\)\.hidden = !visible \|\| !unlocked/);
-  assert.match(appSource, /async function hodlJournalCreate\(\) \{[\s\S]*hodlJournalShowWork\(\);\s*hodlShowJournalTool\("notes"\)/);
-  assert.match(appSource, /async function hodlJournalUnlock\(\) \{[\s\S]*hodlJournalShowWork\(\);\s*hodlShowJournalTool\("notes"\)/);
+  assert.match(appSource, /async function hodlJournalCreate\(\) \{[\s\S]*hodlJournalBackfillDerivedKeys\(\);[\s\S]*hodlJournalShowWork\(\);\s*hodlShowJournalTool\("book"\)/);
+  assert.match(appSource, /async function hodlJournalUnlock\(\) \{[\s\S]*hodlJournalBackfillDerivedKeys\(\);[\s\S]*hodlJournalShowWork\(\);\s*hodlShowJournalTool\("book"\)/);
+  assert.match(appSource, /function hodlJournalSyncDerivedKeys\(states\) \{\s*if \(!hodlJournalUnlocked\(\)\) return \{ added: 0, updated: 0, matched: 0 \}/);
+  assert.match(appSource, /hodlJournalKeyEntries\.clear\(\)/);
+  assert.match(appSource, /hodlCommitDerivedKey\(\);\s*hodlJournalCaptureDerivedKey\(hodlKeys\[hodlActiveKey\]\)/);
+  assert.match(appSource, /Unsaved changes \\u2014 download the journal file to preserve them/);
   assert.match(appSource, /function hodlJournalLock\(\) \{[\s\S]*hodlJournalTool = "book";[\s\S]*hodlSyncJournalTool\(\)/);
   assert.match(appSource, /function hodlJournalWipeMem\(\) \{[\s\S]*hodlJournalTool = "book";[\s\S]*hodlSyncJournalTool\(\)/);
   // The notebook never seals or opens without an explicit click.
@@ -2226,15 +2234,16 @@ test("fixed inner tabs reserve the height of their longest introduction", () => 
   assert.match(appSource, /editorIntro\.classList\.toggle\("active", visible && hodlPsbtTool === "editor"\);\s*editorIntro\.setAttribute\("aria-hidden", String\(!visible \|\| hodlPsbtTool !== "editor"\)\);/);
 });
 
-test("BIP-85 stays available as a workspace without a duplicate Key Station action", () => {
+test("Key Station keeps derivation actions focused and BIP-85 remains its own workspace", () => {
   // BIP-85 has its own tab, so the shortcut that used to sit beside Derive Key
-  // is gone; the row is Derive, progress, Save to Journal, Clear.
+  // is gone; automatic Journal capture also removes the old manual shortcut.
   for (const markup of [shell]) {
-    assert.match(markup, /id="go"[^>]*>Derive Key<\/button>[\s\S]*?id="derive-progress"[\s\S]*?id="journal-open"[^>]*>Save to Journal<\/button>[\s\S]*?id="wipe"/);
+    assert.match(markup, /id="go"[^>]*>Derive Key<\/button>[\s\S]*?id="derive-progress"[\s\S]*?id="wipe"/);
+    assert.doesNotMatch(markup, /id="journal-open"|>Save to Journal<\/button>|id="journal-use-calc"|>Use active key<\/button>/);
     assert.doesNotMatch(markup, /id="bip85-open"|>Derive BIP-85 child<\/button>/);
   }
   assert.doesNotMatch(appSource, /getElementById\("bip85-open"\)/);
-  assert.match(appSource, /getElementById\("journal-open"\)/);
+  assert.doesNotMatch(appSource, /getElementById\("journal-open"\)|getElementById\("journal-use-calc"\)|hodlJournalUseActiveKey|hodlJournalApplySnapshot/);
   assert.match(appSource, /\["calc", "Keys", "Keys"\], \["vanity", "Vanity", "Vanity"\], \["bip85", "BIP-85", "BIP85"\]/);
   // The tab keeps its own way to adopt a key, so the removal must not have
   // taken the underlying session-key path with it.
@@ -2716,7 +2725,7 @@ test("the vanity grinder is a workspace tab that ships collapsed and never auto-
     assert.match(markup, /<p class="muted" id="vanity-estimate" aria-live="polite"><\/p>/);
     assert.match(markup, /<button class="btn primary" id="vanity-go" type="button">Start grinding<\/button>/);
     assert.match(markup, /id="vanity-progress" role="progressbar"[^>]*hidden>/);
-    assert.match(markup, /<button class="btn secondary" id="vanity-stop" type="button" disabled>Stop<\/button>/);
+    assert.doesNotMatch(markup, /id="vanity-stop"/);
     assert.match(markup, /<button class="btn clear-current-action" id="vanity-wipe" type="button" disabled aria-disabled="true">Clear results<\/button>/);
     assert.match(markup, /<p class="muted" id="vanity-status" aria-live="polite">/);
     assert.match(markup, /<p class="err" id="vanity-error" role="alert"><\/p>/);
@@ -2735,7 +2744,8 @@ test("the vanity grinder is a workspace tab that ships collapsed and never auto-
   assert.match(appSource, /function hodlInitWorkspace\(\) \{[\s\S]*?hodlInitVanity\(\);/);
   // The workers spawn only from the button handler; nothing starts on boot,
   // on tab switches, or on input.
-  assert.match(appSource, /go\.onclick = hodlRunVanity;/);
+  assert.match(appSource, /go\.onclick = \(\) => hodlVanityRunning \? hodlVanityStop\(\) : hodlRunVanity\(\);/);
+  assert.match(appSource, /go\.dataset\.derivationWidth[\s\S]*go\.style\.width = `\$\{width\}px`[\s\S]*go\.textContent = hodlTText\("Stop"\)[\s\S]*go\.dataset\.derivationState = "running"/);
   assert.match(appSource, /function hodlRunVanity\(\) \{[\s\S]*?new VanityGrinder\(/);
   assert.equal(appSource.indexOf("new VanityGrinder"), appSource.indexOf("new VanityGrinder", appSource.indexOf("function hodlRunVanity")));
   // Passphrases are private material: masked by default behind the same
@@ -2814,7 +2824,9 @@ test("the private recovery section lists the BIP39 passphrase beside the seed ph
 
 test("the vanity estimate is timed from a device sample, and Stop on first find halts the grind at the first match", () => {
   for (const markup of [shell]) {
-    assert.match(markup, /<button class="btn secondary" id="vanity-stop" type="button" disabled>Stop<\/button>\s*<button class="btn secondary" id="vanity-first" type="button" aria-pressed="false"[^>]*>Stop on first find<\/button>/);
+    assert.match(markup, /<label class="seed-autocomplete-toggle switch-toggle vanity-first-toggle"><input id="vanity-first" type="checkbox"><span>Stop on first find<\/span><\/label>[\s\S]*?<button class="btn primary" id="vanity-go"/);
+    assert.doesNotMatch(markup, /id="vanity-first"[^>]*>[\s\S]*?<span class="label">Stop on first find/);
+    assert.doesNotMatch(markup, /<button[^>]*id="vanity-first"/);
   }
   const vanityController = appSource.slice(appSource.indexOf("// ── Vanity grinder"), appSource.indexOf("function hodlInitWorkspace()"));
   // The sample runs on tab entry, once per session, never while a grind is
@@ -2829,11 +2841,12 @@ test("the vanity estimate is timed from a device sample, and Stop on first find 
   assert.match(vanityController, /function hodlVanityExpectedRate\(\) \{\s*if \(hodlVanityRunning && hodlVanityLiveRate > 0\) return hodlVanityLiveRate;/);
   assert.match(vanityController, /expect a match roughly every \$\{hodlVanityFormatDuration\(Number\(work\) \/ rate\)\}/);
   assert.match(vanityController, /"Measuring this device…"/);
-  // Stop on first find is a toggle that asks the pool to stop as the first
+  // Stop on first find is a checkbox that asks the pool to stop as the first
   // match lands, and the status says so.
   assert.match(vanityController, /if \(hodlVanityStopFirst && hodlVanityRunning\) hodlVanityStop\(\);/);
   assert.match(vanityController, /"Stopped at first match"/);
-  assert.match(vanityController, /document\.getElementById\("vanity-first"\)\.onclick = hodlVanityToggleStopFirst;/);
+  assert.match(vanityController, /hodlVanityStopFirst = Boolean\(document\.getElementById\("vanity-first"\)\?\.checked\);/);
+  assert.match(vanityController, /document\.getElementById\("vanity-first"\)\.onchange = hodlVanityStopFirstChanged;/);
   // Worker chunks adapt to the device so the bar moves smoothly from the start.
   const worker = read("src/js/vanity-worker.js");
   assert.match(worker, /var STEP_MS = 120;/);


### PR DESCRIPTION
## Summary
- update Number Bases naming and use the Bech32 Base32 alphabet with the shared on-screen keyboard
- automatically capture and backfill Key Station derivations in an open Entropy Journal while preserving passphrase privacy and safe deduplication
- simplify Vanity grinding controls with one fixed-width Start/Stop action and a properly aligned Stop-on-first-find checkbox

## Validation
- npm run build && npm test
- 1,278 tests total: 1,276 passed, 0 failed, 2 skipped (Firefox and Edge unavailable)
- generated entropylab.html restored; source and test changes only