### PR TITLE
docs: require accepted and rejected validation tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,1 @@
+- [ ] Tests: Includes both valid and invalid vectors. Invalid cases fail before fix and are correctly rejected after (per Bitcoin Core guidelines)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,1 @@
-- [ ] Tests: Includes both valid and invalid vectors. Invalid cases fail before fix and are correctly rejected after (per Bitcoin Core guidelines)
+- [ ] Security-sensitive validation/parsing changes include applicable accepted and rejected test cases, or this does not apply.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,3 +81,17 @@ Guidelines for AI coding agents.
   it, rather than sweeping the suite, so the design diff stays reviewable and
   the count comes down as the work moves through each surface.
 - Before finishing, run `npm run build && npm test` and make sure they pass.
+
+### Testing - valid AND invalid (borrowed from Bitcoin Core)
+
+Following Bitcoin Core's contribution guidelines: https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md
+
+For any PR touching verification, consensus, cryptography, script, or PSBT parsing:
+
+1. Every PR must include tests
+2. For validation logic, include BOTH valid and invalid vectors
+3. Invalid vectors must fail before your fix and be correctly rejected after
+
+This is not AI-specific - it's the same rule Bitcoin Core uses for `feature_taproot.py`.
+
+If your issue lists "Negative cases", copy them into tests first.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,16 +82,16 @@ Guidelines for AI coding agents.
   the count comes down as the work moves through each surface.
 - Before finishing, run `npm run build && npm test` and make sure they pass.
 
-### Testing - valid AND invalid (borrowed from Bitcoin Core)
+### Security-sensitive test coverage
 
-Following Bitcoin Core's contribution guidelines: https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md
+For changes to verification, cryptography, consensus-sensitive behaviour,
+scripts, or transaction/PSBT parsing:
 
-For any PR touching verification, consensus, cryptography, script, or PSBT parsing:
+- Include tests for both accepted and rejected inputs.
+- For bug fixes, add a regression case that fails before the fix and passes
+  afterward when practicable.
+- Cover applicable negative cases identified in the issue or review. Explain
+  in the pull request when a listed case is intentionally out of scope.
 
-1. Every PR must include tests
-2. For validation logic, include BOTH valid and invalid vectors
-3. Invalid vectors must fail before your fix and be correctly rejected after
-
-This is not AI-specific - it's the same rule Bitcoin Core uses for `feature_taproot.py`.
-
-If your issue lists "Negative cases", copy them into tests first.
+Documentation-only and presentation-only changes do not need test vectors
+solely to satisfy this section.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,8 +126,12 @@ for UI testing only and must never receive funds. The loader and its
 - **Docs:** user-facing or security-model changes require `README.md` /
   `SECURITY.md` updates in the same pull request.
 - **Tests:** new or changed behaviour needs a test; published vectors (BIP39,
-  BIP32, Bitcoin Core) are preferred. Never weaken, skip, or delete an existing
-  test to make CI pass — if it is wrong, say why.
+  BIP32, Bitcoin Core) are preferred. Changes to security-sensitive validation,
+  cryptography, scripts, or transaction/PSBT parsing must cover both accepted
+  and rejected inputs. For bug fixes, add a regression case that fails before
+  the fix when practicable, and explain any identified negative case that is
+  intentionally out of scope. Never weaken, skip, or delete an existing test
+  to make CI pass — if it is wrong, say why.
 - **Translations:** user-facing text is written in English and translated
   content-keyed — the English string at the call site is the catalog key
   (`t("Save watch-only sheet")`), and a content sweep translates static markup


### PR DESCRIPTION
## Why

Bitcoin Core's contributing guidelines require:
> Have unit tests, functional tests, and fuzz tests, where appropriate; Where bugs are fixed, where possible, there should be unit tests demonstrating the bug and also proving the fix.

We don't have that explicitly documented for validation code, and it cost us time and money (well.. Mr Hodl's.. 🥲 - I don't like to see money getting wasted.. ) to retroactively red-team it constantly.

## Case study: #418 / #422

Issue #418 listed 5 negative cases, but initial AI implementation in #422 tested only valid cases. Result: 6 BLOCKING bugs shipped in the first implementation PR submission (version check used `!= 0xc0` instead of evenness, zero key, invalid tweak, bad length, etc). Caught only by post-push hunt and fixed in b5626d6.

In Bitcoin Core, this would have been caught because `feature_taproot.py` requires both valid and invalid vectors. We should adopt same practice.

## What this PR does

Documents Core's practice for our repo:

> For any PR touching verification, consensus, cryptography, script, or PSBT parsing: include both valid and invalid vectors. Invalid must fail before fix and be rejected after.

This is inspired by Core's guidelines (not verbatim quote, but same intent). Adds to AGENTS.md + creates.github/pull_request_template.md.

<img width="915" height="377" alt="image" src="https://github.com/user-attachments/assets/d1a40d91-47d0-4c88-884d-d6fc30b22483" />

Reference: https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md

Docs-only.