### PR TITLE
fix: treat .elkeys imports as unverified inputs until rederived

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,13 +183,18 @@ Official website: [entropylab.online](https://entropylab.online)
   to keep it. Closing the page discards the sitting. The notebook is a
   calculator companion, not a password manager: it only stores material the
   user generated themselves.
-  The **Key manager** tab packages selected derived Key Station keys and
-  ignored-key metadata into an `.elkeys` file. It reuses the unlocked
+  The **Key manager** tab packages selected Key Station source inputs and
+  settings, including ignored entries, into an `.elkeys` file. It reuses the unlocked
   Journal's password setting, so it adds no password prompt, random salt,
-  or random nonce. Imported keys remain in Key Manager until the user chooses
-  **Use in Key Station** for one key or **Add all to Key Station** for every
-  waiting key. Adding all skips keys already in the station and leaves ignored
-  keys untouched. Deleting a Key Station tab while a Journal is open
+  or random nonce. Imports are **unverified inputs**, not ready-to-use wallets.
+  Choose **Load inputs to derive**, review the inputs/settings, then derive each
+  key in Key Station. Cached addresses, private outputs, and fingerprints from
+  legacy files are discarded; only fresh derivation can match an existing key.
+  **Add all to Key Station** applies only to already-derived keys, leaving
+  unverified and ignored entries untouched. New files use input-only format
+  version 2 (requires this updated reader); version 1 files remain importable.
+  Cached-output-only files cannot replace missing source inputs.
+  Deleting a Key Station tab while a Journal is open
   likewise removes it from the station without discarding it from Key Manager.
   The Journal also includes a paged notepad. Pages use
   the Key Station's numbered naming convention, can be added or removed with

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -124,6 +124,13 @@ material. Its security posture rests on the following model:
 - Key Manager lives behind the same unlocked Journal gate. Its `.elkeys`
   exports reuse the Journal's deterministic export encryption and optional password;
   the Key Manager does not generate a salt, nonce, password, or key material.
+  Version 2 vaults store source inputs/settings, not cached wallet results.
+  Both version 1 and 2 imports discard cached results, claimed identities,
+  and any claimed verification state. Imports (including ignored entries)
+  are labeled unverified and must be loaded into the lab and freshly derived
+  before becoming station wallets or supplying outputs to other tools.
+  Re-derivation proves consistency with the supplied inputs, not that the
+  sender lacks a copy of the key or that the inputs have adequate entropy.
   Imported private material remains in page memory and is not loaded into Key
   Station until the user explicitly chooses it. Locking or clearing the
   Journal drops pending and ignored Key Manager entries on a best-effort basis.

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1220,10 +1220,9 @@ function hodlBindAddressMatch() {
 }
 var hodlAddressVirtualThreshold = 24, hodlAddressVirtualRowHeight = 34, hodlAddressVirtualOverscan = 6;
 // Address indexes come out of the derivation loops as non-negative integers.
-// An imported cached result (Key Manager → "Use in Key Station") is restored
-// without re-derivation and can carry an arbitrary value instead, so anything
-// but a non-negative integer renders as escaped text — never markup that an
-// imported file could smuggle onto the page (issue #389).
+// Keep the renderer defensive even though Key Manager now discards imported
+// cached results: anything but a non-negative integer renders as escaped
+// text, never markup (issue #389).
 function hodlAddressIndexHtml(index) {
   return Number.isSafeInteger(index) && index >= 0 ? String(index) : hodlEscapeHtml(index);
 }
@@ -10529,6 +10528,12 @@ function hodlKeyManagerRename(state, input) {
 }
 function hodlKeyManagerDetails(state) {
   let result = state.result || {};
+  if (state.needsDerivation) return [
+    ["Verification", "Unverified inputs — derive in Key Station before using any address or export."],
+    ["Method", hodlKeySummaryMethod(state) || "Unknown"],
+    ["Derivation path", state.fields?.derivationPath || "Not available"],
+    ["Private material", "Saved inputs may contain secrets. Cached outputs were discarded."],
+  ];
   return [
     ["Created", state.createdAt ? new Date(state.createdAt).toLocaleString() : "Not available"],
     ["Master fingerprint", result.masterFingerprint || "Not available"],
@@ -10565,7 +10570,7 @@ function hodlKeyManagerRender() {
   let states = hodlKeyManagerStates();
   let addAll = document.getElementById("journal-keymanager-add-all");
   if (addAll) {
-    addAll.disabled = !states.some((state) => !hodlKeys.includes(state));
+    addAll.disabled = !states.some((state) => !state.needsDerivation && !hodlKeys.includes(state));
     addAll.onclick = hodlKeyManagerUseAllInStation;
   }
   tabs.replaceChildren();
@@ -10651,7 +10656,7 @@ function hodlKeyManagerRender() {
   include.onclick = () => hodlKeyManagerToggle(active);
   use.className = "btn secondary";
   use.type = "button";
-  use.textContent = hodlKeys.includes(active) ? "Open in Key Station" : "Use in Key Station";
+  use.textContent = active.needsDerivation ? "Load inputs to derive" : hodlKeys.includes(active) ? "Open in Key Station" : "Use in Key Station";
   use.onclick = () => hodlKeyManagerUseInStation(active);
   ignore.className = "btn clear-current-action journal-keymanager-ignore";
   ignore.type = "button";
@@ -10684,6 +10689,8 @@ function hodlKeyManagerImportedState(entry) {
     createdAt: entry.createdAt || state.createdAt,
     fields: { ...state.fields, ...entry.fields, ...(entry.fields?.privateKeys ? { privateKeys: { ...state.fields.privateKeys, ...entry.fields.privateKeys } } : {}) },
     reveal: false,
+    result: null,
+    needsDerivation: true,
     error: "",
     errorSpec: null,
   });
@@ -10691,6 +10698,16 @@ function hodlKeyManagerImportedState(entry) {
   return state;
 }
 function hodlKeyManagerUseInStation(state) {
+  if (state.needsDerivation) {
+    if (!hodlKeyManagerPending.includes(state) || hodlActiveDerivation) return;
+    let lab = hodlFillLabFromKey(state);
+    hodlKeys[lab].importedKeyId = state.id;
+    hodlActiveKey = lab;
+    hodlRenderKeyTabs();
+    hodlShowWorkspace("calc");
+    hodlKeyManagerStatus("Unverified inputs loaded. Review them and derive the key before using addresses or exports.");
+    return;
+  }
   let identity = keyVaultIdentity(state), existing = hodlKeys.find((candidate) => !candidate.isLab && keyVaultIdentity(candidate) === identity);
   if (existing) hodlActiveKey = hodlKeys.indexOf(existing);
   else {
@@ -10705,7 +10722,7 @@ function hodlKeyManagerUseInStation(state) {
   hodlShowWorkspace("calc");
 }
 function hodlKeyManagerUseAllInStation() {
-  let states = hodlKeyManagerStates().filter((state) => !hodlKeys.includes(state));
+  let states = hodlKeyManagerStates().filter((state) => !state.needsDerivation && !hodlKeys.includes(state));
   if (!states.length) return;
   states.forEach((state) => {
     let pending = hodlKeyManagerPending.indexOf(state);
@@ -10831,6 +10848,7 @@ function hodlCommitDerivedKey() {
     hodlRestoreKey();
     return hodlActiveKey;
   }
+  let imported = hodlKeyManagerPending.find((state) => state.id === lab.importedKeyId);
   let fingerprint = lab.result.masterFingerprint || "";
   let existing = fingerprint ? hodlKeys.findIndex((state) => !state.isLab && state.result?.masterFingerprint === fingerprint) : -1;
   if (existing >= 0) {
@@ -10842,6 +10860,12 @@ function hodlCommitDerivedKey() {
     hodlKeys[hodlActiveKey] = hodlNewLabState();
     hodlKeys.push(derived);
     hodlActiveKey = hodlKeys.length - 1;
+  }
+  if (imported) {
+    let identity = keyVaultIdentity(imported), derivedIdentity = keyVaultIdentity(hodlKeys[hodlActiveKey]);
+    hodlKeyManagerPending.splice(hodlKeyManagerPending.indexOf(imported), 1);
+    if (hodlKeyManagerIds.delete(identity)) hodlKeyManagerIds.add(derivedIdentity);
+    if (hodlKeyManagerActiveId === identity) hodlKeyManagerActiveId = derivedIdentity;
   }
   hodlRenderKeyTabs();
   hodlRestoreKey();
@@ -10862,7 +10886,7 @@ function hodlFillLabFromKey(source) {
   let labIndex = hodlKeys.findIndex((state) => state.isLab);
   let existing = labIndex >= 0 ? hodlKeys[labIndex] : hodlNewLabState();
   let lab = hodlCloneDerivedKey(source, existing);
-  Object.assign(lab, { isLab: true, name: "Key Station", result: null, error: "", reveal: false, createdScript: "", createdPath: "" });
+  Object.assign(lab, { isLab: true, name: "Key Station", result: null, importedKeyId: null, error: "", reveal: false, createdScript: "", createdPath: "" });
   if (labIndex < 0) {
     hodlKeys.unshift(lab);
     labIndex = 0;
@@ -12781,28 +12805,22 @@ async function hodlKeyManagerImportFile(file) {
     if (!hodlJournalUnlocked()) throw new Error("Create or open a journal first.");
     let opened = await hodlJournalOpenExport(await file.text(), hodlJournalKeys);
     if (opened.kind !== "key-manager") throw new Error("That encrypted file is not a Key Manager export.");
-    let imported = parseKeyVault(opened.content), added = 0, duplicates = 0;
+    let imported = parseKeyVault(opened.content), added = 0;
     imported.keys.forEach((entry) => {
-      let identity = keyVaultIdentity(entry), existing = identity && hodlKeyManagerStates().find((state) => keyVaultIdentity(state) === identity);
-      if (existing) {
-        hodlKeyManagerIds.add(identity);
-        duplicates++;
-        return;
-      }
+      // Cached fingerprints and file-local IDs are not identity evidence.
+      // Only a fresh derivation may match an existing station key.
       let state = hodlKeyManagerImportedState(entry);
       hodlKeyManagerPending.push(state);
       hodlKeyManagerIds.add(keyVaultIdentity(state));
       added++;
     });
     imported.ignoredKeys.forEach((entry) => {
-      let identity = keyVaultIdentity(entry);
-      if (!identity || hodlKeyManagerStates().some((state) => keyVaultIdentity(state) === identity) || hodlKeyManagerIgnored.some((state) => keyVaultIdentity(state) === identity)) return;
-      hodlKeyManagerIgnored.push(entry);
+      hodlKeyManagerIgnored.push(hodlKeyManagerImportedState(entry));
     });
     hodlKeyManagerActiveId = hodlKeyManagerActiveId || keyVaultIdentity(hodlKeyManagerStates()[0]);
     hodlKeyManagerRender();
-    hodlKeyManagerStatus(`${added} new key${added === 1 ? "" : "s"} imported${duplicates ? `; ${duplicates} duplicate${duplicates === 1 ? "" : "s"} kept unchanged` : ""}. ` + hodlTText("Use “Use in Key Station” to load one, or “Add all to Key Station” to load every waiting key."));
-    hodlJournalLog("key-manager-import", `${added} keys; ${duplicates} duplicates`, "journal");
+    hodlKeyManagerStatus(hodlTText("{n} unverified input set(s) imported. Use “Load inputs to derive” for each key. Cached outputs were discarded.", { n: added }));
+    hodlJournalLog("key-manager-import", `${added} unverified inputs`, "journal");
   } catch (error) {
     hodlKeyManagerStatus(error?.message || "The key file could not be imported.", true);
     hodlJournalLog("key-manager-import-error", "invalid-file", "journal");

--- a/src/js/keymanager.js
+++ b/src/js/keymanager.js
@@ -1,7 +1,7 @@
 // Portable Key Manager payloads. Encryption is supplied by the unlocked
 // Entropy Journal so this module never generates salts, nonces, or key data.
 export const KEY_VAULT_FORMAT = "entropylab-key-manager";
-export const KEY_VAULT_VERSION = 1;
+export const KEY_VAULT_VERSION = 2;
 export const KEY_VAULT_MAX_KEYS = 100;
 
 export function keyVaultIdentity(state) {
@@ -9,13 +9,27 @@ export function keyVaultIdentity(state) {
 }
 
 function vaultEntry(entry) {
-  if (!entry || typeof entry !== "object" || entry.isLab || !entry.fields || typeof entry.fields !== "object" || !entry.result || typeof entry.result !== "object") {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry) || entry.isLab || !entry.fields || typeof entry.fields !== "object" || Array.isArray(entry.fields)) {
     throw new Error("The key file contains an invalid key.");
   }
-  let copy = JSON.parse(JSON.stringify(entry));
-  delete copy.isLab;
+  // Only source inputs/settings cross the import boundary. Encryption proves
+  // file integrity, not that cached addresses or private outputs were derived
+  // from these inputs. Never accept a serialized "verified" flag or identity.
+  let copy = {};
+  for (const field of [
+    "name", "createdAt", "mode", "diceMethod", "cardMethod", "seedMethod",
+    "seedZeroIndexed", "cardColemanSymbols", "entropyFormat", "globalSync",
+    "globalSyncSource", "globalSyncBitCount", "seedAutocomplete",
+    "passphraseBip39Words", "brainWalletOutput", "passphraseAutocomplete",
+    "brainWalletTrim", "showCards", "showDiceFairness", "showNumberBaseCalculations",
+    "targetWords", "diceCoinPositions", "lastWord", "dplusLastWord", "accountId", "fields",
+  ]) {
+    if (Object.prototype.hasOwnProperty.call(entry, field) && entry[field] !== undefined) copy[field] = JSON.parse(JSON.stringify(entry[field]));
+  }
   copy.name = String(copy.name || "Imported key").trim().replace(/\s+/g, " ").slice(0, 120) || "Imported key";
   copy.reveal = false;
+  copy.result = null;
+  copy.needsDerivation = true;
   copy.error = "";
   delete copy.errorSpec;
   return copy;
@@ -42,7 +56,7 @@ export function parseKeyVault(text) {
   } catch {
     throw new Error("This is not valid Key Manager JSON.");
   }
-  if (!document || document.format !== KEY_VAULT_FORMAT || document.version !== KEY_VAULT_VERSION) {
+  if (!document || document.format !== KEY_VAULT_FORMAT || ![1, KEY_VAULT_VERSION].includes(document.version)) {
     throw new Error("This file is not a supported EntropyLab key file.");
   }
   return {

--- a/src/shell.html
+++ b/src/shell.html
@@ -825,7 +825,7 @@ words, pick one of the checksum words.</span></span>
       <div class="journal-section-intro" id="journal-keymanager-tool-intro">
         <div class="kicker">Keys on paper you control.</div>
         <h2>Key manager</h2>
-        <p class="muted tool-intro-note" data-i18n-rich>Collect derived Key Station keys in one <code>.elkeys</code> file. Imported keys stay here until you explicitly load one into Key Station. The file uses this Journal's password setting and never leaves your machine; without a password it has no access protection.</p>
+        <p class="muted tool-intro-note" data-i18n-rich>Save key inputs and settings in one <code>.elkeys</code> file. Imported inputs are unverified: load and derive each key before using addresses or exports. New files use input-only version 2 and require an updated reader; older files remain importable, but cached outputs are discarded. The file uses this Journal's password setting and never leaves your machine; without a password it has no access protection.</p>
       </div>
       <div class="row tool-actions"><button class="btn secondary" id="journal-keymanager-add-all" type="button" disabled>Add all to Key Station</button></div>
       <div class="key-tab-strip journal-keymanager-tab-strip"><div class="key-tabs" id="journal-keymanager-tabs" role="tablist" aria-label="Managed keys"></div></div>

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -4316,6 +4316,45 @@
     await until(() => !image.hidden && image.src.startsWith("data:image/png"), "footer LifeHash");
   });
 
+  await test("a forged legacy .elkeys cache stays unverified until the source inputs are derived", async () => {
+    // Deterministic sealExport("key-manager", ...) fixture, password below.
+    // V1 input: BIP39 abandon x11/about, empty passphrase, m/84'/0'/0'/0/0.
+    // Cache: deadbeef fingerprint, "forged cached xprv", "forged WIF",
+    // "forged address", plus verified:true and needsDerivation:false.
+    const fixture = {"entropylabJournal":2,"kdf":"PBKDF2-SHA-256","iterations":600000,"cipher":"AES-256-GCM","iv":"437ff043fb7b9cc1da70f61e","ciphertext":"699a11e60bdf32ec7d8af7f14284783befc6bc68d8007a0d1680f6034c1f7258be9476042c7898267d6e0f46f31f66ea3bd2afbeb507490eab0c7b45fdbaf4e3ea39b6193f2d663aa8982d8e8ce7f40379cc49567423bd9e1cee0cb9849b03a36666d77e489a19096670ff3687b3394ec9d7746bc71ab26806284f27fce809ff038aaf31f4d421c1175bbe9255f7a0f6069ecd731fc1c198b771208b2d3e7eb0c98b2d0f587b82c7084392740d80d7ca0f021b812007d5c5cc50540dc489ed4672b0ecdbf495d006d9e2f97d28e3ec0dde39b711f20559d1b9115e80e7f23c712e20538f8d80ec1f27929bf19e59881eccbdb0b54a7aa98e3a9961b4b5693801ee2439e5b9787f08d06219bf6910a0d7a7b95e10221cf6f4617ff13144646978550ce152cadf139a7cf985d278c0da272249924d2b86029242cbbbed4cab105833ee560fe09b177b1e5d91a1a5f3ab610547b765d0667e9cf86d84d8a5eede7970d6bec993500e40a6cc95d3e5e6c294b5502f98a733d7d73947146971d9e6374416ed61f82b30f70074cf9f57a72b6f31276fd617e69020d39252a5601a953f173e4d7881302ead614480881845f94cb7c2aafe891f1a391266795bf70a99f5e0d28e61a9723bb206086eaba9464a973b3a7d93b640329387a1ca9749509dd1a3ed745fe937ed72546c4516d8ec5a532d6566a1c9173ca9bb062dde7323290dfe95a5e1900521b19163b47522d12d291f3d8bb4f8c89f26d34ae1141bfd68b5cdb0a8981ad45e40faad1a608dd11e78a280252a495f44e26ff66bf28f63d9faae29ac5b25ec02570f46f2b82bcb447bfde786446c7672de73736d0117a9a185f697a79a574b770dbbf42ecd84d1a618fa6edbfe038bc3624268fba6081670c1645d9aa46cb631711af89c5d7ebd2a35a77d9d1780c694077e5d1b5dfa0129968706aca41dc3872c0dfde0089c65bb0032055edac06277aa43467e1de01998e62cd981fb1f193c63c90192b2d24fdf7da62b87d41868ba33a6798a7583eb59f5c521b05ffbbd9dd64176368eb0c01d141034aebafb6e438857adc32e21adbc27fd409319cc79350676235312a2065e1f3c885ad987a5e10dd116a6dfba3add4353564e0160cfe81f2fc0c5d1e6cad4944c8920df2deaa2cb7be35f932dd409e7035f16b6cdad80432b07c1cc9913c0754366bf2915b43766e0b6c56ea73b4160928fdc2ebd5fac2d08ee47b1473b29d9060f375a","entropylabJournalExport":1};
+    document.querySelector('#workspace [data-workspace="journal"]').click();
+    if (!document.getElementById("journal-work-panel").hidden) {
+      document.getElementById("journal-global-clear").click();
+      await until(() => document.getElementById("journal-global-download").disabled, "journal reset for import");
+    }
+    input(document.getElementById("journal-create-password"), "elkeys fixture password");
+    input(document.getElementById("journal-create-confirm"), "elkeys fixture password");
+    document.getElementById("journal-create").click();
+    await until(() => !document.getElementById("journal-global-download").disabled, "journal for legacy key import");
+    document.querySelector('#journal-tool-tabs [data-journal-tool="keymanager"]').click();
+    const file = document.getElementById("journal-keymanager-file");
+    Object.defineProperty(file, "files", { configurable: true, value: [new File([JSON.stringify(fixture)], "legacy.elkeys", { type: "application/json" })] });
+    file.dispatchEvent(new Event("change", { bubbles: true }));
+    await until(() => document.getElementById("journal-keymanager-status").textContent.includes("unverified input"), "unverified import");
+    const tab = [...document.querySelectorAll("#journal-keymanager-tabs button")].find(button => button.textContent.includes("Unverified legacy fixture"));
+    assert(tab, "the input-only entry is available");
+    tab.click();
+    const panel = document.getElementById("journal-keymanager-panel");
+    assert(panel.textContent.includes("Unverified inputs"), "the manager must label the input unverified");
+    assert(!/forged|deadbeef/.test(panel.textContent), "cached outputs and identity must not be shown");
+    assert(document.getElementById("journal-keymanager-add-all").disabled, "bulk add must not install unverified inputs");
+    [...panel.querySelectorAll("button")].find(button => button.textContent === "Load inputs to derive").click();
+    await until(() => !document.getElementById("key-manager").hidden && document.getElementById("seed"), "imported inputs in the lab");
+    equal(document.getElementById("seed").value, "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about");
+    assert(!/forged/.test(document.getElementById("out").textContent), "loading cannot restore cached output");
+    document.getElementById("go").click();
+    await until(() => document.getElementById("out").textContent.includes("bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu"), "fresh BIP84 address from imported inputs");
+    document.querySelector('#workspace [data-workspace="journal"]').click();
+    document.querySelector('#journal-tool-tabs [data-journal-tool="keymanager"]').click();
+    assert(!document.getElementById("journal-keymanager-tabs").textContent.includes("Unverified legacy fixture"), "successful derivation retires the pending input");
+    document.querySelector('#workspace [data-workspace="calc"]').click();
+  });
+
   await test("hosted application makes only expected same-origin connections", () => {
     const resources = performance.getEntriesByType("resource").map((entry) => entry.name);
     const observed = [...state.network.map((entry) => entry.url), ...resources];

--- a/test/journal-backup.test.mjs
+++ b/test/journal-backup.test.mjs
@@ -700,7 +700,7 @@ test("a vault backup normalizes names and drops transient UI state", () => {
   assert.equal(restored.reveal, false);
   assert.equal(restored.error, "");
   assert.equal("errorSpec" in restored, false);
-  assert.equal(restored.extra, "kept"); // unknown state is preserved for forward compatibility
+  assert.equal(restored.extra, undefined); // only input/settings fields cross the trust boundary
   assert.equal(restored.fields.seed, "user supplied words");
   const [unnamed] = parseKeyVault(serializeKeyVault([managedKey({ name: "   " })])).keys;
   assert.equal(unnamed.name, "Imported key");
@@ -715,7 +715,8 @@ test("vault backups are bounded and schema-checked on both directions", () => {
   assert.throws(() => serializeKeyVault([null]), /invalid key/);
   assert.throws(() => serializeKeyVault([{ name: "no state" }]), /invalid key/);
   assert.throws(() => serializeKeyVault([managedKey({ fields: null })]), /invalid key/);
-  assert.throws(() => serializeKeyVault([managedKey({ result: null })]), /invalid key/);
+  assert.equal(parseKeyVault(serializeKeyVault([managedKey({ result: null })])).keys[0].needsDerivation, true);
+  assert.throws(() => serializeKeyVault([managedKey({ fields: [] })]), /invalid key/);
   assert.throws(() => parseKeyVault(JSON.stringify({ format: KEY_VAULT_FORMAT, version: KEY_VAULT_VERSION })), /too many keys/);
   assert.throws(() => parseKeyVault(JSON.stringify({ format: KEY_VAULT_FORMAT, version: KEY_VAULT_VERSION + 1, keys: [] })), /not a supported/);
   const ignoredDefault = parseKeyVault(JSON.stringify({ format: KEY_VAULT_FORMAT, version: KEY_VAULT_VERSION, keys: [] }));
@@ -744,7 +745,8 @@ test("an .elkeys backup is opaque until opened with the journal password", async
   const vault = parseKeyVault(opened.content);
   assert.equal(vault.keys.length, 1);
   assert.equal(vault.ignoredKeys.length, 1);
-  assert.equal(keyVaultIdentity(vault.keys[0]), "deadbeef");
+  assert.equal(keyVaultIdentity(vault.keys[0]), "");
+  assert.equal(vault.keys[0].fields.seed, "user supplied words");
 });
 
 // --- App wiring: the buttons actually route through these primitives ----------
@@ -800,7 +802,8 @@ test("backup drill: seal everything, restore from a cold start", async () => {
   const notes = parseNotebook((await openExport(notebookExport, restored.keys)).content);
   assert.equal(notes.pages[0].notesText, journal.pages[0].notesText);
   const vault = parseKeyVault((await openExport(vaultExport, restored.keys)).content);
-  assert.equal(keyVaultIdentity(vault.keys[0]), "deadbeef");
+  assert.equal(keyVaultIdentity(vault.keys[0]), "");
+  assert.equal(vault.keys[0].fields.seed, "user supplied words");
   const state = await openExport(stateExport, restored.keys);
   assert.match(state.content, /fingerprint deadbeef/);
   const log = await openExport(logExport, restored.keys);

--- a/test/keymanager-import-render.test.mjs
+++ b/test/keymanager-import-render.test.mjs
@@ -1,17 +1,19 @@
-// Issue #389: a crafted .elkeys payload passes Key Manager validation with
-// attacker-controlled strings inside the cached result — the address-row
-// index, for one — and "Use in Key Station" restores that cached result
-// without re-derivation. The renderers are the injection boundary: an address
-// index must come out as a validated number or as escaped text, never as
-// markup. These tests run the real vault parser and the real app.js table
-// renderer against such a payload.
+// Issue #389 requires defensive rendering even for crafted result values.
+// Issue #425 additionally requires authenticity: imported caches are not
+// derivation evidence. Exercise the real parser and controllers, and retain
+// the renderer's escaping checks as an independent boundary.
 // Run with: npm test
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { parseKeyVault, serializeKeyVault } from "../src/js/keymanager.js";
+import { keyVaultIdentity, parseKeyVault, serializeKeyVault } from "../src/js/keymanager.js";
+import { runInNewContext } from "node:vm";
+import { mnemonicToSeedSync, validateMnemonic } from "@scure/bip39";
+import { wordlist } from "@scure/bip39/wordlists/english.js";
+import { HDKey } from "@scure/bip32";
+import { p2wpkh } from "@scure/btc-signer";
 import { addressQrButtonHtml } from "../src/js/address-qr.js";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
@@ -33,8 +35,152 @@ function loadSlice(name) {
     }
   }
   assert.ok(end > start, name);
-  return app.slice(start, end);
+  return (app.slice(start - 6, start) === "async " ? "async " : "") + app.slice(start, end);
 }
+
+const WORDS = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+const legacyEntry = () => ({
+  id: 1, number: 1, name: "Imported", mode: "seed", targetWords: 12,
+  fields: { seed: WORDS, pass: "", derivationPath: "m/84'/0'/0'/0/0" },
+  needsDerivation: false, verified: true, importedKeyId: 1,
+  result: { kind: "hd", masterFingerprint: "deadbeef", mnemonic: "forged cached mnemonic",
+    rootXprv: "forged cached xprv", accounts: [{ primaryPrivate: "forged WIF", address: "forged address" }] },
+});
+const legacyFile = (keys, ignoredKeys = []) => JSON.stringify({ format: "entropylab-key-manager", version: 1, keys, ignoredKeys });
+
+function importHarness() {
+  const calls = [], context = {
+    keyVaultIdentity, parseKeyVault,
+    hodlNextKeyId: 1, hodlNextKeyNumber: 1, hodlActiveKey: 0,
+    hodlKeys: [], hodlKeyManagerPending: [], hodlKeyManagerIgnored: [],
+    hodlKeyManagerIds: new Set(), hodlKeyManagerActiveId: "", hodlActiveDerivation: null,
+    hodlWalletResult: null, hodlOutEl: { innerHTML: "" },
+    hodlDefaultCoinType: () => 0, hodlNetworkDefault: "mainnet", hodlKeyColor: id => String(id),
+    hodlDefaultKeyName: id => `Key ${id}`,
+    hodlJournalUnlocked: () => true, hodlJournalKeys: {}, hodlJournalGeneration: 0,
+    hodlJournalOpenExport: async content => ({ kind: "key-manager", content }),
+    hodlTText: (text, vars) => text.replace("{n}", String(vars?.n ?? "")),
+    hodlJournalLog: (...args) => calls.push(args),
+    hodlKeyManagerStatus: text => calls.push(["status", text]),
+    hodlRenderKeyTabs() {}, hodlKeyManagerRender() {},
+    hodlCaptureKey: () => { context.hodlKeys[context.hodlActiveKey].result = context.hodlWalletResult; },
+    hodlShowWorkspace: () => { context.hodlWalletResult = context.hodlKeys[context.hodlActiveKey].result; },
+    hodlRestoreKey: () => { context.hodlWalletResult = context.hodlKeys[context.hodlActiveKey].result; },
+  };
+  for (const name of ["hodlNewKeyState", "hodlNewLabState", "hodlKeyManagerImportedState",
+    "hodlKeyManagerStates", "hodlKeyManagerUseInStation", "hodlKeyManagerUseAllInStation",
+    "hodlCloneDerivedKey", "hodlFillLabFromKey", "hodlCommitDerivedKey", "hodlKeyManagerImportFile",
+    "hodlKeyManagerRestoreIgnored"])
+    runInNewContext(loadSlice(name), context);
+  context.hodlKeys.push(context.hodlNewLabState());
+  return { context, calls, importFile: text => context.hodlKeyManagerImportFile({ size: text.length, text: async () => text }) };
+}
+
+test("both vault versions ignore forged caches, identity, flags, and unrelated properties", () => {
+  for (const version of [1, 2]) {
+    const entry = legacyEntry();
+    const parsed = parseKeyVault(JSON.stringify({ format: "entropylab-key-manager", version, keys: [entry], ignoredKeys: [entry] }));
+    for (const item of [...parsed.keys, ...parsed.ignoredKeys]) {
+      assert.equal(item.result, null);
+      assert.equal(item.needsDerivation, true);
+      assert.equal(item.id, undefined);
+      assert.equal(item.verified, undefined);
+      assert.equal(item.importedKeyId, undefined);
+      assert.equal(item.fields.seed, WORDS);
+      assert.ok(!JSON.stringify(item).includes("forged"));
+    }
+  }
+});
+
+test("forged fingerprint/ID cannot alias an existing key; ignored imports stay unverified", async () => {
+  const { context: c, importFile } = importHarness();
+  const trusted = c.hodlNewKeyState();
+  trusted.result = { masterFingerprint: "deadbeef", rootXprv: "existing secret" };
+  c.hodlKeys.push(trusted);
+  await importFile(legacyFile([legacyEntry(), legacyEntry()], [legacyEntry()]));
+  assert.equal(c.hodlKeys[1], trusted);
+  assert.equal(trusted.result.rootXprv, "existing secret");
+  assert.equal(c.hodlKeyManagerPending.length, 2);
+  assert.equal(c.hodlKeyManagerIgnored.length, 1);
+  const pending = c.hodlKeyManagerPending[0];
+  assert.notEqual(pending.id, trusted.id);
+  assert.equal(pending.result, null);
+  c.hodlKeyManagerUseAllInStation();
+  assert.equal(c.hodlKeys.length, 2, "bulk add cannot install an unverified wallet");
+  c.hodlKeyManagerRestoreIgnored(c.hodlKeyManagerIgnored[0]);
+  assert.equal(c.hodlKeyManagerPending.length, 3);
+  assert.equal(c.hodlKeyManagerPending[2].needsDerivation, true);
+  assert.equal(c.hodlKeyManagerPending[2].result, null);
+  c.hodlKeyManagerUseInStation(pending);
+  const lab = c.hodlKeys[c.hodlActiveKey];
+  assert.equal(lab.isLab, true);
+  assert.equal(lab.result, null);
+  assert.equal(c.hodlWalletResult, null);
+  assert.equal(lab.fields.seed, WORDS);
+  assert.equal(c.hodlKeyManagerPending.length, 3, "loading alone does not verify or remove the input");
+});
+
+function enableDerivation(c) {
+  Object.assign(c, {
+    hodlKeyMode: "seed", hodlSeedMethod: "words", hodlTargetWordCount: 12, hodlNetworkChoice: "mainnet",
+    document: { getElementById: id => ({ value: c.hodlKeys[c.hodlActiveKey].fields[id] || "" }) },
+    hodlReadDerivationPlan: () => ({ network: "mainnet", coinType: 0 }),
+    hodlNetworkFamily: value => value, hodlReadAddressWindow: () => ({ start: 0, range: 1 }),
+    hodlReadBranchWindow: () => ({ start: 0, range: 1 }), hodlSelectedScriptType: () => "bip84",
+    hodlDefaultHardening: () => ({}), hodlPassphraseBip39Enabled: () => false,
+    hodlSelectedSeedInput: () => ({ value: c.hodlKeys[c.hodlActiveKey].fields.seed }),
+    hodlValidateTargetMnemonic: value => {
+      assert.ok(validateMnemonic(value, wordlist), "invalid source mnemonic");
+      return { words: value.split(" ") };
+    },
+    hodlThrowIfFailed() {}, hodlSetWorkspaceError() {}, hodlSetSelectedScriptType() {},
+    hodlSnapshotKeySummary() {}, hodlJournalCaptureDerivedKey() {}, hodlFocusWalletResult() {},
+    hodlErrorSpecFrom: error => error.message,
+    // The real controller drives an independent BIP39/BIP32 implementation.
+    // Its existing wallet-engine vector tests separately cover production crypto.
+    hodlMnemonicWalletWithProgress: async (words, passphrase, network) => {
+      const master = HDKey.fromMasterSeed(mnemonicToSeedSync(words, passphrase));
+      const leaf = master.derive("m/84'/0'/0'/0/0");
+      return { network, mnemonic: words, masterFingerprint: master.fingerprint.toString(16).padStart(8, "0"),
+        rootXprv: master.privateExtendedKey, address: p2wpkh(leaf.publicKey).address };
+    },
+  });
+  // Keep the real cancellation control declarations with the controller,
+  // including the generation fence supplied by the separate lifecycle fix.
+  runInNewContext(app.slice(app.indexOf("class HodlDerivationCancelledError"), app.indexOf("function hodlDerivationButton")), c);
+  runInNewContext(loadSlice("hodlCalculateKey"), c);
+}
+
+test("only a successful fresh derivation retires an imported input and publishes the genuine wallet", async () => {
+  const { context: c, importFile } = importHarness();
+  await importFile(legacyFile([legacyEntry()]));
+  const imported = c.hodlKeyManagerPending[0], oldIdentity = keyVaultIdentity(imported);
+  c.hodlKeyManagerUseInStation(imported);
+  enableDerivation(c);
+  assert.equal(await c.hodlCalculateKey({}), true);
+  const derived = c.hodlKeys[c.hodlActiveKey];
+  assert.equal(derived.isLab, false);
+  assert.equal(derived.result.address, "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu");
+  assert.equal(derived.result.mnemonic, WORDS);
+  assert.ok(!JSON.stringify(derived.result).includes("forged"));
+  assert.equal(c.hodlKeyManagerPending.length, 0);
+  assert.equal(c.hodlKeyManagerIds.has(oldIdentity), false);
+  assert.equal(c.hodlKeyManagerIds.has(keyVaultIdentity(derived)), true);
+  assert.equal(parseKeyVault(serializeKeyVault([derived])).keys[0].result, null, "even a genuine export must be rederived next time");
+});
+
+test("invalid source inputs cannot fall back to the imported cached wallet", async () => {
+  const { context: c, importFile } = importHarness();
+  const entry = legacyEntry();
+  entry.fields.seed = "invalid source words";
+  await importFile(legacyFile([entry]));
+  c.hodlKeyManagerUseInStation(c.hodlKeyManagerPending[0]);
+  enableDerivation(c);
+  assert.equal(await c.hodlCalculateKey({}), false);
+  assert.equal(c.hodlWalletResult, null);
+  assert.equal(c.hodlKeyManagerPending.length, 1);
+  assert.equal(c.hodlKeys.every(state => !state.result), true);
+});
 
 // The real escaping helpers and table renderer from app.js; hodlPrivateValue
 // (the WIF cell) is sliced too, with its two globals stubbed.
@@ -55,7 +201,7 @@ const loadRows = (revealPrivate = false) =>
 const ATTACK_INDEX = '<svg onload="alert(document.domain)">';
 const craftedRow = { index: ATTACK_INDEX, path: "m/84'/0'/0'/0/0", address: "bc1qexampleaddress000000000000000000000000" };
 
-test("the vault parser carries imported result metadata through unchecked (the renderer is the boundary)", () => {
+test("legacy vault caches are discarded before rendering or identity matching (#425)", () => {
   const entry = {
     id: 7,
     number: 2,
@@ -64,8 +210,11 @@ test("the vault parser carries imported result metadata through unchecked (the r
     fields: { seed: "user supplied words" },
     result: { masterFingerprint: "deadbeef", kind: "hd", accounts: [{ rows: [craftedRow] }] },
   };
-  const [parsed] = parseKeyVault(serializeKeyVault([entry])).keys;
-  assert.equal(parsed.result.accounts[0].rows[0].index, ATTACK_INDEX, "a string index survives parsing — validation must not be the only line of defense");
+  const [parsed] = parseKeyVault(JSON.stringify({ format: "entropylab-key-manager", version: 1, keys: [entry] })).keys;
+  assert.equal(parsed.result, null);
+  assert.equal(parsed.needsDerivation, true);
+  assert.equal(parsed.id, undefined);
+  assert.equal(parsed.fields.seed, entry.fields.seed);
 });
 
 test("the address table renders a crafted index as inert text (issue #389)", () => {

--- a/test/keymanager.test.mjs
+++ b/test/keymanager.test.mjs
@@ -72,7 +72,7 @@ test("Add all ignores duplicate identities and does nothing without pending keys
 test("Add all is disabled initially and refreshed from available managed keys", () => {
   assert.match(read("src/shell.html"), /id="journal-keymanager-add-all" type="button" disabled>Add all to Key Station/);
   const source = read("src/js/app.js");
-  assert.match(source, /addAll\.disabled = !states\.some\(\(state\) => !hodlKeys\.includes\(state\)\)/);
+  assert.match(source, /addAll\.disabled = !states\.some\(\(state\) => !state\.needsDerivation && !hodlKeys\.includes\(state\)\)/);
   assert.match(source, /addAll\.onclick = hodlKeyManagerUseAllInStation/);
 });
 
@@ -100,7 +100,9 @@ test("Key Manager payloads round-trip and clear transient UI state", () => {
   assert.equal(raw.keys[0].errorSpec, undefined);
   assert.equal(raw.ignoredKeys[0].name, "Ignored");
   assert.deepEqual(parseKeyVault(text), { keys: raw.keys, ignoredKeys: raw.ignoredKeys });
-  assert.equal(keyVaultIdentity(raw.keys[0]), "deadbeef");
+  assert.equal(raw.keys[0].result, null);
+  assert.equal(raw.keys[0].needsDerivation, true);
+  assert.equal(keyVaultIdentity(raw.keys[0]), "", "file claims cannot supply a trusted identity");
 });
 
 test("Key Manager payload validation rejects malformed or oversized files", () => {
@@ -119,7 +121,8 @@ test(".elkeys reuse deterministic Journal encryption and the Journal password", 
   assert.deepEqual(second, first);
   const opened = await openExport(JSON.stringify(first), journal.keys);
   assert.equal(opened.kind, "key-manager");
-  assert.equal(parseKeyVault(opened.content).keys[0].result.masterFingerprint, "deadbeef");
+  assert.equal(parseKeyVault(opened.content).keys[0].fields.seed, "user supplied words");
+  assert.equal(parseKeyVault(opened.content).keys[0].result, null);
 });
 
 test("Key Manager has no entropy, network, or browser-storage primitive", () => {


### PR DESCRIPTION
## Summary

Refs #425, finding 3 (.elkeys cached-result authenticity). This does not close the omnibus audit.

Imported files are now unverified source inputs, not restored wallets:

- Discard cached addresses, private outputs, fingerprints, file-local IDs, and verification claims. Only an allowlist of inputs/settings and display metadata is retained.
- Load an imported entry into the lab for review and fresh derivation. Only a successful derivation can become a station wallet, match an existing key, and retire the pending entry.
- Bulk add cannot install unverified inputs; ignored entries receive the same treatment.
- Preserve encryption and user-supplied inputs. Re-derivation establishes consistency, not exclusive ownership or entropy quality.

## Compatibility

New exports use input-only vault format v2 and require the updated reader. V1 imports remain supported, but their caches are discarded. Output-only caches cannot substitute for missing source inputs. Repeated imports are not deduplicated using untrusted fingerprints; matching happens only after fresh derivation.

The app package version is unchanged. UI help, README, and SECURITY document the changed workflow.

## Tests

- `npm run build`: passed.
- `npm run test:ci`: **1,275 passed, 4 skipped, 0 failed**.
- Final full run: `node --test --test-force-exit --test-concurrency=4 test/*.test.mjs`. All non-browser tests passed; the new encrypted-file import regression passed in both Firefox and Chrome. Firefox passed 87/87 browser checks; Chrome passed 86/87, failing the existing enabled-Derive-Key color assertion (also observed on #427; no CSS or that assertion is changed here). Full Node summary: 1,276 passed, 2 failed (the Chrome subtest and its parent), 5 skipped.
- Ordinary `npm test` was also attempted; its browser process retained open handles after reporting results. The final run uses Node's exit-after-completed-tests option, without skipping assertions.
- Focused parser/controller/renderer tests: 8 passed, also 8 passed against the clean merge-tree combination with #427.
- `git diff --check`: passed.

- Parser/controller regressions cover both file versions, forged flags/identities/private outputs, ignored entries, bulk add, failed derivation, and a genuine BIP84 address from the published BIP39 vector.
- Browser regression uploads a deterministically encrypted legacy file with forged cached outputs and drives the actual upload → unverified inputs → derivation workflow.
- Existing renderer escaping and encryption/backup tests remain, with cached-result expectations updated to the input-only contract.

Generated site artifacts and locale catalogs are excluded.
