### PR TITLE
fix: prevent Clear and pagehide from restoring pending secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Official website: [entropylab.online](https://entropylab.online)
 
 ## Features
 
+Clearing a Key or Multisig station cancels its pending derivation. Leaving
+the page clears rendered seed-word copies and prevents a late derivation or
+import from restoring cleared secrets. Locking the journal also invalidates
+pending notebook and Key Manager imports. See [SECURITY.md](SECURITY.md) for
+the limits of browser-memory cleanup.
+
 - Accepts dice rolls, coin flips, hexadecimal entropy, BIP39 seed phrases,
   extended keys, WIF keys, raw private keys, and Casascius mini private keys.
   All five BIP39 phrase lengths (12, 15, 18, 21, and 24 words) are supported

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,6 +50,13 @@ material. Its security posture rests on the following model:
   iOS/macOS Lockdown Mode disables WebAssembly. Exclude the site in Safari
   or use a host that can compile WASM. There is no JavaScript secp256k1
   fallback; a host that cannot run the module is treated as broken.
+- Clearing a Key or Multisig station invalidates pending derivation work.
+  Pagehide and persisted-page restoration also invalidate derivations and
+  clear rendered seed-word grids, checksum choices, and brain-lab hex.
+  Journal teardown (including Lock) invalidates pending notebook and Key
+  Manager imports at both file-read and decryption boundaries. Obsolete
+  completions cannot restore cleared state; this is not guaranteed erasure
+  of immutable strings or browser-managed memory.
 - Secret byte buffers are overwritten after use, on a best-effort basis. The
   WASM bindings zero every linear-memory buffer before freeing it
   (`el_free`/`psbt_free` use volatile writes) and erase their own secret

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1917,6 +1917,14 @@ class HodlDerivationCancelledError extends Error {
   }
 }
 var hodlActiveDerivation = null;
+var hodlDerivationGeneration = 0;
+function hodlInvalidateDerivation() {
+  hodlDerivationGeneration++;
+  if (hodlActiveDerivation) hodlActiveDerivation.cancelled = true;
+}
+function hodlAssertDerivationActive(generation, control) {
+  if (generation !== hodlDerivationGeneration || control?.cancelled) throw new HodlDerivationCancelledError();
+}
 function hodlDerivationButton(kind) {
   return document.getElementById(kind === "msig" ? "msig-go" : "go");
 }
