### PR TITLE
Fixing the layout issue that occurs after 'Derive Key' clicked

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1182,6 +1182,7 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
   position: relative; z-index: 1;
   border: 1px solid var(--border); border-radius: 0 0 20px 20px;
   padding: 20px 16px;
+  min-width: 0; overflow-x: hidden;
 }
 /* The tool's context sits on the panel's own ground above the card, so the
    grey surface starts at the controls rather than at the explanation. */
@@ -1330,7 +1331,7 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .segmented-control.is-stacked > .tab:last-child { border-radius: 0 0 8px 8px; }
 .segmented-control.is-stacked > .tab:only-child { border-radius: 8px; }
 #msig-card[hidden], #calc-card[hidden], #psbt-card[hidden], #psbted-card[hidden], #bip85-card[hidden], #sp-card[hidden], #vanity-card[hidden], #ln-card[hidden] { display: none !important; }
-#calc-card:not([hidden]), #msig-card:not([hidden]), #bip85-card:not([hidden]), #sp-card:not([hidden]), #psbt-card:not([hidden]), #psbted-card:not([hidden]), #vanity-card:not([hidden]), #ln-card:not([hidden]) { margin-top: 0; border-radius: 0 0 20px 20px; position: relative; z-index: 1; }
+#calc-card:not([hidden]), #msig-card:not([hidden]), #bip85-card:not([hidden]), #sp-card:not([hidden]), #psbt-card:not([hidden]), #psbted-card:not([hidden]), #vanity-card:not([hidden]), #ln-card:not([hidden]) { margin-top: 0; border-radius: 0 0 20px 20px; position: relative; z-index: 1; min-width: 0; overflow-x: hidden; }
 #journal-card[hidden], #journal-notes-card[hidden], #journal-keymanager-card[hidden], #journal-state-card[hidden], #journal-log-card[hidden] { display: none !important; }
 #journal-card:not([hidden]), #journal-notes-card:not([hidden]), #journal-keymanager-card:not([hidden]), #journal-state-card:not([hidden]), #journal-log-card:not([hidden]) { margin-top: 0; border-radius: 0 0 20px 20px; position: relative; z-index: 1; }
 #journal-locked-panel[hidden], #journal-work-panel[hidden], #journal-create-panel[hidden], #journal-open-panel[hidden], #journal-editor[hidden], #journal-view[hidden] { display: none; }

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -784,10 +784,10 @@ details.lab-entropy .wallet-result-messages { margin-top: var(--space-control); 
 .table-private-field-value { display: inline-grid; white-space: nowrap; }
 .private-field-value:not(.secret-placeholder),
 .table-private-field-value:not(.secret-placeholder) { color: var(--blue); }
-.secret-placeholder { position: relative; display: grid; min-width: 0; max-width: 100%; color: var(--muted); }
+.secret-placeholder { display: grid; color: var(--muted); }
 .secret-placeholder > .secret-placeholder-mask,
 .secret-placeholder > .secret-placeholder-message { grid-area: 1 / 1; }
-.secret-placeholder-mask { min-width: 0; max-width: 100%; visibility: hidden; overflow-wrap: anywhere; word-break: break-all; user-select: none; }
+.secret-placeholder-mask { visibility: hidden; user-select: none; }
 .secret-placeholder-message { color: var(--muted); }
 .secret-placeholder-label {
   position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
@@ -1182,6 +1182,8 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
   position: relative; z-index: 1;
   border: 1px solid var(--border); border-radius: 0 0 20px 20px;
   padding: 20px 16px;
+  /* Wide result tables scroll inside their own wrappers; contain their
+     min-content width here so deriving a wallet cannot widen the page. */
   min-width: 0; overflow-x: hidden;
 }
 /* The tool's context sits on the panel's own ground above the card, so the
@@ -1226,9 +1228,9 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .key-tab.is-lab { font-weight: 700; }
 .key-tab-lab-icon { width: 16px; height: 16px; padding: 0; color: var(--muted); }
 .key-tab-lab-icon svg { display: block; width: 100%; height: 100%; }
-.key-result { min-width: 0; max-width: 100%; margin-top: 16px; }
+.key-result { margin-top: 16px; }
 .key-result-scripts-label { margin: 0 0 8px; color: var(--muted); font-size: 12px; font-weight: 700; }
-.key-result-main { min-width: 0; max-width: 100%; margin-top: 8px; padding: 16px 16px 20px; border: 1px solid var(--border); border-radius: 20px; background: var(--surface); }
+.key-result-main { margin-top: 8px; padding: 16px 16px 20px; border: 1px solid var(--border); border-radius: 20px; background: var(--surface); }
 .key-result .wallet-result-messages { margin: 0 0 16px; }
 .account-receive-section { margin-top: 0; }
 .station-key-source > .label { margin: 0 0 8px; }
@@ -1331,7 +1333,7 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .segmented-control.is-stacked > .tab:last-child { border-radius: 0 0 8px 8px; }
 .segmented-control.is-stacked > .tab:only-child { border-radius: 8px; }
 #msig-card[hidden], #calc-card[hidden], #psbt-card[hidden], #psbted-card[hidden], #bip85-card[hidden], #sp-card[hidden], #vanity-card[hidden], #ln-card[hidden] { display: none !important; }
-#calc-card:not([hidden]), #msig-card:not([hidden]), #bip85-card:not([hidden]), #sp-card:not([hidden]), #psbt-card:not([hidden]), #psbted-card:not([hidden]), #vanity-card:not([hidden]), #ln-card:not([hidden]) { margin-top: 0; border-radius: 0 0 20px 20px; position: relative; z-index: 1; min-width: 0; overflow-x: hidden; }
+#calc-card:not([hidden]), #msig-card:not([hidden]), #bip85-card:not([hidden]), #sp-card:not([hidden]), #psbt-card:not([hidden]), #psbted-card:not([hidden]), #vanity-card:not([hidden]), #ln-card:not([hidden]) { margin-top: 0; border-radius: 0 0 20px 20px; position: relative; z-index: 1; }
 #journal-card[hidden], #journal-notes-card[hidden], #journal-keymanager-card[hidden], #journal-state-card[hidden], #journal-log-card[hidden] { display: none !important; }
 #journal-card:not([hidden]), #journal-notes-card:not([hidden]), #journal-keymanager-card:not([hidden]), #journal-state-card:not([hidden]), #journal-log-card:not([hidden]) { margin-top: 0; border-radius: 0 0 20px 20px; position: relative; z-index: 1; }
 #journal-locked-panel[hidden], #journal-work-panel[hidden], #journal-create-panel[hidden], #journal-open-panel[hidden], #journal-editor[hidden], #journal-view[hidden] { display: none; }
@@ -2345,7 +2347,7 @@ input.bad, textarea.bad { border-color: var(--danger) !important; }
 .account-address-lead { display: grid; gap: 10px; justify-items: start; margin-bottom: 22px; }
 .account-address-lead p { margin: 0; }
 .wallet-table {
-  width: 100%; max-width: 100%; max-height: 252px; overflow: auto; border: 1px solid var(--border); border-radius: 9px;
+  width: 100%; max-height: 252px; overflow: auto; border: 1px solid var(--border); border-radius: 9px;
   overflow-anchor: none; overscroll-behavior: contain;
   scrollbar-width: thin; scrollbar-color: var(--scrollbar-thumb) var(--surface);
 }

--- a/test/browser-suite.html
+++ b/test/browser-suite.html
@@ -3427,18 +3427,23 @@
     derive.click();
     await until(() => document.getElementById("save") || document.getElementById("error").textContent, "wallet result");
     assert(!document.getElementById("error").textContent, "Wallet derivation failed");
-    const mobileResult = document.querySelector(".key-result");
-    mobileResult.style.width = "220px";
-    const tablePrivateValue = mobileResult.querySelector(".table-private-field-value.secret-placeholder");
-    assert(
-      tablePrivateValue?.querySelector(".secret-placeholder-label")?.offsetParent === tablePrivateValue,
-      "The hidden WIF label escaped its horizontally scrolling table",
-    );
-    assert(
-      mobileResult.scrollWidth <= mobileResult.clientWidth,
-      `Derived wallet widened a mobile layout to ${mobileResult.scrollWidth}px from ${mobileResult.clientWidth}px`,
-    );
-    mobileResult.style.width = "";
+    const page = document.querySelector(".wrap");
+    const previousPageWidth = page.style.width;
+    try {
+      page.style.width = "390px";
+      await wait(0);
+      assert(
+        page.scrollWidth <= page.clientWidth,
+        `Derived wallet widened the 390px page container to ${page.scrollWidth}px`,
+      );
+      const addressTable = document.querySelector("#acct .wallet-table");
+      assert(
+        addressTable.scrollWidth > addressTable.clientWidth,
+        "The wide address table was clipped instead of remaining horizontally scrollable",
+      );
+    } finally {
+      page.style.width = previousPageWidth;
+    }
     const derivationProgress = await until(() => document.getElementById("derive-progress").classList.contains("is-complete") && document.getElementById("derive-progress"), "completed derivation progress");
     assert(!derivationProgress.hidden, "Completed derivation progress did not remain visible");
     equal(derivationProgress.getAttribute("aria-valuenow"), "100", "Derivation progress did not reach 100%");

--- a/test/ui-defaults.test.mjs
+++ b/test/ui-defaults.test.mjs
@@ -2459,15 +2459,12 @@ test("derived key results put private recovery before script type and addresses"
 });
 
 test("derived wallet results stay within the mobile layout (#238)", () => {
-  assert.match(css, /\.key-result \{ min-width: 0; max-width: 100%;/);
-  assert.match(css, /\.key-result-main \{ min-width: 0; max-width: 100%;/);
-  assert.match(css, /\.secret-placeholder \{ position: relative; display: grid; min-width: 0; max-width: 100%;/);
-  assert.match(css, /\.secret-placeholder-mask \{[^}]*max-width: 100%;[^}]*overflow-wrap: anywhere;[^}]*word-break: break-all;/);
+  assert.match(css, /\.workspace-panel \{[^}]*min-width: 0; overflow-x: hidden;/s);
   assert.match(css, /\.qr \{ max-width: 100%;/);
   assert.match(css, /\.qr svg \{[^}]*max-width: 100%;[^}]*height: auto;[^}]*aspect-ratio: 1;/);
   assert.match(css, /\.qr-descriptor svg \{ width: 280px; height: auto; \}/);
   assert.match(css, /\.qr-seed svg \{ width: 200px; height: auto; \}/);
-  assert.match(css, /\.wallet-table \{[^}]*width: 100%; max-width: 100%;[^}]*overflow: auto;/);
+  assert.match(css, /\.wallet-table \{[^}]*width: 100%;[^}]*overflow: auto;/);
 });
 
 test("every MS Station co-signer keeps its key and full path visible with synchronized advanced components", () => {


### PR DESCRIPTION
Fixed issue #238 by adding min-width: 0 and overflow-x: hidden to .workspace-panel and #calc-card (and sibling tool cards) in src/css/styles.css. The wallet result rendered after key derivation contains address tables with large min-width values (660–700px) that caused the card to expand beyond the viewport on narrow screens, particularly iPhone. The parent containers had no overflow constraints, so the tables' minimum width pushed the entire layout wider than the viewport. Adding min-width: 0 allows the flex/grid layout to shrink the containers below their intrinsic content width, while overflow-x: hidden provides a containment boundary so the inner table's own overflow: auto can scroll horizontally within the card. 