@@ -6270,6 +6278,7 @@ async function hodlCalculateKey(progress) {
   // from genesis) so a previous "new keys" choice cannot leak into a
   // recovery export.
   hodlWalletDatBirthday = "genesis";
+  let generation = hodlDerivationGeneration, control = hodlActiveDerivation, result;
   try {
     // `network` is the encoding family the tool fields settled on (from the
     // coin type); `chain` is the picker's chain identity when it belongs to
@@ -6306,7 +6315,7 @@ async function hodlCalculateKey(progress) {
         hodlThrowIfFailed(validation);
         let notes = parsed.notes.slice();
         if (!rollsFinalWord) notes.push(`Selected checksum-valid final word: ${finalWord}.`);
-        hodlWalletResult = await hodlMnemonicWalletWithProgress(phrase, passphrase, chain, count, {
+        result = await hodlMnemonicWalletWithProgress(phrase, passphrase, chain, count, {
           notes,
           warnings: parsed.warnings
         }, account, addressStart, progress, purpose, coinType, hardening, branchStart, branchRange, derivationPlan)
@@ -6318,30 +6327,30 @@ async function hodlCalculateKey(progress) {
         if (!hodlPickedLastWord || !possible?.candidates.includes(hodlPickedLastWord)) throw hodlError("Choose one of the {n} valid final checksum words before deriving the wallet.", { n: hodlSeedConfig().candidates });
         let phrase = [...parsed.words, hodlPickedLastWord].join(" "), validation = hodlValidateTargetMnemonic(phrase, hodlTargetWordCount);
         hodlThrowIfFailed(validation);
-        hodlWalletResult = await hodlMnemonicWalletWithProgress(phrase, passphrase, chain, count, { notes: parsed.notes, warnings: parsed.warnings }, account, addressStart, progress, purpose, coinType, hardening, branchStart, branchRange, derivationPlan);
+        result = await hodlMnemonicWalletWithProgress(phrase, passphrase, chain, count, { notes: parsed.notes, warnings: parsed.warnings }, account, addressStart, progress, purpose, coinType, hardening, branchStart, branchRange, derivationPlan);
       } else {
         let diceValue = document.getElementById("dice").value;
         if (hodlAnalyzeDiceInput(diceValue, hodlDiceMethod, hodlTargetWordCount).coinDerivedCount) throw hodlError("Coin-button digits are entropy-equivalent only in BitBox mode. Clear them and enter fair die rolls for this conversion method.");
         let entropy = hodlDiceEntropy(diceValue, hodlDiceMethod, hodlTargetWordCount);
         hodlThrowIfFailed(entropy);
-        hodlWalletResult = await hodlEntropyWalletWithProgress(entropy, passphrase, chain, count, account, addressStart, progress, purpose, coinType, hardening, branchStart, branchRange, derivationPlan);
+        result = await hodlEntropyWalletWithProgress(entropy, passphrase, chain, count, account, addressStart, progress, purpose, coinType, hardening, branchStart, branchRange, derivationPlan);
       }
     } else if (hodlKeyMode === "cards") {
       let entropy = hodlSelectedCardsEntropy(hodlTargetWordCount);
       hodlThrowIfFailed(entropy);
-      hodlWalletResult = await hodlEntropyWalletWithProgress(entropy, passphrase, chain, count, account, addressStart, progress, purpose, coinType, hardening, branchStart, branchRange, derivationPlan);
+      result = await hodlEntropyWalletWithProgress(entropy, passphrase, chain, count, account, addressStart, progress, purpose, coinType, hardening, branchStart, branchRange, derivationPlan);
     } else if (hodlKeyMode === "hex") {
       let entropy = hodlSelectedEntropy();
       hodlThrowIfFailed(entropy);
-      hodlWalletResult = await hodlEntropyWalletWithProgress(entropy, passphrase, chain, count, account, addressStart, progress, purpose, coinType, hardening, branchStart, branchRange, derivationPlan);
+      result = await hodlEntropyWalletWithProgress(entropy, passphrase, chain, count, account, addressStart, progress, purpose, coinType, hardening, branchStart, branchRange, derivationPlan);
     } else if (hodlKeyMode === "seed") {
       let selected = hodlSelectedSeedInput(hodlTargetWordCount), value = selected.value;
-      if (selected.extended) hodlWalletResult = await hodlImportedWalletWithProgress(value, chain, count, account, addressStart, progress, purpose, coinType, hardening, branchStart, branchRange, derivationPlan);
+      if (selected.extended) result = await hodlImportedWalletWithProgress(value, chain, count, account, addressStart, progress, purpose, coinType, hardening, branchStart, branchRange, derivationPlan);
       else {
         if (hodlSeedMethod === "numbers" && !selected.parsed?.complete) throw selected.parsed?.invalidEntries.length ? hodlError("Word numbers must be between {min} and {max}.", { min: selected.parsed.minimum, max: selected.parsed.maximum }) : selected.parsed?.extraEntries.length ? hodlError("Enter exactly {words} BIP39 word numbers.", { words: hodlTargetWordCount }) : selected.parsed?.checksumInvalid ? hodlError("The entered word numbers do not have a valid BIP39 checksum.") : hodlError("Enter exactly {words} BIP39 word numbers before deriving the wallet.", { words: hodlTargetWordCount });
         let validation = hodlValidateTargetMnemonic(value, hodlTargetWordCount);
         hodlThrowIfFailed(validation);
-        hodlWalletResult = await hodlMnemonicWalletWithProgress(validation.words.join(" "), passphrase, chain, count, void 0, account, addressStart, progress, purpose, coinType, hardening, branchStart, branchRange, derivationPlan);
+        result = await hodlMnemonicWalletWithProgress(validation.words.join(" "), passphrase, chain, count, void 0, account, addressStart, progress, purpose, coinType, hardening, branchStart, branchRange, derivationPlan);
       }
     } else {
       let value = document.getElementById("key").value, kind = hodlNormalizePrivateKeyKind(document.querySelector("input[name=kk]:checked")?.value, value);
@@ -6352,19 +6361,21 @@ async function hodlCalculateKey(progress) {
         if (passphrase && document.getElementById("passphrase-field")?.hidden) throw hodlError("A passphrase is set but not visible for this output. Show it and confirm it, or clear it, before deriving.");
         let entropy = hodlBrainLabEntropy(hodlBrainWalletPassphrase(value, hodlBrainWalletTrimEnabled()), hodlBrainWalletTrimEnabled());
         hodlThrowIfFailed(entropy);
-        hodlWalletResult = await hodlEntropyWalletWithProgress(entropy, passphrase, chain, count, account, addressStart, progress, purpose, coinType, hardening, branchStart, branchRange, derivationPlan);
+        result = await hodlEntropyWalletWithProgress(entropy, passphrase, chain, count, account, addressStart, progress, purpose, coinType, hardening, branchStart, branchRange, derivationPlan);
       } else {
         let trimBrainWallet = hodlBrainWalletTrimEnabled();
         hodlAssertPrivateKeyKind(value, chain, kind, trimBrainWallet);
         progress.setTotal(1);
-        hodlWalletResult = hodlSingleKeyWallet(value, chain, kind, trimBrainWallet);
+        result = hodlSingleKeyWallet(value, chain, kind, trimBrainWallet);
         progress.step();
       }
       // Mark brain-derived results so a revoked acknowledgement can retract
       // them from every key slot, not just the lab that produced them.
-      if (kind === "brain") hodlWalletResult.brainWalletOutput = hodlBrainWalletOutput();
+      if (kind === "brain") result.brainWalletOutput = hodlBrainWalletOutput();
     }
-    if (hodlNetworkFamily(hodlWalletResult?.network) !== hodlNetworkFamily(chain)) throw hodlError("The supplied key is for {have}, but Network is set to {want}.", { have: hodlWalletResult.network, want: chain });
+    if (hodlNetworkFamily(result?.network) !== hodlNetworkFamily(chain)) throw hodlError("The supplied key is for {have}, but Network is set to {want}.", { have: result.network, want: chain });
+    hodlAssertDerivationActive(generation, control);
+    hodlWalletResult = result;
     hodlRevealPrivate = false;
     hodlSetSelectedScriptType(scriptType);
     hodlCaptureKey();
@@ -6375,6 +6386,7 @@ async function hodlCalculateKey(progress) {
     hodlFocusWalletResult();
     return true;
   } catch (error) {
+    hodlAssertDerivationActive(generation, control);
     if (error instanceof HodlDerivationCancelledError) throw error;
     hodlWalletResult = null;
     hodlSetWorkspaceError("key", hodlErrorSpecFrom(error, "Could not derive key"));
@@ -8073,6 +8085,7 @@ function hodlValidatedMsigInputs() {
   return { network, coinType, count, addressStart, branchStart, branchRange, hardening, n, m, kind, purpose, legacyStandard, nodes, xpubs, keyTokens, accountSummary, accountWarning };
 }
 async function hodlBuildMsig(progress) {
+  let generation = hodlDerivationGeneration, control = hodlActiveDerivation;
   let error = document.getElementById("msig-error");
   hodlSetWorkspaceError("msig", null);
   try {
@@ -8120,6 +8133,7 @@ async function hodlBuildMsig(progress) {
     if (kind === "p2sh" && legacyStandard === "bip87") notes.push("Legacy P2SH uses the selected BIP87 account paths. Keep the descriptor with every seed backup.");
     if (kind === "p2tr") notes.push("Taproot script-path multisig. The internal key is the BIP341 NUMS point, so spending is only possible through the " + (sorted ? "sortedmulti_a" : "multi_a") + " script path.");
     if (!sorted) notes.push("This wallet uses " + hodlMsigPolicyOp(kind, !1) + ", so the listed co-signer order is part of the script. Reordering keys changes addresses.");
+    hodlAssertDerivationActive(generation, control);
     hodlWalletResult = {
       kind: "msig",
       network,
@@ -8156,6 +8170,7 @@ async function hodlBuildMsig(progress) {
     hodlFocusWalletResult();
     return true;
   } catch (exception) {
+    hodlAssertDerivationActive(generation, control);
     if (exception instanceof HodlDerivationCancelledError) throw exception;
     hodlWalletResult = null;
     hodlClearMsigOut();
@@ -11041,6 +11056,7 @@ function hodlSyncKeyClearButton(capture = false) {
   button.setAttribute("aria-disabled", String(button.disabled));
 }
 function hodlWipeActiveKey() {
+  hodlInvalidateDerivation();
   if (hodlActiveKey < 0 || !hodlKeys[hodlActiveKey]) return;
   let state = hodlKeys[hodlActiveKey];
   hodlKeys[hodlActiveKey] = state.isLab ? hodlNewLabState() : hodlNewKeyState(state.name, state.id, state.number);
@@ -11827,6 +11843,7 @@ function hodlRestoreMsig() {
   hodlSyncMsigClearButton();
 }
 function hodlWipeActiveMsig() {
+  hodlInvalidateDerivation();
   if (hodlActiveMsig < 0 || !hodlMsigs[hodlActiveMsig]) return;
   let state = hodlMsigs[hodlActiveMsig];
   hodlMsigs[hodlActiveMsig] = state.isLab ? hodlNewMsigLabState() : hodlNewMsigState(state.name, state.id, state.number);
@@ -12719,6 +12736,7 @@ async function hodlJournalDownloadContent(kind, filename, text, type = "text/pla
 }
 async function hodlJournalImportFile(file) {
   if (!file) return;
+  let generation = hodlJournalGeneration;
   if (file.size > 2 * 1024 * 1024) {
     hodlJournalLog("notebook-import-error", "too-large", "journal");
     hodlJournalSetStatus("That notebook is larger than the 2 MiB import limit.", true);
@@ -12726,10 +12744,12 @@ async function hodlJournalImportFile(file) {
   }
   try {
     let text = await file.text(), encryptedNotebook = false;
+    if (generation !== hodlJournalGeneration) return;
     let outer;
     try { outer = JSON.parse(text); } catch { outer = null; }
     if (outer?.entropylabJournalExport) {
       let decrypted = await hodlJournalOpenExport(outer, hodlJournalKeys);
+      if (generation !== hodlJournalGeneration) return;
       if (decrypted.kind !== "notebook") throw new Error("That encrypted file is not a notepad export.");
       text = decrypted.content;
       encryptedNotebook = true;
@@ -12748,6 +12768,7 @@ async function hodlJournalImportFile(file) {
     hodlJournalLog("notebook-import", `${imported.pages.length} page${imported.pages.length === 1 ? "" : "s"}`);
     hodlJournalSetStatus(`Imported ${imported.pages.length} page${imported.pages.length === 1 ? "" : "s"} from ${file.name}.`);
   } catch (error) {
+    if (generation !== hodlJournalGeneration) return;
     hodlJournalLog("notebook-import-error", "invalid-file", "journal");
     hodlJournalSetStatus(error?.message || "The notebook could not be imported.", true);
   }
@@ -12772,6 +12793,7 @@ async function hodlKeyManagerDownload() {
 }
 async function hodlKeyManagerImportFile(file) {
   if (!file) return;
+  let generation = hodlJournalGeneration;
   if (file.size > 2 * 1024 * 1024) {
     hodlKeyManagerStatus("That key file is larger than the 2 MiB import limit.", true);
     hodlJournalLog("key-manager-import-error", "too-large", "journal");
@@ -12779,7 +12801,10 @@ async function hodlKeyManagerImportFile(file) {
   }
   try {
     if (!hodlJournalUnlocked()) throw new Error("Create or open a journal first.");
-    let opened = await hodlJournalOpenExport(await file.text(), hodlJournalKeys);
+    let text = await file.text();
+    if (generation !== hodlJournalGeneration) return;
+    let opened = await hodlJournalOpenExport(text, hodlJournalKeys);
+    if (generation !== hodlJournalGeneration) return;
     if (opened.kind !== "key-manager") throw new Error("That encrypted file is not a Key Manager export.");
     let imported = parseKeyVault(opened.content), added = 0, duplicates = 0;
     imported.keys.forEach((entry) => {
@@ -12804,6 +12829,7 @@ async function hodlKeyManagerImportFile(file) {
     hodlKeyManagerStatus(`${added} new key${added === 1 ? "" : "s"} imported${duplicates ? `; ${duplicates} duplicate${duplicates === 1 ? "" : "s"} kept unchanged` : ""}. ` + hodlTText("Use “Use in Key Station” to load one, or “Add all to Key Station” to load every waiting key."));
     hodlJournalLog("key-manager-import", `${added} keys; ${duplicates} duplicates`, "journal");
   } catch (error) {
+    if (generation !== hodlJournalGeneration) return;
     hodlKeyManagerStatus(error?.message || "The key file could not be imported.", true);
     hodlJournalLog("key-manager-import-error", "invalid-file", "journal");
   }
@@ -14765,6 +14791,7 @@ function hodlInitTheme() {
 }
 function hodlInitSecretFieldAutoClear() {
   let clearSecretFields = () => {
+    hodlInvalidateDerivation();
     hodlPsbtWipeMem();
     hodlBip85WipeMem();
     hodlSpWipeMem();
@@ -14850,7 +14877,7 @@ function hodlInitSecretFieldAutoClear() {
     hodlRefreshStationKeyPickers();
     // The <pre> mirrors behind each input hold a second live copy of whatever
     // was typed (dice rolls, seed words, passphrase, private key).
-    document.querySelectorAll(".dice-input-highlight").forEach((highlight) => {
+    document.querySelectorAll(".dice-input-highlight, .dice-word-grid, #last-words, #brain-lab-hex").forEach((highlight) => {
       highlight.textContent = "";
     });
     // Copy buttons keep the phrase/child secret in a data attribute.

--- a/test/brain-wallet.test.mjs
+++ b/test/brain-wallet.test.mjs
@@ -172,7 +172,7 @@ test("a derived brain wallet does not outlive its acknowledgement or its output 
   // re-render their stored result without asking again, so every brain-derived
   // result carries a marker and revoking sweeps it from every slot.
   const derive = loadSlice("hodlCalculateKey");
-  assert.match(derive, /if \(kind === "brain"\) hodlWalletResult\.brainWalletOutput = hodlBrainWalletOutput\(\);/);
+  assert.match(derive, /if \(kind === "brain"\) result\.brainWalletOutput = hodlBrainWalletOutput\(\);/);
   const retract = loadSlice("hodlRetractBrainWalletResults");
   assert.match(retract, /for \(let state of hodlKeys\)/);
   assert.match(retract, /state\?\.result\?\.brainWalletOutput !== output/);

--- a/test/keymanager.test.mjs
+++ b/test/keymanager.test.mjs
@@ -133,5 +133,5 @@ test("the Journal integration keeps imported keys pending until explicit use", (
   assert.match(source, /function hodlKeyManagerUseInStation\(state\)[\s\S]*hodlKeyManagerPending\.splice\(pending, 1\);[\s\S]*hodlKeys\.push\(state\)/);
   assert.match(source, /function hodlDeleteActiveKey\(\)[\s\S]*hodlJournalUnlocked\(\)[\s\S]*hodlKeyManagerDetachFromStation\(state\)/);
   assert.match(source, /hodlJournalSealExport\("key-manager", content, hodlJournalKeys\)/);
-  assert.match(source, /hodlJournalOpenExport\(await file\.text\(\), hodlJournalKeys\)/);
+  assert.match(source, /let text = await file\.text\(\);\s*if \(generation !== hodlJournalGeneration\) return;\s*let opened = await hodlJournalOpenExport\(text, hodlJournalKeys\)/);
 });

--- a/test/secret-clear.test.mjs
+++ b/test/secret-clear.test.mjs
@@ -4,6 +4,155 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import vm from "node:vm";
+
+function deferred() {
+  let resolve, reject;
+  const promise = new Promise((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+
+// Execute the real controller functions, with delayed crypto and a small DOM.
+function functionSource(name) {
+  const start = app.indexOf(`function ${name}(`);
+  assert.ok(start >= 0, name);
+  const next = app.indexOf("\nfunction ", start + 1);
+  const asyncNext = app.indexOf("\nasync function ", start + 1);
+  const end = Math.min(...[next, asyncNext].filter(value => value >= 0));
+  return (app.slice(start - 6, start) === "async " ? "async " : "") + app.slice(start, end);
+}
+
+function raceHarness() {
+  const pending = deferred(), decryptStarted = deferred(), events = {}, effects = [];
+  const fields = new Map();
+  const mirrors = [".dice-input-highlight", ".dice-word-grid", "#last-words", "#brain-lab-hex"]
+    .map(selector => ({ selector, textContent: "secret mnemonic" }));
+  const context = vm.createContext({
+    document: {
+      getElementById: id => fields.get(id) ?? null,
+      querySelectorAll: selector => mirrors.filter(el => selector.split(", ").includes(el.selector)),
+    },
+    addEventListener: (type, callback) => { events[type] = callback; },
+    hodlActiveDerivation: { kind: "key", cancelled: false }, hodlDerivationGeneration: 0,
+    hodlJournalGeneration: 0, hodlJournalKeys: {}, hodlJournal: {},
+    hodlKeys: [{ id: 1, number: 1, fields: {}, result: null }], hodlActiveKey: 0,
+    hodlKeyMode: "hex", hodlTargetWordCount: 24, hodlNetworkChoice: "mainnet",
+    hodlWalletResult: null, hodlOutEl: { innerHTML: "" }, hodlLastWordCache: new Map(),
+    hodlBip85Note: "", hodlSpNote: "",
+    hodlReadDerivationPlan: () => ({ network: "mainnet", coinType: 0 }),
+    hodlNetworkFamily: value => value,
+    hodlReadAddressWindow: () => ({ start: 0, range: 1 }),
+    hodlReadBranchWindow: () => ({ start: 0, range: 2 }),
+    hodlSelectedScriptType: () => "bip84", hodlDefaultHardening: () => ({}),
+    hodlPassphraseBip39Enabled: () => false, hodlSelectedEntropy: () => ({}),
+    hodlEntropyWalletWithProgress: () => pending.promise,
+    hodlNewKeyState: () => ({ fields: {}, result: null }),
+    hodlRestoreKey: () => { context.hodlWalletResult = null; },
+    hodlJournalUnlocked: () => true,
+    hodlJournalOpenExport: () => { decryptStarted.resolve(); return pending.promise; },
+    hodlJournalWipeMem: () => { context.hodlJournalGeneration++; },
+    hodlErrorSpecFrom: error => error.message,
+  });
+  fields.set("pass", { value: "private passphrase" });
+  for (const name of ["hodlThrowIfFailed", "hodlSetSelectedScriptType", "hodlCaptureKey",
+    "hodlSnapshotKeySummary", "hodlCommitDerivedKey", "hodlJournalCaptureDerivedKey",
+    "hodlFocusWalletResult", "hodlJournalLog", "hodlSetWorkspaceError", "hodlJournalSetStatus",
+    "hodlKeyManagerStatus", "hodlPsbtWipeMem", "hodlBip85WipeMem", "hodlSpWipeMem",
+    "hodlLnWipeMem", "hodlRenderBip85Tabs", "hodlSyncBip85View", "hodlVanityCancel",
+    "hodlVanitySyncSource", "hodlVanitySyncControls", "hodlRefreshStationKeyPickers"])
+    context[name] = (...args) => { effects.push([name, ...args]); };
+  vm.runInContext('class HodlDerivationCancelledError extends Error {}', context);
+  for (const name of ["hodlInvalidateDerivation", "hodlAssertDerivationActive", "hodlCalculateKey",
+    "hodlWipeActiveKey", "hodlJournalImportFile", "hodlKeyManagerImportFile", "hodlInitSecretFieldAutoClear"])
+    vm.runInContext(functionSource(name), context);
+  context.hodlInitSecretFieldAutoClear();
+  return { context, pending, decryptStarted, events, effects, mirrors };
+}
+
+for (const teardown of ["clear", "pagehide", "pageshow", "stop"]) {
+  for (const rejects of [false, true]) test(`${teardown} discards a late derivation ${rejects ? "error" : "result"}`, async () => {
+    const { context, pending, events, effects } = raceHarness();
+    const calculation = context.hodlCalculateKey({});
+    const rejected = assert.rejects(calculation, error => error.constructor.name === "HodlDerivationCancelledError");
+    if (teardown === "clear") context.hodlWipeActiveKey();
+    else if (teardown === "stop") context.hodlActiveDerivation.cancelled = true;
+    else events[teardown]({ persisted: true });
+    effects.length = 0;
+    if (rejects) pending.reject(new Error("late crypto failure"));
+    else pending.resolve({ network: "mainnet", privateKey: "secret" });
+    await rejected;
+    assert.equal(context.hodlWalletResult, null);
+    assert.deepEqual(effects, []);
+  });
+}
+
+test("an uninterrupted derivation still commits its result", async () => {
+  const { context, pending, effects } = raceHarness();
+  const calculation = context.hodlCalculateKey({});
+  const result = { network: "mainnet", privateKey: "secret" };
+  pending.resolve(result);
+  assert.equal(await calculation, true);
+  assert.equal(context.hodlWalletResult, result);
+  assert.ok(effects.some(([name]) => name === "hodlCommitDerivedKey"));
+});
+
+test("Multisig Clear prevents a suspended derivation from committing", async () => {
+  const { context, pending, effects } = raceHarness();
+  Object.assign(context, {
+    hodlActiveMsig: 0, hodlMsigs: [{ id: 2, number: 1 }],
+    hodlNewMsigState: () => ({ result: null }), hodlRestoreMsig: () => {},
+    hodlValidatedMsigInputs: () => ({
+      count: 1, addressStart: 0, branchStart: 0, branchRange: 1,
+      kind: "p2wsh", keyTokens: ["key"], accountSummary: {},
+    }),
+    hodlMsigKeysSorted: () => true, hodlMsigInnerDescriptor: () => "descriptor",
+    descriptorDerive: () => ({ address: "test address", pubkeys: [] }),
+    hodlHex: { decode: value => value, encode: value => value },
+    hodlAddressBranchRole: () => "receive", hodlAddressBranchLabel: () => "Receive",
+    hodlDescriptorWithChecksum: value => value,
+  });
+  vm.runInContext(functionSource("hodlBuildMsig"), context);
+  vm.runInContext(functionSource("hodlWipeActiveMsig"), context);
+  const operation = context.hodlBuildMsig({ setTotal() {}, step: () => pending.promise });
+  const rejected = assert.rejects(operation, error => error.constructor.name === "HodlDerivationCancelledError");
+  context.hodlWipeActiveMsig();
+  effects.length = 0;
+  pending.resolve();
+  await rejected;
+  assert.equal(context.hodlWalletResult, null);
+  assert.deepEqual(effects, []);
+});
+
+test("pagehide and persisted pageshow erase rendered word copies", () => {
+  const { events, mirrors } = raceHarness();
+  for (const type of ["pagehide", "pageshow"]) {
+    mirrors.forEach(el => { el.textContent = "secret mnemonic"; });
+    events[type]({ persisted: true });
+    assert.ok(mirrors.every(el => el.textContent === ""));
+  }
+});
+
+for (const name of ["hodlJournalImportFile", "hodlKeyManagerImportFile"]) {
+  for (const phase of ["read", "decrypt"]) {
+    for (const rejects of [false, true]) test(`${name} discards stale ${phase} ${rejects ? "failure" : "completion"}`, async () => {
+      const { context, pending, decryptStarted, effects } = raceHarness();
+      const read = deferred();
+      const operation = context[name]({ size: 1, name: "notes.elkeys", text: () => read.promise });
+      if (phase === "decrypt") {
+        read.resolve('{"entropylabJournalExport":true}');
+        await decryptStarted.promise;
+      }
+      context.hodlJournalWipeMem();
+      effects.length = 0;
+      const gate = phase === "read" ? read : pending;
+      if (rejects) gate.reject(new Error("late import failure"));
+      else gate.resolve(phase === "read" ? '{}' : { kind: "key-manager", content: "private" });
+      await operation;
+      assert.deepEqual(effects, []);
+      assert.deepEqual(context.hodlJournal, {});
+    });
+  }
+}
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const app = readFileSync(join(root, "src/js/app.js"), "utf8");
@@ -106,7 +255,7 @@ test("highlight mirrors, copy-button phrases, the last-word cache, and the PSBT 
   // copy of the typed secret; copy buttons keep the phrase in data-phrase;
   // hodlLastWordCache retains partial mnemonics; the editor holds the loaded
   // PSBT (which can carry xprvs in proprietary fields).
-  assert.match(lifecycle, /querySelectorAll\("\.dice-input-highlight"\)/);
+  assert.match(lifecycle, /querySelectorAll\("\.dice-input-highlight, \.dice-word-grid, #last-words, #brain-lab-hex"\)/);
   assert.match(lifecycle, /highlight\.textContent\s*=\s*""/);
   assert.match(lifecycle, /querySelectorAll\("\[data-phrase\]"\)/);
   assert.match(lifecycle, /removeAttribute\("data-phrase"\)/);

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -127,7 +127,7 @@ test("the header network picker sets the network every tool defaults to", () => 
   assert.match(appSource, /function hodlNetworkFamily\(network\) \{\s*return network === "mainnet" \? "mainnet" : "testnet";/);
   assert.match(appSource, /chain = hodlNetworkFamily\(hodlNetworkChoice\) === network \? hodlNetworkChoice : network/);
   assert.match(appSource, /hodlMnemonicWalletWithProgress\(phrase, passphrase, chain, count,/);
-  assert.match(appSource, /hodlNetworkFamily\(hodlWalletResult\?\.network\) !== hodlNetworkFamily\(chain\)/);
+  assert.match(appSource, /hodlNetworkFamily\(result\?\.network\) !== hodlNetworkFamily\(chain\)/);
   // The option names and the button's accessible name come from the locale
   // catalogs so the whole header follows the selected language.
   assert.match(appSource, /let key = \["mainnet", "testnet", "signet", "regtest"\]\.includes\(hodlNetworkChoice\) \? hodlNetworkChoice : "mainnet"/);


### PR DESCRIPTION
## Summary

Refs #423 (F3) and #425 (Clear/pagehide/import race). This is a focused fix, not a closure of either audit.

- Invalidate pending Key/Multisig derivations on Clear and page lifecycle teardown.
- Keep a derived key result local until generation/cancellation checks pass; stale failures cannot overwrite the cleared UI either.
- Reject notebook and Key Manager imports that outlive their journal generation, after file reads and decryption, including stale failures.
- Clear rendered seed-word grids, final-word choices, and brain-lab hex on pagehide and persisted pageshow.
- Add 19 behavioral regressions alongside the existing cleanup checks; update source-shape assertions and cleanup documentation.

## Validation

- `node test/secret-clear.test.mjs`: 30 passed.
- `npm run build`: passed.
- `npm run test:ci`: 1,290 passed, 4 skipped, 0 failed.
- `npm test` attempted: Firefox report collection timed out locally. Chrome completed 85/86 checks, failing the enabled Derive Key color assertion (expected orange, got light gray). No CSS or that browser assertion was changed here; browser validation is not claimed as fully passing.
- `git diff --check`: passed.

Generated site artifacts and locale files are intentionally excluded.

## Remaining audit work

Vanity retained-node cleanup/resume and imported .elkeys result authenticity are separate concerns; this PR does not claim to resolve them.
